### PR TITLE
Issue 52: Uncaught I/O-exception

### DIFF
--- a/include/lo2s/error.hpp
+++ b/include/lo2s/error.hpp
@@ -25,7 +25,6 @@
 
 namespace lo2s
 {
-
 inline std::system_error make_system_error()
 {
     return std::system_error(errno, std::system_category());
@@ -43,4 +42,4 @@ inline void check_errno(long retval)
         throw_errno();
     }
 }
-}
+} // namespace lo2s

--- a/include/lo2s/perf/tracepoint/format.hpp
+++ b/include/lo2s/perf/tracepoint/format.hpp
@@ -90,21 +90,12 @@ private:
 class EventFormat
 {
 public:
-    class Error : public std::runtime_error
+    class ParseError : public std::runtime_error
     {
     public:
-        Error(const std::string& event, const std::string& what)
-        : std::runtime_error(what), event_name_(event)
+        ParseError(const std::string& what) : std::runtime_error(what)
         {
         }
-
-        const std::string& event() const
-        {
-            return event_name_;
-        }
-
-    private:
-        std::string event_name_;
     };
 
 public:
@@ -140,6 +131,7 @@ public:
     static std::vector<std::string> get_tracepoint_event_names();
 
 private:
+    void parse_id();
     void parse_format_line(const std::string& line);
 
     std::string name_;

--- a/include/lo2s/perf/tracepoint/format.hpp
+++ b/include/lo2s/perf/tracepoint/format.hpp
@@ -96,6 +96,8 @@ public:
         ParseError(const std::string& what) : std::runtime_error(what)
         {
         }
+
+        ParseError(const std::string& what, int error_code);
     };
 
 public:

--- a/include/lo2s/perf/tracepoint/format.hpp
+++ b/include/lo2s/perf/tracepoint/format.hpp
@@ -90,6 +90,24 @@ private:
 class EventFormat
 {
 public:
+    class Error : public std::runtime_error
+    {
+    public:
+        Error(const std::string& event, const std::string& what)
+        : std::runtime_error(what), event_name_(event)
+        {
+        }
+
+        const std::string& event() const
+        {
+            return event_name_;
+        }
+
+    private:
+        std::string event_name_;
+    };
+
+public:
     EventFormat(const std::string& name);
 
     int id() const
@@ -131,6 +149,6 @@ private:
 
     const static boost::filesystem::path base_path_;
 };
-}
-}
-}
+} // namespace tracepoint
+} // namespace perf
+} // namespace lo2s

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,7 @@ int main(int argc, const char** argv)
         if (e.code())
         {
             lo2s::Log::fatal() << "Aborting: " << e.what();
-            return EXIT_FAILURE;
+            return e.code().value();
         }
         else
         {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -49,13 +49,19 @@ int main(int argc, const char** argv)
         // Check for success
         if (e.code())
         {
-            lo2s::Log::error() << "Aborting: " << e.what();
+            lo2s::Log::fatal() << "Aborting: " << e.what();
+            return EXIT_FAILURE;
         }
         else
         {
             lo2s::summary().show();
+            return EXIT_SUCCESS;
         }
-        return e.code().value();
+    }
+    catch (const std::runtime_error& e)
+    {
+        lo2s::Log::fatal() << "Aborting: " << e.what();
+        return EXIT_FAILURE;
     }
 
     return 0;

--- a/src/perf/tracepoint/exit_reader.cpp
+++ b/src/perf/tracepoint/exit_reader.cpp
@@ -45,14 +45,10 @@ ExitReader::ExitReader(int cpu, trace::Trace& trace) try
   comm_field_(get_sched_process_exit_event().field("comm"))
 {
 }
-catch (const EventFormat::Error& e)
+catch (const EventFormat::ParseError& e)
 {
-
-    Log::error() << "Cannot open tracepoint exit reader!";
-    Log::error() << "Failed to open tracepoint event '" << e.event() << "': " << e.what();
-    Log::warn() << "Tracepoint events are inaccessible if read/execute permissions are missing "
-                   "on /sys/kernel/debug";
-    throw std::system_error(EIO, std::system_category());
+    Log::error() << "Failed to open process exit tracepoint event: " << e.what();
+    throw std::runtime_error("Failed to open tracepoint exit reader");
 }
 
 ExitReader::~ExitReader()

--- a/src/perf/tracepoint/exit_reader.cpp
+++ b/src/perf/tracepoint/exit_reader.cpp
@@ -45,6 +45,9 @@ ExitReader::ExitReader(int cpu, trace::Trace& trace) try
   comm_field_(get_sched_process_exit_event().field("comm"))
 {
 }
