### PR TITLE
Issue 25 revert mmap pages

### DIFF
--- a/include/lo2s/perf/event_reader.hpp
+++ b/include/lo2s/perf/event_reader.hpp
@@ -126,9 +126,9 @@ protected:
         if (base == MAP_FAILED || base == nullptr)
         {
             Log::error() << "mapping memory for recording events failed. You can try "
-                "to decrease the buffer size with the -m flag, or try to increase "
-                "the amount of mappable memory by increasing /proc/sys/kernel/"
-                "perf_event_mlock_kb";
+                            "to decrease the buffer size with the -m flag, or try to increase "
+                            "the amount of mappable memory by increasing /proc/sys/kernel/"
+                            "perf_event_mlock_kb";
             throw_errno();
         }
     }

--- a/include/lo2s/perf/event_reader.hpp
+++ b/include/lo2s/perf/event_reader.hpp
@@ -125,8 +125,10 @@ protected:
         // Should not be necessary to check for nullptr, but we've seen it!
         if (base == MAP_FAILED || base == nullptr)
         {
-            Log::error() << "mmap failed. You can decrease the buffer size or try to increase "
-                            "/proc/sys/kernel/perf_event_mlock_kb";
+            Log::error() << "mapping memory for recording events failed. You can try "
+                "to decrease the buffer size with the -m flag, or try to increase "
+                "the amount of mmappable memory by increasing /proc/sys/kernel/"
+                "perf_event_mlock_kb";
             throw_errno();
         }
     }

--- a/include/lo2s/perf/event_reader.hpp
+++ b/include/lo2s/perf/event_reader.hpp
@@ -127,7 +127,7 @@ protected:
         {
             Log::error() << "mapping memory for recording events failed. You can try "
                 "to decrease the buffer size with the -m flag, or try to increase "
-                "the amount of mmappable memory by increasing /proc/sys/kernel/"
+                "the amount of mappable memory by increasing /proc/sys/kernel/"
                 "perf_event_mlock_kb";
             throw_errno();
         }

--- a/include/lo2s/util.hpp
+++ b/include/lo2s/util.hpp
@@ -66,7 +66,6 @@ private:
 };
 
 std::size_t get_page_size();
-std::size_t get_perf_event_mlock();
 std::string get_process_exe(pid_t pid);
 
 std::string get_datetime();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -121,7 +121,7 @@ void parse_program_options(int argc, const char** argv)
              "suppress output")
         ("verbose,v", po::value(&verbosity)->zero_tokens(),
              "verbose output (specify multiple times to get increasingly more verbose output)")
