### PR TITLE
Add sampling source event as a counter

### DIFF
--- a/src/perf/event_collection.cpp
+++ b/src/perf/event_collection.cpp
@@ -71,6 +71,16 @@ EventCollection collect_requested_events()
         used_counters.emplace_back(perf::EventProvider::get_event_by_name("cpu-cycles"));
     }
 
+    // if not already present, add sampling event as a counter
+    const auto& sampling_event = config().sampling_event;
+    if (std::count_if(used_counters.begin(), used_counters.end(),
+                      [&sampling_event](const perf::CounterDescription& desc) {
+                          return desc.name == sampling_event;
+                      }) == 0)
+    {
+        used_counters.emplace_back(perf::EventProvider::get_event_by_name(sampling_event));
+    }
+
     return { leader, used_counters };
 }
 


### PR DESCRIPTION
If not already requested by `-E` or `--metric-leader`, the sampling source event specified by `-e` is added as a metric counter.

This should implement the behavior requested in issue #32.