### PR TITLE
Issue 63 Split up locations to make the creation of writers semantically correct

### DIFF
--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -94,7 +94,7 @@ public:
     otf2::writer::local& sample_writer(pid_t pid, pid_t tid);
     otf2::writer::local& cpu_writer(int cpuid);
     otf2::writer::local& metric_writer(pid_t pid, pid_t tid);
-    otf2::writer::local& metric_writer(const std::string& name, pid_t pid = METRIC_PID);
+    otf2::writer::local& metric_writer(const std::string& name);
 
     otf2::definition::metric_member metric_member(const std::string& name,
                                                   const std::string& description,
@@ -155,9 +155,11 @@ private:
 
     otf2::definition::string intern(const std::string&);
 
+    // This generates a contiguous set of IDs for all locations
     otf2::definition::location::reference_type location_ref() const
     {
-        return thread_locations_.size() + cpu_locations_.size() + named_locations_.size();
+        return thread_locations_.size() + cpu_locations_.size() + metric_locations_.size() +
+               named_locations_.size();
     }
 
     otf2::definition::location_group::reference_type location_group_ref() const
@@ -251,7 +253,9 @@ private:
     // TODO add location groups (processes), read path from /proc/self/exe symlink
     std::map<pid_t, otf2::definition::location> thread_locations_;
     std::map<int, otf2::definition::location> cpu_locations_;
-    std::map<std::string, otf2::definition::location> named_locations_;
+    std::map<pid_t, otf2::definition::location> metric_locations_;
+
+    otf2::definition::container<otf2::definition::location> named_locations_;
 
     std::map<LineInfo, otf2::definition::source_code_location> source_code_locations_;
     std::map<LineInfo, otf2::definition::region> regions_line_info_;

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -94,7 +94,7 @@ public:
     otf2::writer::local& sample_writer(pid_t pid, pid_t tid);
     otf2::writer::local& cpu_writer(int cpuid);
     otf2::writer::local& metric_writer(pid_t pid, pid_t tid);
-    otf2::writer::local& metric_writer(const std::string& name);
+    otf2::writer::local& metric_writer(const std::string& name, pid_t pid = METRIC_PID);
 
     otf2::definition::metric_member metric_member(const std::string& name,
                                                   const std::string& description,
@@ -157,7 +157,7 @@ private:
 
     otf2::definition::location::reference_type location_ref() const
     {
-        return locations_.size();
+        return thread_locations_.size() + cpu_locations_.size() + named_locations_.size();
     }
 
     otf2::definition::location_group::reference_type location_group_ref() const
@@ -249,7 +249,9 @@ private:
     std::map<int, otf2::definition::location_group> location_groups_cpu_;
 
     // TODO add location groups (processes), read path from /proc/self/exe symlink
-    otf2::definition::container<otf2::definition::location> locations_;
+    std::map<pid_t, otf2::definition::location> thread_locations_;
+    std::map<int, otf2::definition::location> cpu_locations_;
+    std::map<std::string, otf2::definition::location> named_locations_;
 
     std::map<LineInfo, otf2::definition::source_code_location> source_code_locations_;
     std::map<LineInfo, otf2::definition::region> regions_line_info_;

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -353,41 +353,48 @@ otf2::writer::local& Trace::sample_writer(pid_t pid, pid_t tid)
         std::piecewise_construct, std::forward_as_tuple(tid),
         std::forward_as_tuple(location_ref(), intern(name), location_groups_process_.at(pid),
                               otf2::definition::location::location_type::cpu_thread));
+
     process_comm_groups_.at(pid).add_member(location.first->second);
 
     return archive()(location.first->second);
 }
