### PR TITLE
Adds x86 energy metrics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ IfUpdatedUnsetAll(lo2s_USE_STATIC_LIBS
     OTF2XX_USE_STATIC_LIBS
     Radare_USE_STATIC_LIBS
     X86Adapt_STATIC
+    x86_energy_STATIC
 )
 
 if(lo2s_USE_STATIC_LIBS STREQUAL "OFF")
@@ -39,6 +40,7 @@ if(lo2s_USE_STATIC_LIBS STREQUAL "OFF")
     set(OTF2XX_USE_STATIC_LIBS   OFF CACHE BOOL "")
     set(Radare_USE_STATIC_LIBS   OFF CACHE BOOL "")
     set(X86Adapt_STATIC          OFF CACHE BOOL "")
+    set(x86_energy_STATIC        OFF CACHE BOOL "")
 endif()
 
 if(lo2s_USE_STATIC_LIBS STREQUAL "MOSTLY")
@@ -50,6 +52,7 @@ if(lo2s_USE_STATIC_LIBS STREQUAL "MOSTLY")
     set(OTF2XX_USE_STATIC_LIBS   ON CACHE BOOL "")
     set(Radare_USE_STATIC_LIBS   ON CACHE BOOL "")
     set(X86Adapt_STATIC          ON CACHE BOOL "")
+    set(x86_energy_STATIC        ON CACHE BOOL "")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -static-libgcc")
 endif()
 
@@ -62,6 +65,7 @@ if(lo2s_USE_STATIC_LIBS STREQUAL "ALL")
     set(OTF2XX_USE_STATIC_LIBS   ON CACHE BOOL "")
     set(Radare_USE_STATIC_LIBS   ON CACHE BOOL "")
     set(X86Adapt_STATIC          ON CACHE BOOL "")
+    set(x86_energy_STATIC        ON CACHE BOOL "")
 
     # Doesn't seem to work with clang, even though it should,
     # but at least it doesn't complain about it either
@@ -94,6 +98,7 @@ find_package(Radare)
 set(THREADS_PREFER_PTHREAD_FLAG true)
 find_package(Threads REQUIRED)
 find_package(Doxygen COMPONENTS dot)
+find_package(x86_energy 2.0)
 
 # configurable options
 CMAKE_DEPENDENT_OPTION(USE_RADARE "Enable Radare support." ON "Radare_FOUND" OFF)
@@ -172,6 +177,7 @@ target_link_libraries(lo2s
         Boost::program_options
         Boost::filesystem
         Binutils::Binutils
+        x86_energy::x86_energy
 )
 
 # old glibc versions require -lrt for clock_gettime()
@@ -191,6 +197,20 @@ if(X86Adapt_FOUND)
         src/metric/x86_adapt/node_monitor.cpp
     )
     target_link_libraries(lo2s PRIVATE x86_adapt::x86_adapt)
+endif()
+
+# handle x86_energy dependency
+if(x86_energy_FOUND)
+    target_compile_definitions(lo2s PRIVATE HAVE_X86_ENERGY)
+    target_sources(lo2s PRIVATE
+        src/metric/x86_energy/metrics.cpp
+        src/metric/x86_energy/monitor.cpp
+    )
+    if(x86_energy_STATIC)
+        target_link_libraries(lo2s PRIVATE x86_energy::x86_energy-static)
+    else()
+        target_link_libraries(lo2s PRIVATE x86_energy::x86_energy)
+    endif()
 endif()
 
 # handle radare dependency

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,6 @@ target_link_libraries(lo2s
         Boost::program_options
         Boost::filesystem
         Binutils::Binutils
-        x86_energy::x86_energy
 )
 
 # old glibc versions require -lrt for clock_gettime()

--- a/include/lo2s/config.hpp
+++ b/include/lo2s/config.hpp
@@ -79,6 +79,8 @@ struct Config
     // time synchronization
     bool use_clockid;
     clockid_t clockid;
+    // x86_energy
+    bool use_x86_energy;
 };
 
 const Config& config();