+// NOTE: function-try-block is intentional; catch get_sched_process_exit_event()
+// throwing in constructor initializers if sched/sched_process_exit tracepoint
+// event is unavailable.
 catch (const EventFormat::ParseError& e)
 {
     Log::error() << "Failed to open process exit tracepoint event: " << e.what();

--- a/src/perf/tracepoint/format.cpp
+++ b/src/perf/tracepoint/format.cpp
@@ -45,17 +45,35 @@ EventFormat::EventFormat(const std::string& name) : name_(name)
     boost::filesystem::path path_event = base_path_ / name_;
     boost::filesystem::ifstream ifs_id, ifs_format;
 
-    ifs_id.exceptions(std::ios::failbit | std::ios::badbit);
-    ifs_format.exceptions(std::ios::failbit | std::ios::badbit);
+    auto id_path = path_event / "id";
 
-    ifs_id.open(path_event / "id");
+    ifs_id.open(id_path);
+    if (ifs_id.fail())
+    {
+        throw Error(name, "failed to open tracepoint ID file");
+    }
+
     ifs_id >> id_;
+    if (ifs_id.fail())
+    {
+        throw Error(name, "failed to read tracepoint ID");
+    }
 
     ifs_format.open(path_event / "format");
+    if (ifs_format.fail())
+    {
+        throw Error(name, "failed to open tracepoint format file");
+    }
+
     std::string line;
     ifs_format.exceptions(std::ios::badbit);
     while (getline(ifs_format, line))
     {
+        if (ifs_format.bad())
+        {
+            throw Error(name, "failed to read tracepoint format");
+        }
+
         parse_format_line(line);
     }
 }
@@ -124,6 +142,6 @@ std::vector<std::string> EventFormat::get_tracepoint_event_names()
     }
 }
 const boost::filesystem::path EventFormat::base_path_ = "/sys/kernel/debug/tracing/events";
-}
-}
-}
+} // namespace tracepoint
+} // namespace perf
+} // namespace lo2s

--- a/src/perf/tracepoint/metric_monitor.cpp
+++ b/src/perf/tracepoint/metric_monitor.cpp
@@ -33,7 +33,8 @@
 
 #include <boost/format.hpp>
 
-extern "C" {
+extern "C"
+{
 #include <poll.h>
 }
 
@@ -74,6 +75,11 @@ MetricMonitor::MetricMonitor(trace::Trace& trace) : monitor::FdMonitor(trace, ""
                 (void)index;
             }
         }
+        catch (const std::exception& e)
+        {
+            Log::error() << "Couldn't read information for tracepoint event " << event_name << ": "
+                         << e.what();
+        }
         catch (...)
         {
             Log::error() << "Couldn't read information for tracepoint event " << event_name;
@@ -90,6 +96,6 @@ void MetricMonitor::finalize_thread()
 {
     perf_writers_.clear();
 }
-}
-}
-}
+} // namespace tracepoint
+} // namespace perf
+} // namespace lo2s

--- a/src/perf/tracepoint/switch_writer.cpp
+++ b/src/perf/tracepoint/switch_writer.cpp
@@ -53,13 +53,10 @@ SwitchWriter::SwitchWriter(int cpu, trace::Trace& trace) try
   prev_state_field_(get_sched_switch_event().field("prev_state"))
 {
 }
-catch (const EventFormat::Error& e)
+catch (const EventFormat::ParseError& e)
 {
-    Log::error() << "Cannot open tracepoint switch writer!";
-    Log::error() << "Failed to open tracepoint event '" << e.event() << "': " << e.what();
-    Log::warn() << "Tracepoint events are inaccessible if read/execute permissions are missing "
-                   "on /sys/kernel/debug";
-    throw std::system_error(EIO, std::system_category());
+    Log::error() << "Failed to open scheduler switch tracepoint event: " << e.what();
+    throw std::runtime_error("Failed to open tracepoint switch writer");
 }
 
 SwitchWriter::~SwitchWriter()

--- a/src/perf/tracepoint/switch_writer.cpp
+++ b/src/perf/tracepoint/switch_writer.cpp
@@ -53,6 +53,9 @@ SwitchWriter::SwitchWriter(int cpu, trace::Trace& trace) try
   prev_state_field_(get_sched_switch_event().field("prev_state"))
 {
 }
+// NOTE: function-try-block is intentional; catch get_sched_switch_event()
+// throwing in constructor initializers if sched/sched_switch tracepoint
+// event is unavailable.
 catch (const EventFormat::ParseError& e)
 {
     Log::error() << "Failed to open scheduler switch tracepoint event: " << e.what();


### PR DESCRIPTION
Previously, if parsing a tracepoint event failed, an uncaught
`std::ios_base::failure` terminated `lo2s`.

Now, a `lo2s::perf::tracepoint::EventFormat::ParseError` is thrown. Alongside,
possible causes for parsing failure are logged, such as missing permissions on
/sys/kernel/debug or a non-existent event.

If parsing fails when opening the tracepoint `SwitchWriter`/`ExitReader`, log
accordingly and die with an (hopefully helpful) error message.  If parsing fails
when opening regular tracepoint events (with `-t`), log and ignore the event.


If the changes are approved of, I'd like to sqash and remove all the typos from
the commit messages.