### PR TITLE
Issue #49: usability enhancements

### DIFF
--- a/include/lo2s/io.hpp
+++ b/include/lo2s/io.hpp
@@ -1,0 +1,124 @@
+/*
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2018,
+ *    Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file lo2s/io.hpp
+ * \brief I/O helper functions for lo2s' types
+ *
+ * This header contains overloads for stream-based formatted output of types
+ * used by lo2s and I/O-manipulators for uniform looking output.
+ *
+ */
+
+#pragma once
+
+#include <iostream>
+
+#include <lo2s/time/time.hpp>
+
+namespace lo2s
+{
+
+namespace time
+{
+inline std::ostream& operator<<(std::ostream& os, const ClockDescription& desc)
+{
+    return os << desc.name;
+}
+}
+
+namespace io
+{
+
+/**
+ * \brief Format a range of values as a list of arguments to an option.
+ */
+template <class InputIterator>
+struct ArgumentList
+{
+    ArgumentList() = delete;
+
+    /**
+     * \param description   description of list contents printed before list
+     * \param first         iterator pointing to first item to print
+     * \param last          iterator pointing past the last item to print
+     * */
+    constexpr ArgumentList(const char* description, InputIterator first, InputIterator last)
+    : description_(description), first_(first), last_(last)
+    {
+    }
+
+    template <class _InputIt>
+    friend ArgumentList<InputIterator> make_argument_list(const char*, _InputIt, _InputIt);
+
+    template <class T, std::size_t N>
+    friend ArgumentList<InputIterator> make_argument_list(const char* description,
+                                                          const T (&array)[N]);
+
+    template <class _InputIt>
+    friend std::ostream& operator<<(std::ostream&, const ArgumentList<_InputIt>&);
+
+private:
+    const char* description_;
+    InputIterator first_, last_;
+};
+
+/**
+ * \brief   Creates ArgumentList object, deducing the target type from the types
+ *          of the arguments
+ */
+template <class InputIterator>
+inline constexpr auto make_argument_list(const char* description, InputIterator first,
+                                         InputIterator last)
+{
+    return ArgumentList<InputIterator>{ description, first, last };
+}
+
+/**
+ * \brief Creates ArgumentList object from a fixed-size array of elements
+ */
+template <class T, std::size_t N>
+inline constexpr auto make_argument_list(const char* description, const T (&array)[N])
+{
+    return ArgumentList<const T*>{ description, array, array + N };
+}
+
+template <class InputIterator>
+inline std::ostream& operator<<(std::ostream& os, const ArgumentList<InputIterator>& list)
+{
+    os << "\nList of " << list.description_ << ":\n\n";
+
+    if (list.first_ != list.last_)
+    {
+        for (auto it = list.first_; it != list.last_; ++it)
+        {
+            os << "  " << *it << '\n';
+        }
+    }
+    else
+    {
+        os << "  (none available)\n";
+    }
+    os << '\n';
+    return os;
+}
+}
+}

--- a/include/lo2s/io.hpp
+++ b/include/lo2s/io.hpp
@@ -31,6 +31,7 @@
 #pragma once
 
 #include <iostream>
+#include <string>
 
 #include <lo2s/time/time.hpp>
 
@@ -61,23 +62,19 @@ struct ArgumentList
      * \param first         iterator pointing to first item to print
      * \param last          iterator pointing past the last item to print
      * */
-    constexpr ArgumentList(const char* description, InputIterator first, InputIterator last)
+    constexpr ArgumentList(const std::string& description, InputIterator first, InputIterator last)
     : description_(description), first_(first), last_(last)
     {
     }
 
     template <class _InputIt>
-    friend ArgumentList<InputIterator> make_argument_list(const char*, _InputIt, _InputIt);
-
-    template <class T, std::size_t N>
-    friend ArgumentList<InputIterator> make_argument_list(const char* description,
-                                                          const T (&array)[N]);
+    friend ArgumentList<InputIterator> make_argument_list(const std::string&, _InputIt, _InputIt);
 
     template <class _InputIt>
     friend std::ostream& operator<<(std::ostream&, const ArgumentList<_InputIt>&);
 
 private:
-    const char* description_;
+    std::string description_;
     InputIterator first_, last_;
 };
 
@@ -86,19 +83,10 @@ private:
  *          of the arguments
  */
 template <class InputIterator>
-inline constexpr auto make_argument_list(const char* description, InputIterator first,
+inline constexpr auto make_argument_list(const std::string& description, InputIterator first,
                                          InputIterator last)
 {
     return ArgumentList<InputIterator>{ description, first, last };
-}
-
-/**
- * \brief Creates ArgumentList object from a fixed-size array of elements
- */
-template <class T, std::size_t N>
-inline constexpr auto make_argument_list(const char* description, const T (&array)[N])
-{
-    return ArgumentList<const T*>{ description, array, array + N };
 }
 
 template <class InputIterator>

--- a/include/lo2s/perf/event_provider.hpp
+++ b/include/lo2s/perf/event_provider.hpp
@@ -85,7 +85,8 @@ public:
 
     static bool has_event(const std::string& name);
 
-    static std::vector<EventMap::key_type> get_event_names();
+    static std::vector<std::string> get_predefined_event_names();
+    static std::vector<std::string> get_pmu_event_names();
 
     class InvalidEvent : public std::runtime_error
     {

--- a/include/lo2s/perf/tracepoint/format.hpp
+++ b/include/lo2s/perf/tracepoint/format.hpp
@@ -119,6 +119,8 @@ public:
         throw std::out_of_range("field not found");
     }
 
+    static std::vector<std::string> get_tracepoint_event_names();
+
 private:
     void parse_format_line(const std::string& line);
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -180,6 +180,7 @@ Arguments to options:
           "  " << name << " [options] ./a.out\n"
           "  " << name << " [options] -- ./a.out --option-to-a-out\n"
           "  " << name << " [options] --pid $(pidof some-process)\n"
+          "  " << name << " [options] --all-cpus"
           "\n" << desc << argument_detail;
     // clang-format on
 }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -148,12 +148,36 @@ static inline void print_version(std::ostream& os)
 static inline void print_usage(std::ostream& os, const char* name,
                                const po::options_description& desc)
 {
+    static constexpr char argument_detail[] =
+        R"(
+Arguments to options:
+
+    EVENT       Name of a perf event.  Format is either
+                    <name>
+                for a predefined event or one of
+                    <pmu>/<event>/
+                    <pmu>:<event>
+                for kernel PMU events.  Kernel PMU events can be found at
+                    /sys/bus/event_source/devices/<pmu>/event/<event>.
+
+    TRACEPOINT  Name of a kernel tracepoint event.  Format is either
+                    <group>:<name>
+                or
+                    <group>/<name>.
+                Tracepoint events can be found at
+                    /sys/kernel/debug/tracing/events/<group>/<name>.
+                Accessing tracepoints (even for --list-events=tracepoint)
+                usually requires read/execute permissions on
+                    /sys/kernel/debug,
+                which by default is owned by root:root.
+)";
+
     // clang-format off
     os << "Usage:\n"
           "  " << name << " [options] ./a.out\n"
           "  " << name << " [options] -- ./a.out --option-to-a-out\n"
           "  " << name << " [options] --pid $(pidof some-process)\n"
-          "\n" << desc;
+          "\n" << desc << argument_detail;
     // clang-format on
 }
 
@@ -507,7 +531,8 @@ void parse_program_options(int argc, const char** argv)
 #ifdef HAVE_X86_ADAPT
         config.x86_adapt_cpu_knobs = std::move(x86_adapt_cpu_knobs);
 #else