--- a/include/lo2s/metric/x86_energy/metrics.hpp
+++ b/include/lo2s/metric/x86_energy/metrics.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#ifndef HAVE_X86_ENERGY
+#error "Trying to build x86 energy stuff without x86 energy support"
+#endif
+
+#include <lo2s/metric/x86_energy/monitor.hpp>
+
+#include <lo2s/topology.hpp>
+#include <lo2s/trace/fwd.hpp>
+
+#include <x86_energy.hpp>
+
+#include <chrono>
+#include <memory>
+#include <vector>
+
+namespace lo2s
+{
+namespace metric
+{
+namespace x86_energy
+{
+class Metrics
+{
+public:
+    Metrics(trace::Trace& trace, std::chrono::nanoseconds sampling_interval);
+
+public:
+    void start();
+    void stop();
+
+private:
+    ::x86_energy::Architecture architecture_;
+    std::vector<std::unique_ptr<Monitor>> recorders_;
+};
+} // namespace x86_energy
+} // namespace metric
+} // namespace lo2s

--- a/include/lo2s/metric/x86_energy/monitor.hpp
+++ b/include/lo2s/metric/x86_energy/monitor.hpp
@@ -1,0 +1,54 @@
+#pragma once
+
+#ifndef HAVE_X86_ENERGY
+#error "Trying to build x86 energy stuff without x86 energy support"
+#endif
+
+#include <lo2s/time/time.hpp>
+
+#include <lo2s/monitor/interval_monitor.hpp>
+#include <lo2s/trace/fwd.hpp>
+
+#include <x86_energy.hpp>
+
+#include <otf2xx/definition/metric_instance.hpp>
+#include <otf2xx/writer/local.hpp>
+
+#include <nitro/lang/enumerate.hpp>
+
+namespace lo2s
+{
+namespace metric
+{
+namespace x86_energy
+{
+class Monitor : public monitor::IntervalMonitor
+{
+public:
+    Monitor(::x86_energy::SourceCounter counter, int cpu,
+            std::chrono::nanoseconds sampling_interval, trace::Trace& trace,
+            const otf2::definition::metric_class& metric_class,
+            const otf2::definition::system_tree_node& stn);
+
+protected:
+    void monitor() override;
+    void initialize_thread() override;
+
+    std::string group() const override
+    {
+        return "x86_energy::Monitor";
+    }
+
+private:
+    ::x86_energy::SourceCounter counter_;
+
+    int cpu_;
+
+    otf2::writer::local otf2_writer_;
+
+    otf2::definition::metric_instance metric_instance_;
+    otf2::event::metric::value_container metric_value_;
+};
+} // namespace x86_energy
+} // namespace metric
+} // namespace lo2s

--- a/include/lo2s/monitor/main_monitor.hpp
+++ b/include/lo2s/monitor/main_monitor.hpp
@@ -25,6 +25,9 @@
 #ifdef HAVE_X86_ADAPT
 #include <lo2s/metric/x86_adapt/metrics.hpp>
 #endif
+#ifdef HAVE_X86_ENERGY
+#include <lo2s/metric/x86_energy/metrics.hpp>
+#endif
 #include <lo2s/perf/time/converter.hpp>
 #include <lo2s/trace/trace.hpp>
 
@@ -67,6 +70,9 @@ protected:
     otf2::definition::metric_class metric_class_;
 #ifdef HAVE_X86_ADAPT
     std::unique_ptr<metric::x86_adapt::Metrics> x86_adapt_metrics_;
+#endif
+#ifdef HAVE_X86_ENERGY
+    std::unique_ptr<metric::x86_energy::Metrics> x86_energy_metrics_;
 #endif
 };
 } // namespace monitor

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -140,9 +140,19 @@ public:
         return system_tree_cpu_nodes_.at(cpuid);
     }
 
+    const otf2::definition::system_tree_node& system_tree_core_node(int coreid, int packageid) const
+    {
+        return system_tree_core_nodes_.at(std::make_pair(coreid, packageid));
+    }
+
     const otf2::definition::system_tree_node& system_tree_package_node(int packageid) const
     {
         return system_tree_package_nodes_.at(packageid);
+    }
+
+    const otf2::definition::system_tree_node& system_tree_root_node() const
+    {
+        return system_tree_root_node_;
     }
 
     otf2::definition::regions_group regions_group_executable(const std::string& name);

