### PR TITLE
Issue 40 Add full lo2s arguments to trace archive metadata

### DIFF
--- a/include/lo2s/config.hpp
+++ b/include/lo2s/config.hpp
@@ -47,6 +47,7 @@ struct Config
     MonitorType monitor_type;
     pid_t pid;
     std::vector<std::string> command;
+    std::string command_line;
     bool quiet;
     // Optional features
     std::vector<std::string> tracepoint_events;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -101,13 +101,6 @@ void parse_program_options(int argc, const char** argv)
 
     std::string requested_clock_name;
 
-    for(int arg = 0; arg < argc - 1; arg++)
-    {
-        config.command_line.append(argv[arg]);
-        config.command_line.append(" ");
-    }
-    config.command_line.append(argv[argc - 1]);
-
     // clang-format off
     desc.add_options()
         ("help",
@@ -354,6 +347,13 @@ void parse_program_options(int argc, const char** argv)
     {
         config.exclude_kernel = true;
     }
+
+    for(int arg = 0; arg < argc - 1; arg++)
+    {
+        config.command_line.append(argv[arg]);
+        config.command_line.append(" ");
+    }
+    config.command_line.append(argv[argc - 1]);
 
     instance = std::move(config);
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -101,6 +101,13 @@ void parse_program_options(int argc, const char** argv)
 
     std::string requested_clock_name;
 
+    for(int arg = 0; arg < argc - 1; arg++)
+    {
+        config.command_line.append(argv[arg]);
+        config.command_line.append(" ");
+    }
+    config.command_line.append(argv[argc - 1]);
+
     // clang-format off
     desc.add_options()
         ("help",

--- a/src/monitor/main_monitor.cpp
+++ b/src/monitor/main_monitor.cpp
@@ -41,6 +41,8 @@ MainMonitor::MainMonitor()
     // the first possible timestamp in the trace
     trace_.begin_record();
 
+    trace_.archive().set_creator(config().command_line);
+
     // TODO we can still have events earlier due to different timers.
 
     // try to initialize raw counter metrics

--- a/src/monitor/main_monitor.cpp
+++ b/src/monitor/main_monitor.cpp
@@ -41,7 +41,7 @@ MainMonitor::MainMonitor()
     // the first possible timestamp in the trace
     trace_.begin_record();
 
-    trace_.archive().set_creator(config().command_line);
+    trace_.archive().set_description(config().command_line);
 
     // TODO we can still have events earlier due to different timers.
 


### PR DESCRIPTION
This pull requests adds code to set the creator field of the otf2 archive metadata to the used command line.