-        std::cerr << "lo2s was built without support for x86_adapt; cannot set x86_adapt CPU knobs.";
+        std::cerr
+            << "lo2s was built without support for x86_adapt; cannot set x86_adapt CPU knobs.";
         std::exit(EXIT_FAILURE);
 #endif
     }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -80,7 +80,7 @@ void validate(boost::any& v, const std::vector<std::string>&, SwitchCounter*, lo
     }
 }
 
-static inline void list_arguments_sorted(std::ostream& os, const char* description,
+static inline void list_arguments_sorted(std::ostream& os, const std::string& description,
                                          std::vector<std::string> items)
 {
     std::sort(items.begin(), items.end());
@@ -109,7 +109,7 @@ static inline void list_x86_adapt_cpu_knobs(std::ostream& os)
 
     os << io::make_argument_list("x86_adapt CPU knobs", knobs.begin(), knobs.end());
 #else
-    (void) os;
+    (void)os;
     std::cerr << "lo2s was built without support for x86_adapt; cannot read CPU knobs.\n";
     std::exit(EXIT_FAILURE);
 #endif
@@ -396,8 +396,9 @@ void parse_program_options(int argc, const char** argv)
     {
         if (list_clockids)
         {
-            std::cout << io::make_argument_list("available clockids",
-                                                time::ClockProvider::get_descriptions());
+            auto& clockids = time::ClockProvider::get_descriptions();
+            std::cout << io::make_argument_list("available clockids", std::begin(clockids),
+                                                std::end(clockids));
             std::exit(EXIT_SUCCESS);
         }
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -23,6 +23,7 @@
 
 #include <lo2s/log.hpp>
 #include <lo2s/perf/event_provider.hpp>
+#include <lo2s/perf/tracepoint/format.hpp>
 #include <lo2s/perf/util.hpp>
 #include <lo2s/time/time.hpp>
 #include <lo2s/util.hpp>
@@ -87,6 +88,8 @@ static void list_event_names(std::ostream& os, const std::string& category_name)
     static constexpr event_category CATEGORIES[] = {
         { "predefined", "predefined events", &perf::EventProvider::get_predefined_event_names },
         { "pmu", "Kernel PMU events", &perf::EventProvider::get_pmu_event_names },
+        { "tracepoint", "Kernel tracepoint events",
+          &perf::tracepoint::EventFormat::get_tracepoint_event_names },
     };
 
     bool list_all = category_name == "all";

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -131,8 +131,23 @@ static inline void print_usage(std::ostream& os, const char* name,
     static constexpr char argument_detail[] =
         R"(
 Arguments to options:
-    PATH        A filesystem path.  It can be either relative to the
-                current working directory or absolute.
+    PATH        A filesystem path.  If the pathname given in PATH is
+                relative, then  it is  interpreted  relative  to the
+                current working  directory of  lo2s, otherwise it is
+                interpreted as an absolute path.
+
+                NOTE: PATH arguments given to --output-trace support
+                simple variable substitution, where any occurence of
+                {<var>} will be replaced before being interpreted.
+
+                For substitution, <var> is one of the following:
+                - DATE:       current date (format %Y-%m-%dT%H-%M-%S)
+                - HOSTNAME:   current system host name
+                - ENV=<VAR>:  contents of environment variable <VAR>
+
+                Example:
+                    $ FOO=bar lo2s -o lo2s_{ENV=FOO}_{HOSTNAME} ...
+                    > Using trace directory: lo2s_bar_HAL-9000
 
     EVENT       Name of a perf event.  Format is either
                 - for a predefined event:
@@ -219,7 +234,7 @@ void parse_program_options(int argc, const char** argv)
         ("output-trace,o",
             po::value(&config.trace_path)
                 ->value_name("PATH"),
-            "Output trace directory. If not specified, lo2s_trace_$(date +%Y-%m-%dT%H-%M-%S) will be used.")
+            "Output trace directory. Defaults to lo2s_trace_{DATE} if not specified.")
         ("quiet,q",
             po::bool_switch(&config.quiet),
             "Suppress output.")

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -99,10 +99,11 @@ static void list_event_names(std::ostream& os, const std::string& category_name)
             listed_any = true;
             os << "\nList of " << category.description << ":\n\n";
 
-            const auto list = category.event_list();
+            auto list = category.event_list();
 
             if (!list.empty())
             {
+                std::sort(list.begin(), list.end());
                 for (const auto& event : list)
                 {
                     os << "  " << event << '\n';

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -109,6 +109,7 @@ static inline void list_x86_adapt_cpu_knobs(std::ostream& os)
 
     os << io::make_argument_list("x86_adapt CPU knobs", knobs.begin(), knobs.end());
 #else
+    (void) os;
     std::cerr << "lo2s was built without support for x86_adapt; cannot read CPU knobs.\n";
     std::exit(EXIT_FAILURE);
 #endif

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -143,15 +143,30 @@ Arguments to options:
                   Kernel PMU events can be found at
                     /sys/bus/event_source/devices/<pmu>/event/<event>.
 
+                To list all available event names, use --list-events.
+
     TRACEPOINT  Name of a kernel tracepoint event.  Format is either
                     <group>:<name>
                 or
                     <group>/<name>.
                 Tracepoint events can be found at
                     /sys/kernel/debug/tracing/events/<group>/<name>.
-                Accessing tracepoints (even for --list-tracepoints)
-                usually requires read/execute permissions on
-                    /sys/kernel/debug
+
+                Use --list-tracepoints to get the names of available
+                tracepoints events.
+
+                NOTE:  Accessing tracepoint  events usually requires
+                read+execute permissions on /sys/kernel/debug.
+
+    CLOCKID     Name of a system clock.  To show a list of available
+                clock names, use --list-clockids.
+
+                NOTE: Clock names are determined at compile time and
+                might not be available when running on a system that
+                is not the build system.
+
+    KNOB        Name of a x86_adapt CPU configuration item.  To show
+                a list of available knobs, use --list-knobs.
 )";
 
     // clang-format off
@@ -221,7 +236,7 @@ void parse_program_options(int argc, const char** argv)
             po::value(&requested_clock_name)
                 ->value_name("CLOCKID")
                 ->default_value("monotonic-raw"),
-            "Clock used for perf timestamps (see --list-clockids).")
+            "Reference clock used as timestamp source.")
         ("list-clockids",
             po::bool_switch(&list_clockids)
                 ->default_value(false),
@@ -233,7 +248,11 @@ void parse_program_options(int argc, const char** argv)
         ("list-tracepoints",
             po::bool_switch(&list_tracepoints)
                 ->default_value(false),
-            "List available kernel tracepoint events.");
+            "List available kernel tracepoint events.")
+        ("list-knobs",
+            po::bool_switch(&list_knobs)
+                ->default_value(false),
+            "List available x86_adapt CPU knobs.");
 
     system_wide_options.add_options()
         ("all-cpus,a",
@@ -313,11 +332,7 @@ void parse_program_options(int argc, const char** argv)
         ("x86-adapt-cpu-knob,x",
             po::value(&x86_adapt_cpu_knobs)
                 ->value_name("KNOB"),
-            "Add x86_adapt knobs as recordings. Append #accumulated_last for semantics.")
-        ("list-knobs",
-            po::bool_switch(&list_knobs)
-                ->default_value(false),
-            "List available x86_adapt CPU knobs.");
+            "Add x86_adapt knobs as recordings. Append #accumulated_last for semantics.");
     // clang-format on
 
     po::options_description all_options;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -98,9 +98,19 @@ static void list_event_names(std::ostream& os, const std::string& category_name)
         {
             listed_any = true;
             os << "\nList of " << category.description << ":\n\n";
-            for (const auto& event : category.event_list())
+
+            const auto list = category.event_list();
+
+            if (!list.empty())
             {
-                os << "  " << event << '\n';
+                for (const auto& event : list)
+                {
+                    os << "  " << event << '\n';
+                }
+            }
+            else
+            {
+                os << "  (none available)\n";
             }
             os << '\n';
         }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -273,7 +273,7 @@ void parse_program_options(int argc, const char** argv)
             "Interrupt source event for sampling.")
         ("call-graph,g",
             po::bool_switch(&config.enable_cct),
-            "Enable call-graph recording.")
+            "Record call stack of instruction samples.")
         ("no-ip,n",
             po::bool_switch(&config.suppress_ip),
             "Do not record instruction pointers [NOT CURRENTLY SUPPORTED]")

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -213,6 +213,10 @@ void parse_program_options(int argc, const char** argv)
 
     std::string requested_clock_name;
 