--- a/src/metric/x86_energy/metrics.cpp
+++ b/src/metric/x86_energy/metrics.cpp
@@ -73,7 +73,7 @@ Metrics::Metrics(trace::Trace& trace, std::chrono::nanoseconds sampling_interval
         auto mc = trace.metric_class();
         mc.add_member(trace.metric_member(metric_name, metric_name,
                                           otf2::common::metric_mode::accumulated_start,
-                                          otf2::common::type::int64, "J"));
+                                          otf2::common::type::double, "J"));
 
         // if we get here, we need to setup a source counter, a monitor thread and so on
 

--- a/src/metric/x86_energy/metrics.cpp
+++ b/src/metric/x86_energy/metrics.cpp
@@ -73,7 +73,7 @@ Metrics::Metrics(trace::Trace& trace, std::chrono::nanoseconds sampling_interval
         auto mc = trace.metric_class();
         mc.add_member(trace.metric_member(metric_name, metric_name,
                                           otf2::common::metric_mode::accumulated_start,
-                                          otf2::common::type::double, "J"));
+                                          otf2::common::type::Double, "J"));
 
         // if we get here, we need to setup a source counter, a monitor thread and so on
 

--- a/src/metric/x86_energy/metrics.cpp
+++ b/src/metric/x86_energy/metrics.cpp
@@ -1,0 +1,152 @@
+#include <lo2s/metric/x86_energy/metrics.hpp>
+
+#include <lo2s/log.hpp>
+#include <lo2s/topology.hpp>
+#include <lo2s/trace/trace.hpp>
+
+#include <sstream>
+#include <string>
+
+namespace xe = x86_energy;
+
+namespace lo2s
+{
+namespace metric
+{
+namespace x86_energy
+{
+
+Metrics::Metrics(trace::Trace& trace, std::chrono::nanoseconds sampling_interval)
+{
+    xe::Mechanism mechanism;
+
+    Log::debug() << "Using x86_energy mechanism: " << mechanism.name();
+
+    std::unique_ptr<xe::AccessSource> active_source;
+
+    auto sources = mechanism.available_sources();
+
+    for (auto& source : sources)
+    {
+        try
+        {
+            source.init();
+
+            active_source = std::make_unique<xe::AccessSource>(std::move(source));
+            break;
+        }
+        catch (std::exception& e)
+        {
+            Log::info() << "Failed to initialize access source: " << source.name()
+                        << " error was: " << e.what();
+        }
+    }
+
+    if (!active_source)
+    {
+        Log::error()
+            << "Failed to initialize any available source. x86_energy values won't be available.";
+        throw std::runtime_error("Failed to initialize x86_energy access source.");
+    }
+
+    // if we get here, we have at least one access source to collect metric data from
+    Log::info() << "Using x86_energy access source: " << active_source->name();
+
+    // okay, we have
+    for (int i = 0; i < static_cast<int>(xe::Counter::SIZE); i++)
+    {
+        auto counter = static_cast<xe::Counter>(i);
+        auto granularity = mechanism.granularity(counter);
+
+        if (granularity == xe::Granularity::SIZE)
+        {
+            Log::debug() << "Counter is not available: " << counter << " (Skipping)";
+
+            continue;
+        }
+
+        std::stringstream str;
+        str << mechanism.name() << " " << counter;
+
+        std::string metric_name = str.str();
+
+        auto mc = trace.metric_class();
+        mc.add_member(trace.metric_member(metric_name, metric_name,
+                                          otf2::common::metric_mode::accumulated_start,
+                                          otf2::common::type::int64, "J"));
+
+        // if we get here, we need to setup a source counter, a monitor thread and so on
+
+        for (auto index = 0; index < architecture_.size(granularity); index++)
+        {
+            int cpuid = -1;
+            int packageid = -1;
+            int coreid = -1;
+
+            for (const auto& cpu : lo2s::Topology::instance().cpus())
+            {
+                auto node = architecture_.get_arch_for_cpu(granularity, cpu.id);
+                if (node.id() == index)
+                {
+                    cpuid = cpu.id;
+                    packageid = cpu.package_id;
+                    coreid = cpu.core_id;
+                    break;
+                }
+            }
+
+            if (cpuid == -1)
+            {
+                Log::warn() << "Cannot determine a cpu to pin the measurement thread for the "
+                            << counter << " counter " << index << " Using cpu 0 instead.";
+                cpuid = 0;
+            }
+
+            otf2::definition::system_tree_node stn;
+
+            switch (granularity)
+            {
+            case xe::Granularity::SYSTEM:
+                stn = trace.system_tree_root_node();
+                break;
+            case xe::Granularity::SOCKET:
+            case xe::Granularity::DIE:
+            case xe::Granularity::MODULE:
+                stn = trace.system_tree_package_node(packageid);
+                break;
+            case xe::Granularity::CORE:
+                stn = trace.system_tree_core_node(coreid, packageid);
+                break;
+            case xe::Granularity::THREAD:
+                stn = trace.system_tree_cpu_node(cpuid);
+                break;
+            default:
+                Log::warn() << "Cannot determine a suitable system tree node for the " << counter
+                            << " counter. (Falling back to root node)";
+                stn = trace.system_tree_root_node();
+            }
+
+            recorders_.emplace_back(std::make_unique<Monitor>(
+                active_source->get(counter, index), cpuid, sampling_interval, trace, mc, stn));
+        }
+    }
+}
+
+void Metrics::start()
+{
+    for (auto& recorder : recorders_)
+    {
+        recorder->start();
+    }
+}
+
+void Metrics::stop()
+{
+    for (auto& recorder : recorders_)
+    {
+        recorder->stop();
+    }
+}
+} // namespace x86_energy
+} // namespace metric
+} // namespace lo2s

