### PR TITLE
Issue #5: process tree

### DIFF
--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -146,9 +146,21 @@ private:
 
     otf2::definition::string intern(const std::string&);
 
+    otf2::definition::location::reference_type location_ref() const
+    {
+        return locations_.size();
+    }
+
     otf2::definition::location_group::reference_type location_group_ref() const
     {
         return location_groups_process_.size() + location_groups_cpu_.size();
+    }
+
+    otf2::definition::system_tree_node::reference_type system_tree_ref() const
+    {
+        // + for system_tree_root_node_
+        return 1 + system_tree_package_nodes_.size() + system_tree_core_nodes_.size() +
+               system_tree_cpu_nodes_.size();
     }
 
     otf2::definition::region::reference_type region_ref() const
@@ -166,6 +178,32 @@ private:
     otf2::definition::comm::reference_type comm_ref() const
     {
         return process_comms_.size();
+    }
+
+    otf2::definition::metric_member::reference_type metric_member_ref() const
+    {
+        return metric_members_.size();
+    }
+
+    // metric classes and metric instances share a reference space
+    otf2::definition::metric_class::reference_type metric_class_ref() const
+    {
+        return metric_instances_.size() + metric_classes_.size();
+    }
+
+    otf2::definition::metric_instance::reference_type metric_instance_ref() const
+    {
+        return metric_instances_.size() + metric_classes_.size();
+    }
+
+    otf2::definition::source_code_location::reference_type scl_ref() const
+    {
+        return source_code_locations_.size();
+    }
+
+    otf2::definition::string::reference_type string_ref() const
+    {
+        return strings_.size();
     }
 
 private:

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -89,6 +89,8 @@ public:
 
     void process(pid_t pid, pid_t parent, const std::string& name = "");
 
+    void process_update_executable(pid_t pid, const std::string& exe_name);
+
     otf2::writer::local& sample_writer(pid_t pid, pid_t tid);
     otf2::writer::local& cpu_writer(int cpuid);
     otf2::writer::local& metric_writer(pid_t pid, pid_t tid);
@@ -212,6 +214,8 @@ private:
 
     void attach_process_location_group(const otf2::definition::system_tree_node& parent, pid_t id,
                                        const otf2::definition::string& iname);
+
+    void process_update_executable(pid_t pid, const otf2::definition::string& exe_name);
 
 private:
     std::mutex mutex_;

--- a/src/monitor/process_monitor.cpp
+++ b/src/monitor/process_monitor.cpp
@@ -110,7 +110,8 @@ ProcessMonitor::ProcessMonitor(pid_t child, const std::string& name, bool spawn)
     }
     running = true;
 
-    trace().process(child, name);
+    // insert first child as root process in the resulting trace
+    trace().process(child, trace::Trace::NO_PARENT_PROCESS_PID, name);
     threads_.insert(child, child, spawn);
 }
 
@@ -150,7 +151,7 @@ void ProcessMonitor::handle_ptrace_event(pid_t child, int event)
             Log::debug() << "New process is forked " << newpid << ": " << name
                          << " parent: " << child << ": " << get_process_exe(child);
 
-            trace_.process(newpid, name);
+            trace_.process(newpid, child, name);
             threads_.insert(newpid, newpid, false);
         }
         catch (std::system_error& e)