+    config.pid = -1; // Default value is set here and not with
+                     // po::typed_value::default_value to hide
+                     // it from usage message.
+
     // clang-format off
     general_options.add_options()
         ("help,h",
@@ -279,8 +283,7 @@ void parse_program_options(int argc, const char** argv)
             "Do not record instruction pointers [NOT CURRENTLY SUPPORTED]")
         ("pid,p",
             po::value(&config.pid)
-                ->value_name("PID")
-                ->default_value(-1),
+                ->value_name("PID"),
             "Attach to process of given PID.")
         ("readout-interval,i",
             po::value(&read_interval_ms)

--- a/src/perf/event_provider.cpp
+++ b/src/perf/event_provider.cpp
@@ -209,7 +209,7 @@ static void populate_event_map(EventProvider::EventMap& map)
     }
 }
 
-static std::vector<std::string> get_pmu_event_names()
+std::vector<std::string> EventProvider::get_pmu_event_names()
 {
     std::vector<std::string> names;
 
@@ -548,18 +548,7 @@ std::vector<std::string> EventProvider::get_predefined_event_names()
         }
     }
 
-    std::sort(event_names.begin(), event_names.end());
-
     return event_names;
-}
-
-std::vector<std::string> EventProvider::get_pmu_event_names()
-{
-    auto pmu_event_names = lo2s::perf::get_pmu_event_names();
-
-    std::sort(pmu_event_names.begin(), pmu_event_names.end());
-
-    return pmu_event_names;
 }
 }
 }