--- a/src/metric/x86_energy/monitor.cpp
+++ b/src/metric/x86_energy/monitor.cpp
@@ -1,0 +1,43 @@
+#include <lo2s/metric/x86_energy/monitor.hpp>
+
+#include <lo2s/log.hpp>
+#include <lo2s/time/time.hpp>
+#include <lo2s/trace/trace.hpp>
+
+#include <string>
+
+namespace lo2s
+{
+namespace metric
+{
+namespace x86_energy
+{
+
+Monitor::Monitor(::x86_energy::SourceCounter counter, int cpu,
+                 std::chrono::nanoseconds sampling_interval, trace::Trace& trace,
+                 const otf2::definition::metric_class& metric_class,
+                 const otf2::definition::system_tree_node& stn)
+: IntervalMonitor(trace, std::to_string(cpu), sampling_interval), counter_(std::move(counter)),
+  cpu_(cpu), otf2_writer_(trace.metric_writer(name())),
+  metric_instance_(trace.metric_instance(metric_class, otf2_writer_.location(), stn))
+// (WOW this is (almost) better than LISP)
+{
+    metric_value_.metric = metric_instance_.metric_class()[0];
+}
+
+void Monitor::initialize_thread()
+{
+    try_pin_to_cpu(cpu_);
+}
+
+void Monitor::monitor()
+{
+    auto read_time = time::now();
+    metric_value_.set(counter_.read());
+
+    // TODO optimize! (avoid copy, avoid shared pointers...)
+    otf2_writer_.write(otf2::event::metric(read_time, metric_instance_, { metric_value_ }));
+}
+} // namespace x86_energy
+} // namespace metric
+} // namespace lo2s

--- a/src/monitor/main_monitor.cpp
+++ b/src/monitor/main_monitor.cpp
@@ -71,16 +71,20 @@ MainMonitor::MainMonitor() : trace_(), metrics_(trace_), metric_class_(generate_
         }
     }
 #endif
+
 #ifdef HAVE_X86_ENERGY
-    try
+    if (config().use_x86_energy)
     {
-        x86_energy_metrics_ =
-            std::make_unique<metric::x86_energy::Metrics>(trace_, config().read_interval);
-        x86_energy_metrics_->start();
-    }
-    catch (std::exception& e)
-    {
-        Log::warn() << "Failed to initialize x86_energy metrics: " << e.what();
+        try
+        {
+            x86_energy_metrics_ =
+                std::make_unique<metric::x86_energy::Metrics>(trace_, config().read_interval);
+            x86_energy_metrics_->start();
+        }
+        catch (std::exception& e)
+        {
+            Log::warn() << "Failed to initialize x86_energy metrics: " << e.what();
+        }
     }
 #endif
 }


### PR DESCRIPTION
This adds a new type of monitor, which is used to read x86_energy counters. It utilizes the system tree provided by lo2s to spawn threads and write metric events at the corresponding cpus.