-        ("mmap-pages,m", po::value(&config.mmap_pages)->default_value(get_perf_event_mlock()/get_page_size() - 1),
+        ("mmap-pages,m", po::value(&config.mmap_pages)->default_value(16),
              "number of pages to be used by each internal buffer")
         ("readout-interval,i", po::value(&read_interval_ms)->default_value(100),
              "time interval between metric and sampling buffer readouts in milliseconds")

--- a/src/monitor/interval_monitor.cpp
+++ b/src/monitor/interval_monitor.cpp
@@ -23,7 +23,10 @@ IntervalMonitor::IntervalMonitor(trace::Trace& trace, const std::string& name,
 
 IntervalMonitor::~IntervalMonitor()
 {
-    if (!stop_requested_)
+    // If we had an exception in the initialization list of ThreadMonitor (e.g. Writer() fails
+    // because no more mappable memory is available thread_ will not be joinable (and not needed to
+    // be stopped) and stop_requested should be false
+    if (!stop_requested_ && thread_.joinable())
     {
         Log::error() << "Destructing IntervalMonitor before being stopped. This should not happen, "
                         "but it's fine anyway.";

--- a/src/monitor/process_monitor.cpp
+++ b/src/monitor/process_monitor.cpp
@@ -150,6 +150,7 @@ void ProcessMonitor::handle_ptrace_event(pid_t child, int event)
         catch(std::system_error& e)
         {
             Log::error() << "Failure while adding new process " << newpid << ": " << e.what();
+            throw;
         }
     }
     // new Thread?
@@ -163,16 +164,20 @@ void ProcessMonitor::handle_ptrace_event(pid_t child, int event)
 
             // Parent may be a thread, get the process
             auto pid = threads_.pid(child);
-
             Log::info() << "New thread is cloned " << newpid << " parent: " << child << " pid: " << pid;
 
             // register monitoring
             threads_.insert(pid, newpid, false);
         }
-            // TODO change type of exception we catch here accordingly
-        catch(std::exception& e)
+        catch(std::out_of_range& e)
+        {
+            Log::error() << "Failed to get pid of " << child;
+        }
+        catch(std::system_error& e)
         {
             Log::error() << "Failure while adding new thread " << newpid << ": " << e.what();
+            throw;
+
         }
     }
     // process or thread exited?

--- a/src/monitor/process_monitor.cpp
+++ b/src/monitor/process_monitor.cpp
@@ -137,17 +137,18 @@ void ProcessMonitor::handle_ptrace_event(pid_t child, int event)
     {
         pid_t newpid = -1;
 
-        try {
+        try
+        {
             // we need the pid of the new process
             check_ptrace(PTRACE_GETEVENTMSG, child, NULL, &newpid);
             auto name = get_process_exe(newpid);
-            Log::debug() << "New process is forked " << newpid << ": " << name << " parent: " << child
-                         << ": " << get_process_exe(child);
+            Log::debug() << "New process is forked " << newpid << ": " << name
+                         << " parent: " << child << ": " << get_process_exe(child);
 
             trace_.process(newpid, name);
             threads_.insert(newpid, newpid, false);
         }
-        catch(std::system_error& e)
+        catch (std::system_error& e)
         {
             Log::error() << "Failure while adding new process " << newpid << ": " << e.what();
             throw;
@@ -158,44 +159,49 @@ void ProcessMonitor::handle_ptrace_event(pid_t child, int event)
     {
         long newpid = -1;
 
-        try {
+        try
+        {
             // we need the tid of the new process
             check_ptrace(PTRACE_GETEVENTMSG, child, NULL, &newpid);
 
             // Parent may be a thread, get the process
             auto pid = threads_.pid(child);
-            Log::info() << "New thread is cloned " << newpid << " parent: " << child << " pid: " << pid;
+            Log::info() << "New thread is cloned " << newpid << " parent: " << child
+                        << " pid: " << pid;
 
             // register monitoring
             threads_.insert(pid, newpid, false);
         }
-        catch(std::out_of_range& e)
+        catch (std::out_of_range& e)
         {
             Log::error() << "Failed to get pid of " << child;
         }
-        catch(std::system_error& e)
+        catch (std::system_error& e)
         {
             Log::error() << "Failure while adding new thread " << newpid << ": " << e.what();
             throw;
-
         }
     }
     // process or thread exited?
     else if (event == PTRACE_EVENT_EXIT)
     {
-        try {
-            if (threads_.is_process(child)) {
+        try
+        {
+            if (threads_.is_process(child))
+            {
                 auto name = get_process_exe(child);
                 Log::info() << "Process " << child << " / " << name << " about to exit";
                 trace_.process(child, name);
-            } else {
+            }
+            else
+            {
                 auto pid = threads_.pid(child);
                 Log::info() << "Thread " << child << " in process " << pid << " / "
                             << get_process_exe(pid) << " is about to exit";
             }
             threads_.stop(child);
         }
-        catch(std::out_of_range&)
+        catch (std::out_of_range&)
         {
             Log::warn() << "Thread " << child << " is about to exit, but has never seen before.";
         }
@@ -232,9 +238,8 @@ void ProcessMonitor::handle_signal(pid_t child, int status)
             Log::debug() << "Set ptrace options for process: " << child;
 
             // we are only interested in fork/join events
-            check_ptrace_setoptions(child,
-                                    PTRACE_O_TRACEFORK | PTRACE_O_TRACEVFORK | PTRACE_O_TRACECLONE |
-                                        PTRACE_O_TRACEEXIT);
+            check_ptrace_setoptions(child, PTRACE_O_TRACEFORK | PTRACE_O_TRACEVFORK |
+                                               PTRACE_O_TRACECLONE | PTRACE_O_TRACEEXIT);
             // FIXME TODO continue this new thread/process ONLY if already registered in the
             // thread map.
             break;

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -79,24 +79,6 @@ int32_t get_task_last_cpu_id(std::istream& proc_stat)
     proc_stat >> cpu_id;
     return cpu_id;
 }
-std::size_t get_perf_event_mlock()
-{
-    std::fstream mlock_kb_file;
-    std::size_t mlock_kb;
-    try
-    {
-        mlock_kb_file.exceptions(std::fstream::failbit | std::fstream::badbit);
-        mlock_kb_file.open("/proc/sys/kernel/perf_event_mlock_kb", std::fstream::in);
-        mlock_kb_file >> mlock_kb;
-        mlock_kb_file.close();
-        return mlock_kb * 1024;
-    }
-    catch (std::exception& e)
-    {
-        Log::trace() << "Reading /proc/sys/kernel/perf_event_mlock_kb failed: " << e.what();
-        return 516 * 1024;
-    }
-}
 std::unordered_map<pid_t, std::string> read_all_tid_exe()
 {
     std::unordered_map<pid_t, std::string> ret;


### PR DESCRIPTION
This pull request should reset the default mmap value to the previous default of 16 as well as adding
a more informative error message[citation needed] and cleaning up follow up exceptions so that the error message is more highlighted. I have made the decision to abort execution when such an error is met, as we can not recover from this
```bash
cve@archlinux ~/lo2s/build (git)-[issue-25-revert-mmap-pages] % ./lo2s -m 512 bash
[cve@archlinux build]$ bash
[cve@archlinux build]$ bash
[cve@archlinux build]$ bash
[cve@archlinux build]$ bash
[1514986765027380380][pid: 2994][tid:140135648560960][ERROR]: mapping memory for recording events failed. You can try to decrease the buffer size with the -m flag, or try to increase the amount of mappable memory by increasing /proc/sys/kernel/perf_event_mlock_kb
[1514986765027645958][pid: 2994][tid:140135648560960][ERROR]: Failure while adding new process 3004: Operation not permitted
[1514986765051381212][pid: 2994][tid:140135648560960][ERROR]: Aborting: Operation not permitted
```