### PR TITLE
Calculate the correct mmap-page value on the fly

### DIFF
--- a/include/lo2s/util.hpp
+++ b/include/lo2s/util.hpp
@@ -66,7 +66,7 @@ private:
 };
 
 std::size_t get_page_size();
-
+std::size_t get_perf_event_mlock();
 std::string get_process_exe(pid_t pid);
 
 std::string get_datetime();

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -79,7 +79,24 @@ int32_t get_task_last_cpu_id(std::istream& proc_stat)
     proc_stat >> cpu_id;
     return cpu_id;
 }
-
+std::size_t get_perf_event_mlock()
+{
+    std::fstream mlock_kb_file;
+    std::size_t mlock_kb;
+    try
+    {
+        mlock_kb_file.exceptions(std::fstream::failbit | std::fstream::badbit);
+        mlock_kb_file.open("/proc/sys/kernel/perf_event_mlock_kb", std::fstream::in);
+        mlock_kb_file >> mlock_kb;
+        mlock_kb_file.close();
+        return mlock_kb * 1024;
+    }
+    catch (std::exception& e)
+    {
+        Log::trace() << "Reading /proc/sys/kernel/perf_event_mlock_kb failed: " << e.what();
+        return 516 * 1024;
+    }
+}
 std::unordered_map<pid_t, std::string> read_all_tid_exe()
 {
     std::unordered_map<pid_t, std::string> ret;


### PR DESCRIPTION
uses
(/proc/sys/kernel/perf_event_mlock_kb * 1000 )/ pagesize -1
to calculate the correct value