@@ -196,7 +197,6 @@ void ProcessMonitor::handle_ptrace_event(pid_t child, int event)
             {
                 auto name = get_process_exe(child);
                 Log::info() << "Process " << child << " / " << name << " about to exit";
-                trace_.process(child, name);
             }
             else
             {

--- a/src/monitor/process_monitor.cpp
+++ b/src/monitor/process_monitor.cpp
@@ -197,6 +197,10 @@ void ProcessMonitor::handle_ptrace_event(pid_t child, int event)
             {
                 auto name = get_process_exe(child);
                 Log::info() << "Process " << child << " / " << name << " about to exit";
+
+                // record the executable name used before exit; it may have
+                // changed since first time child was added (e.g. by an exec)
+                trace().process_update_executable(child, name);
             }
             else
             {

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -279,11 +279,8 @@ void Trace::process_update_executable(pid_t pid, const otf2::definition::string&
     system_tree_process_nodes_.at(pid).name(exe_name);
     location_groups_process_.at(pid).name(exe_name);
 
-    // TODO: add setters to otf2xx to also update the names in comms and comm
-    // groups
-
-    // process_comm_groups_.at(pid).name(exe_name);
-    // process_comms_.at(pid).name(exe_name);
+    process_comm_groups_.at(pid).name(exe_name);
+    process_comms_.at(pid).name(exe_name);
 }
 
 void Trace::process_update_executable(pid_t pid, const std::string& exe_name)

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -339,8 +339,7 @@ otf2::definition::metric_member Trace::metric_member(const std::string& name,
                                                      otf2::common::type value_type,
                                                      const std::string& unit)
 {
-    auto ref = metric_member_ref();
-    return metric_members_.emplace(ref, intern(name), intern(description),
+    return metric_members_.emplace(metric_member_ref(), intern(name), intern(description),
                                    otf2::common::metric_type::other, mode, value_type,
                                    otf2::common::base_type::decimal, 0, intern(unit));
 }
@@ -349,8 +348,7 @@ otf2::definition::metric_instance
 Trace::metric_instance(otf2::definition::metric_class metric_class,
                        otf2::definition::location recorder, otf2::definition::location scope)
 {
-    auto ref = metric_instance_ref();
-    return metric_instances_.emplace(ref, metric_class, recorder, scope);
+    return metric_instances_.emplace(metric_instance_ref(), metric_class, recorder, scope);
 }
 
 otf2::definition::metric_instance
@@ -358,14 +356,12 @@ Trace::metric_instance(otf2::definition::metric_class metric_class,
                        otf2::definition::location recorder,
                        otf2::definition::system_tree_node scope)
 {
-    auto ref = metric_instance_ref();
-    return metric_instances_.emplace(ref, metric_class, recorder, scope);
+    return metric_instances_.emplace(metric_instance_ref(), metric_class, recorder, scope);
 }
 
 otf2::definition::metric_class Trace::metric_class()
 {
-    auto ref = metric_class_ref();
-    return metric_classes_.emplace(ref, otf2::common::metric_occurence::async,
+    return metric_classes_.emplace(metric_class_ref(), otf2::common::metric_occurence::async,
                                    otf2::common::recorder_kind::abstract);
 }
 
@@ -458,11 +454,10 @@ void Trace::register_tid(pid_t tid, const std::string& exe)
     // Lock this to avoid conflict on regions_thread_ with register_monitoring_tid
     std::lock_guard<std::mutex> guard(mutex_);
 
-    auto ref = region_ref();
     auto iname = intern((boost::format("%s (%d)") % exe % tid).str());
     auto ret = regions_thread_.emplace(
         std::piecewise_construct, std::forward_as_tuple(tid),
-        std::forward_as_tuple(ref, iname, iname, iname, otf2::common::role_type::function,
+        std::forward_as_tuple(region_ref(), iname, iname, iname, otf2::common::role_type::function,
                               otf2::common::paradigm_type::user, otf2::common::flags_type::none,
                               iname, 0, 0));
     if (ret.second)
@@ -479,13 +474,12 @@ void Trace::register_monitoring_tid(pid_t tid, const std::string& name, const st
     std::lock_guard<std::mutex> guard(mutex_);
 
     Log::debug() << "register_monitoring_tid(" << tid << "," << name << "," << group << ");";
-    auto ref = region_ref();
     auto iname = intern((boost::format("lo2s::%s") % name).str());
 
     // TODO, should be paradigm_type::measurement_system, but that's a bug in Vampir
     auto ret = regions_thread_.emplace(
         std::piecewise_construct, std::forward_as_tuple(tid),
-        std::forward_as_tuple(ref, iname, iname, iname, otf2::common::role_type::function,
+        std::forward_as_tuple(region_ref(), iname, iname, iname, otf2::common::role_type::function,
                               otf2::common::paradigm_type::user, otf2::common::flags_type::none,
                               iname, 0, 0));
     if (ret.second)
@@ -562,20 +556,19 @@ otf2::definition::comm Trace::process_comm(pid_t pid)
 
 otf2::definition::source_code_location Trace::intern_scl(const LineInfo& info)
 {
-    auto ref = scl_ref();
-    auto ret =
-        source_code_locations_.emplace(std::piecewise_construct, std::forward_as_tuple(info),
-                                       std::forward_as_tuple(ref, intern(info.file), info.line));
+    auto ret = source_code_locations_.emplace(
+        std::piecewise_construct, std::forward_as_tuple(info),
+        std::forward_as_tuple(scl_ref(), intern(info.file), info.line));
     return ret.first->second;
 }
 
 otf2::definition::region Trace::intern_region(const LineInfo& info)
 {
-    auto ref = region_ref();
     auto name_str = intern(info.function);
     auto ret = regions_line_info_.emplace(
         std::piecewise_construct, std::forward_as_tuple(info),
-        std::forward_as_tuple(ref, name_str, name_str, name_str, otf2::common::role_type::function,
+        std::forward_as_tuple(region_ref(), name_str, name_str, name_str,
+                              otf2::common::role_type::function,
                               otf2::common::paradigm_type::sampling, otf2::common::flags_type::none,
                               intern(info.file), info.line, 0));
     return ret.first->second;
@@ -583,9 +576,8 @@ otf2::definition::region Trace::intern_region(const LineInfo& info)
 
 otf2::definition::string Trace::intern(const std::string& name)
 {
-    auto ref = string_ref();
     auto ret = strings_.emplace(std::piecewise_construct, std::forward_as_tuple(name),
-                                std::forward_as_tuple(ref, name));
+                                std::forward_as_tuple(string_ref(), name));
     return ret.first->second;
 }
 } // namespace trace


### PR DESCRIPTION
Add traced processes in a tree to the trace.

As taken from 6422a2c:

```
Suppose on machine HAL 9000, lo2s traced a process "foo" which spawned
some threads and another process "bar", the resulting system tree now
looks something like this:

<root node>
`-- <machine "HAL 9000">
    `-- <process "foo">         \
    |   `-- <thread 1234>       |
    |   `-- ...                 |
    |   `-- <thread 1337>       | new process subtree
    |   `-- <process "bar">     |
    |       `-- ...             /
    `-- <Metric Location Group>
    `-- <package 0>
    `-- ...
    `-- <package n>
```