+
 otf2::writer::local& Trace::cpu_writer(int cpuid)
 {
-    auto name = (boost::format("cpu %d") % cpuid).str();
+    auto name = intern((boost::format("cpu %d") % cpuid).str());
 
     // As CPU IDs are unique in this context, create only one writer/location per
     // CPU ID
     auto r_group = location_groups_cpu_.emplace(
         std::piecewise_construct, std::forward_as_tuple(cpuid),
-        std::forward_as_tuple(location_group_ref(), intern(name),
+        std::forward_as_tuple(location_group_ref(), name,
                               otf2::definition::location_group::location_group_type::unknown,
                               system_tree_cpu_nodes_.at(cpuid)));
+
     const auto& group = r_group.first->second;
 
     auto location = cpu_locations_.emplace(
         std::piecewise_construct, std::forward_as_tuple(cpuid),
-        std::forward_as_tuple(location_ref(), intern(name), group,
+        std::forward_as_tuple(location_ref(), name, group,
                               otf2::definition::location::location_type::cpu_thread));
+
     return archive()(location.first->second);
 }
 
 otf2::writer::local& Trace::metric_writer(pid_t pid, pid_t tid)
 {
     auto name = (boost::format("metrics for thread %d") % tid).str();
+
     // As the tid is unique in this context, create only one
     // writer/location per tid
     auto location = metric_locations_.emplace(
         std::piecewise_construct, std::forward_as_tuple(tid),
         std::forward_as_tuple(location_ref(), intern(name), location_groups_process_.at(pid),
                               otf2::definition::location::location_type::metric));
+
     return archive()(location.first->second);
 }
+
 otf2::writer::local& Trace::metric_writer(const std::string& name)
 {
     // As names may not be unique in this context, always generate a new location/writer pair

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -343,10 +343,12 @@ void Trace::add_lo2s_property(const std::string& name, const std::string& value)
     system_tree_node_properties_.emplace(system_tree_root_node_, intern(property_name),
                                          otf2::attribute_value{ intern(value) });
 }
-// As pid/tid pairs are unique in this context, create only one writer/location per pair
+
 otf2::writer::local& Trace::sample_writer(pid_t pid, pid_t tid)
 {
     auto name = (boost::format("thread %d") % tid).str();
+
+    // As the tid is unique in this context, create only one writer/location per tid
     auto location = thread_locations_.emplace(
         std::piecewise_construct, std::forward_as_tuple(tid),
         std::forward_as_tuple(location_ref(), intern(name), location_groups_process_.at(pid),
@@ -355,41 +357,40 @@ otf2::writer::local& Trace::sample_writer(pid_t pid, pid_t tid)
 
     return archive()(location.first->second);
 }
-// As CPU IDs are unique in this context, create only one writer/location per
-// CPU IDs
 otf2::writer::local& Trace::cpu_writer(int cpuid)
 {
     auto name = (boost::format("cpu %d") % cpuid).str();
-    auto intern_name = intern(name);
 
+    // As CPU IDs are unique in this context, create only one writer/location per
+    // CPU ID
     auto r_group = location_groups_cpu_.emplace(
         std::piecewise_construct, std::forward_as_tuple(cpuid),
-        std::forward_as_tuple(location_group_ref(), intern_name,
+        std::forward_as_tuple(location_group_ref(), intern(name),
                               otf2::definition::location_group::location_group_type::unknown,
                               system_tree_cpu_nodes_.at(cpuid)));
     const auto& group = r_group.first->second;
 
     auto location = cpu_locations_.emplace(
         std::piecewise_construct, std::forward_as_tuple(cpuid),
-        std::forward_as_tuple(location_ref(), intern_name, group,
+        std::forward_as_tuple(location_ref(), intern(name), group,
                               otf2::definition::location::location_type::cpu_thread));
     return archive()(location.first->second);
 }
 
-// As pid/tid pairs are unique in this context, create only one
-// writer/location per pid/tid pair
 otf2::writer::local& Trace::metric_writer(pid_t pid, pid_t tid)
 {
     auto name = (boost::format("metrics for thread %d") % tid).str();
+    // As the tid is unique in this context, create only one
+    // writer/location per tid
     auto location = metric_locations_.emplace(
         std::piecewise_construct, std::forward_as_tuple(tid),
         std::forward_as_tuple(location_ref(), intern(name), location_groups_process_.at(pid),
                               otf2::definition::location::location_type::metric));
     return archive()(location.first->second);
 }
-// As names may not be unique in this context, always generate a new location/writer pair
 otf2::writer::local& Trace::metric_writer(const std::string& name)
 {
+    // As names may not be unique in this context, always generate a new location/writer pair
     auto location = named_locations_.emplace(location_ref(), intern(name),
                                              location_groups_process_.at(METRIC_PID),
                                              otf2::definition::location::location_type::metric);

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -178,14 +178,15 @@ Trace::~Trace()
     otf2::definition::comm_locations_group comm_locations_group(
         0, intern("All pthread locations"), otf2::common::paradigm_type::pthread,
         otf2::common::group_flag_type::none);
-    for (const auto& location : locations_)
+    for (const auto& location : cpu_locations_)
     {
-        if (location.type() == otf2::common::location_type::cpu_thread)
-        {
-            comm_locations_group.add_member(location);
-        }
+        comm_locations_group.add_member(location.second);
     }
 
+    for (const auto& location : thread_locations_)
+    {
+        comm_locations_group.add_member(location.second);
+    }
     archive_ << otf2::definition::clock_properties(starting_time_, stopping_time_);
     archive_ << strings_;
     archive_ << system_tree_root_node_;
@@ -195,7 +196,19 @@ Trace::~Trace()
     archive_ << system_tree_process_nodes_;
     archive_ << location_groups_process_;
     archive_ << location_groups_cpu_;
-    archive_ << locations_;
+
+    for (const auto& location : thread_locations_)
+    {
+        archive_ << location.second;
+    }
+    for (const auto& location : cpu_locations_)
+    {
+        archive_ << location.second;
+    }
+    for (const auto& location : named_locations_)
+    {
+        archive_ << location.second;
+    }
     archive_ << source_code_locations_;
     archive_ << regions_line_info_;
     archive_ << regions_thread_;
@@ -332,43 +345,47 @@ void Trace::add_lo2s_property(const std::string& name, const std::string& value)
 otf2::writer::local& Trace::sample_writer(pid_t pid, pid_t tid)
 {
     auto name = (boost::format("thread %d") % tid).str();
-    auto location =
-        locations_.emplace(location_ref(), intern(name), location_groups_process_.at(pid),
-                           otf2::definition::location::location_type::cpu_thread);
-    process_comm_groups_.at(pid).add_member(location);
-    return archive()(location);
+    auto location = thread_locations_.emplace(
+        std::piecewise_construct, std::forward_as_tuple(tid),
+        std::forward_as_tuple(location_ref(), intern(name), location_groups_process_.at(pid),
+                              otf2::definition::location::location_type::cpu_thread));
+    process_comm_groups_.at(pid).add_member(location.first->second);
+
+    return archive()(location.first->second);
 }
 
 otf2::writer::local& Trace::cpu_writer(int cpuid)
 {
-    auto name = intern((boost::format("cpu %d") % cpuid).str());
+    auto name = (boost::format("cpu %d") % cpuid).str();
+    auto intern_name = intern(name);
+
     auto r_group = location_groups_cpu_.emplace(
         std::piecewise_construct, std::forward_as_tuple(cpuid),
-        std::forward_as_tuple(location_group_ref(), name,
+        std::forward_as_tuple(location_group_ref(), intern_name,
                               otf2::definition::location_group::location_group_type::unknown,
                               system_tree_cpu_nodes_.at(cpuid)));
     const auto& group = r_group.first->second;
 
-    auto location = locations_.emplace(location_ref(), name, group,
-                                       otf2::definition::location::location_type::cpu_thread);
-    return archive()(location);
+    auto location = cpu_locations_.emplace(
+        std::piecewise_construct, std::forward_as_tuple(cpuid),
+        std::forward_as_tuple(location_ref(), intern_name, group,
+                              otf2::definition::location::location_type::cpu_thread));
+    return archive()(location.first->second);
 }
 
 otf2::writer::local& Trace::metric_writer(pid_t pid, pid_t tid)
 {
     auto name = (boost::format("metrics for thread %d") % tid).str();
-    auto location =
-        locations_.emplace(location_ref(), intern(name), location_groups_process_.at(pid),
-                           otf2::definition::location::location_type::metric);
-    return archive()(location);
+    return metric_writer(name, pid);
 }
 
-otf2::writer::local& Trace::metric_writer(const std::string& name)
+otf2::writer::local& Trace::metric_writer(const std::string& name, pid_t pid)
 {
-    auto location =
-        locations_.emplace(location_ref(), intern(name), location_groups_process_.at(METRIC_PID),
-                           otf2::definition::location::location_type::metric);
-    return archive()(location);
+    auto location = named_locations_.emplace(
+        std::piecewise_construct, std::forward_as_tuple(name),
+        std::forward_as_tuple(location_ref(), intern(name), location_groups_process_.at(pid),
+                              otf2::definition::location::location_type::metric));
+    return archive()(location.first->second);
 }
 
 otf2::definition::metric_member Trace::metric_member(const std::string& name,


### PR DESCRIPTION
This pull request splits up the current locations_ map into 4 different location containers, to ensure uniqueness of the writer and locations where it applies. (For information on which writer/locations are unique and which not, see the comments above the metric_writer, sample_writer and cpu_writer functions inside src/trace/trace.cpp)