--- a/src/perf/event_provider.cpp
+++ b/src/perf/event_provider.cpp
@@ -532,7 +532,7 @@ bool EventProvider::has_event(const std::string& name)
     }
 }
 
-std::vector<EventProvider::EventMap::key_type> EventProvider::get_event_names()
+std::vector<std::string> EventProvider::get_predefined_event_names()
 {
 
     const auto& ev_map = instance().event_map_;
@@ -548,16 +548,18 @@ std::vector<EventProvider::EventMap::key_type> EventProvider::get_event_names()
         }
     }
 
-    auto pmu_event_names = get_pmu_event_names();
-
     std::sort(event_names.begin(), event_names.end());
-    std::sort(pmu_event_names.begin(), pmu_event_names.end());
-
-    event_names.reserve(event_names.size() + pmu_event_names.size());
-    std::move(std::begin(pmu_event_names), std::end(pmu_event_names),
-              std::back_inserter(event_names));
 
     return event_names;
+}
+
+std::vector<std::string> EventProvider::get_pmu_event_names()
+{
+    auto pmu_event_names = lo2s::perf::get_pmu_event_names();
+
+    std::sort(pmu_event_names.begin(), pmu_event_names.end());
+
+    return pmu_event_names;
 }
 }
 }

--- a/src/perf/event_provider.cpp
+++ b/src/perf/event_provider.cpp
@@ -29,6 +29,7 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
+#include <boost/range/iterator_range.hpp>
 #include <ios>
 #include <limits>
 #include <regex>
@@ -216,7 +217,7 @@ static std::vector<std::string> get_pmu_event_names()
 
     const fs::path pmu_devices("/sys/bus/event_source/devices");
 
-    for (const auto& pmu : fs::directory_iterator(pmu_devices))
+    for (const auto& pmu : boost::make_iterator_range(fs::directory_iterator{ pmu_devices }, {}))
     {
         const auto pmu_path = pmu.path();
 
@@ -228,7 +229,8 @@ static std::vector<std::string> get_pmu_event_names()
             continue;
         }
 
-        for (const auto& event : fs::directory_iterator(event_dir))
+        for (const auto& event :
+             boost::make_iterator_range(fs::directory_iterator{ event_dir }, {}))
         {
             std::stringstream event_name;
 

--- a/src/perf/tracepoint/format.cpp
+++ b/src/perf/tracepoint/format.cpp
@@ -98,6 +98,29 @@ void EventFormat::parse_format_line(const std::string& line)
     }
 }
 
+std::vector<std::string> EventFormat::get_tracepoint_event_names() try
+{
+    boost::filesystem::ifstream ifs_available_events;
+    ifs_available_events.exceptions(std::ios::failbit | std::ios::badbit);
+
+    ifs_available_events.open("/sys/kernel/debug/tracing/available_events");
+    ifs_available_events.exceptions(std::ios::badbit);
+
+    std::vector<std::string> available;
+
+    for (std::string tracepoint; std::getline(ifs_available_events, tracepoint);)
+    {
+        available.emplace_back(std::move(tracepoint));
+    }
+
+    return available;
+}
+catch (const std::ios_base::failure& e)
+{
+    Log::debug() << "Retrieving kernel tracepoint event names failed: " << e.what();
+    return {};
+}
+
 const boost::filesystem::path EventFormat::base_path_ = "/sys/kernel/debug/tracing/events";
 }
 }

--- a/src/perf/tracepoint/format.cpp
+++ b/src/perf/tracepoint/format.cpp
@@ -98,29 +98,31 @@ void EventFormat::parse_format_line(const std::string& line)
     }
 }
 
-std::vector<std::string> EventFormat::get_tracepoint_event_names() try
+std::vector<std::string> EventFormat::get_tracepoint_event_names()
 {
-    boost::filesystem::ifstream ifs_available_events;
-    ifs_available_events.exceptions(std::ios::failbit | std::ios::badbit);
-
-    ifs_available_events.open("/sys/kernel/debug/tracing/available_events");
-    ifs_available_events.exceptions(std::ios::badbit);
-
-    std::vector<std::string> available;
-
-    for (std::string tracepoint; std::getline(ifs_available_events, tracepoint);)
+    try
     {
-        available.emplace_back(std::move(tracepoint));
+        boost::filesystem::ifstream ifs_available_events;
+        ifs_available_events.exceptions(std::ios::failbit | std::ios::badbit);
+
+        ifs_available_events.open("/sys/kernel/debug/tracing/available_events");
+        ifs_available_events.exceptions(std::ios::badbit);
+
+        std::vector<std::string> available;
+
+        for (std::string tracepoint; std::getline(ifs_available_events, tracepoint);)
+        {
+            available.emplace_back(std::move(tracepoint));
+        }
+
+        return available;
     }
-
-    return available;
+    catch (const std::ios_base::failure& e)
+    {
+        Log::debug() << "Retrieving kernel tracepoint event names failed: " << e.what();
+        return {};
+    }
 }
-catch (const std::ios_base::failure& e)
-{
-    Log::debug() << "Retrieving kernel tracepoint event names failed: " << e.what();
-    return {};
-}
-
 const boost::filesystem::path EventFormat::base_path_ = "/sys/kernel/debug/tracing/events";
 }
 }


### PR DESCRIPTION
Changes:

* list available events (predefined and kernel PMU) with `--list-events`
* list available tracepoint events with `--list-tracepoints`
* show descriptive error when using `x86_adapt`-related switches but `lo2s` was built without support for `x86_adapt`.
* group options in usage section
* add `lo2s [OPTIONS] -a` as invocation pattern in usage section
* give names to arguments to options
* add usage section explaining arguments to options.