### PR TITLE
Cpu id metric rework

### DIFF
--- a/include/lo2s/perf/counter/abstract_writer.hpp
+++ b/include/lo2s/perf/counter/abstract_writer.hpp
@@ -41,8 +41,6 @@ public:
     bool handle(const RecordSampleType* sample);
 
 protected:
-    virtual void handle_custom_events(std::size_t position) = 0;
-
     time::Converter time_converter_;
     otf2::writer::local& writer_;
     otf2::definition::metric_instance metric_instance_;

--- a/include/lo2s/perf/counter/cpu_writer.hpp
+++ b/include/lo2s/perf/counter/cpu_writer.hpp
@@ -38,11 +38,6 @@ public:
                      false)
     {
     }
-
-private:
-    void handle_custom_events(std::size_t /*position*/)
-    {
-    }
 };
 } // namespace counter
 } // namespace perf

--- a/include/lo2s/perf/counter/process_writer.hpp
+++ b/include/lo2s/perf/counter/process_writer.hpp
@@ -33,10 +33,6 @@ class ProcessWriter : public AbstractWriter
 public:
     ProcessWriter(pid_t pid, pid_t tid, otf2::writer::local& writer, monitor::MainMonitor& parent,
                   bool enable_on_exec);
-
-private:
-    void handle_custom_events(std::size_t position);
-    boost::filesystem::ifstream proc_stat_;
 };
 } // namespace counter
 } // namespace perf

--- a/include/lo2s/perf/sample/reader.hpp
+++ b/include/lo2s/perf/sample/reader.hpp
@@ -34,7 +34,8 @@
 #include <cstdlib>
 #include <cstring>
 
-extern "C" {
+extern "C"
+{
 #include <fcntl.h>
 #include <unistd.h>
 
@@ -61,6 +62,7 @@ public:
         uint64_t ip;
         uint32_t pid, tid;
         uint64_t time;
+        uint32_t cpu, res;
         /* only relevant for has_cct_ / PERF_SAMPLE_CALLCHAIN */
         uint64_t nr;
         uint64_t ips[1]; // ISO C++ forbits zero-size array
@@ -90,7 +92,8 @@ protected:
         }
 
         // TODO see if we can remove remove tid
-        perf_attr.sample_type = PERF_SAMPLE_IP | PERF_SAMPLE_TID | PERF_SAMPLE_TIME;
+        perf_attr.sample_type =
+            PERF_SAMPLE_IP | PERF_SAMPLE_TID | PERF_SAMPLE_TIME | PERF_SAMPLE_CPU;
         if (has_cct_)
         {
             perf_attr.sample_type |= PERF_SAMPLE_CALLCHAIN;
@@ -196,6 +199,6 @@ protected:
 private:
     int fd_ = -1;
 };
-}
-}
-}
+} // namespace sample
+} // namespace perf
+} // namespace lo2s

--- a/include/lo2s/perf/sample/writer.hpp
+++ b/include/lo2s/perf/sample/writer.hpp
@@ -33,7 +33,8 @@
 
 #include <cstdint>
 
-extern "C" {
+extern "C"
+{
 #include <sys/types.h>
 }
 
@@ -53,8 +54,8 @@ namespace sample
 class Writer : public Reader<Writer>
 {
 public:
-    Writer(pid_t pid, pid_t tid, int cpu, monitor::ThreadMonitor& monitor,
-           trace::Trace& trace, otf2::writer::local& otf2_writer, bool enable_on_exec);
+    Writer(pid_t pid, pid_t tid, int cpu, monitor::ThreadMonitor& monitor, trace::Trace& trace,
+           otf2::writer::local& otf2_writer, bool enable_on_exec);
     ~Writer();
 
 public:
@@ -85,6 +86,8 @@ private:
     trace::Trace& trace_;
     otf2::writer::local& otf2_writer_;
 
+    otf2::event::metric cpuid_metric_event_;
+
     trace::IpRefMap local_ip_refs_;
     std::uint64_t ip_ref_counter_ = 0;
     const time::Converter time_converter_;
@@ -93,6 +96,6 @@ private:
     otf2::chrono::time_point first_time_point_;
     otf2::chrono::time_point last_time_point_ = otf2::chrono::genesis();
 };
-}
-}
-}
+} // namespace sample
+} // namespace perf
+} // namespace lo2s

--- a/include/lo2s/perf/sample/writer.hpp
+++ b/include/lo2s/perf/sample/writer.hpp
@@ -86,6 +86,7 @@ private:
     trace::Trace& trace_;
     otf2::writer::local& otf2_writer_;
 
+    otf2::definition::metric_instance cpuid_metric_instance_;
     otf2::event::metric cpuid_metric_event_;
 
     trace::IpRefMap local_ip_refs_;

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -115,6 +115,8 @@ public:
                                                       otf2::definition::location recorder,
                                                       otf2::definition::system_tree_node scope);
 
+    otf2::definition::metric_class cpuid_metric_class();
+
     otf2::definition::mapping_table merge_ips(IpRefMap& new_ips, uint64_t ip_count,
                                               const MemoryMap& maps);
 
@@ -286,6 +288,7 @@ private:
         calling_context_properties_;
     otf2::definition::container<otf2::definition::metric_member> metric_members_;
     otf2::definition::container<otf2::definition::metric_class> metric_classes_;
+    otf2::definition::detail::weak_ref<otf2::definition::metric_class> cpuid_metric_class_;
     otf2::definition::container<otf2::definition::metric_instance> metric_instances_;
     otf2::definition::container<otf2::definition::system_tree_node_property>
         system_tree_node_properties_;

--- a/src/monitor/process_monitor.cpp
+++ b/src/monitor/process_monitor.cpp
@@ -30,9 +30,6 @@ namespace monitor
 
 ProcessMonitor::ProcessMonitor() : MainMonitor()
 {
-    metric_class_.add_member(trace_.metric_member("CPU", "CPU executing the task",
-                                                  otf2::common::metric_mode::absolute_last,
-                                                  otf2::common::type::int64, "cpuid"));
     trace_.register_monitoring_tid(gettid(), "ProcessMonitor", "ProcessMonitor");
 }
 

--- a/src/perf/counter/abstract_writer.cpp
+++ b/src/perf/counter/abstract_writer.cpp
@@ -62,8 +62,6 @@ bool AbstractWriter::handle(const Reader::RecordSampleType* sample)
     values_[index++].set(counters_.enabled());
     values_[index++].set(counters_.running());
 
-    handle_custom_events(index);
-
     // TODO optimize! (avoid copy, avoid shared pointers...)
     writer_.write(otf2::event::metric(tp, metric_instance_, values_));
     return false;

--- a/src/perf/counter/process_writer.cpp
+++ b/src/perf/counter/process_writer.cpp
@@ -31,16 +31,10 @@ ProcessWriter::ProcessWriter(pid_t pid, pid_t tid, otf2::writer::local& writer,
 : AbstractWriter(tid, -1, writer,
                  parent.trace().metric_instance(parent.get_metric_class(), writer.location(),
                                                 parent.trace().sample_writer(pid, tid).location()),
-                 enable_on_exec),
-  proc_stat_(boost::filesystem::path("/proc") / std::to_string(pid) / "task" / std::to_string(tid) /
-             "stat")
+                 enable_on_exec)
 {
 }
 
-void ProcessWriter::handle_custom_events(std::size_t position)
-{
-    values_[position].set(get_task_last_cpu_id(proc_stat_));
-}
 } // namespace counter
 } // namespace perf
 } // namespace lo2s

--- a/src/perf/sample/writer.cpp
+++ b/src/perf/sample/writer.cpp
@@ -164,6 +164,7 @@ bool Writer::handle(const Reader::RecordSampleType* sample)
     otf2_writer_.write_calling_context_sample(tp, cctx_ref(sample), 2,
                                               trace_.interrupt_generator().ref());
 
+    // TODO optimize metric event writing
     cpuid_metric_event_.timestamp(tp);
     cpuid_metric_event_.values()[0].value.signed_int = sample->cpu;
     otf2_writer_ << cpuid_metric_event_;

--- a/src/perf/sample/writer.cpp
+++ b/src/perf/sample/writer.cpp
@@ -39,7 +39,8 @@
 #include <cassert>
 #include <cstring>
 
-extern "C" {
+extern "C"
+{
 #include <linux/perf_event.h>
 }
 
@@ -53,9 +54,13 @@ namespace sample
 Writer::Writer(pid_t pid, pid_t tid, int cpu, monitor::ThreadMonitor& Monitor, trace::Trace& trace,
                otf2::writer::local& otf2_writer, bool enable_on_exec)
 : Reader(config().enable_cct), pid_(pid), tid_(tid), monitor_(Monitor), trace_(trace),
-  otf2_writer_(otf2_writer), time_converter_(perf::time::Converter::instance()),
-  first_time_point_(lo2s::time::now())
+  otf2_writer_(otf2_writer),
+  cpuid_metric_event_(otf2::chrono::genesis(), trace.cpuid_metric_class(),
+                      { otf2::event::metric::value_container() }),
+  time_converter_(perf::time::Converter::instance()), first_time_point_(lo2s::time::now())
 {
+    cpuid_metric_event_.values()[0].metric = trace.cpuid_metric_class()[0];
+
     CounterDescription sampling_event =
         EventProvider::get_event_by_name(config().sampling_event); // config parser has already
                                                                    // checked for event
@@ -158,6 +163,11 @@ bool Writer::handle(const Reader::RecordSampleType* sample)
 
     otf2_writer_.write_calling_context_sample(tp, cctx_ref(sample), 2,
                                               trace_.interrupt_generator().ref());
+
+    cpuid_metric_event_.timestamp(tp);
+    cpuid_metric_event_.values()[0].value.signed_int = sample->cpu;
+    otf2_writer_ << cpuid_metric_event_;
+
     last_time_point_ = tp;
     return false;
 }
@@ -184,6 +194,6 @@ void Writer::end()
     last_time_point_ = std::max(last_time_point_, lo2s::time::now());
     otf2_writer_ << otf2::event::thread_end(last_time_point_, trace_.process_comm(pid_), -1);
 }
-}
-}
-}
+} // namespace sample
+} // namespace perf
+} // namespace lo2s

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -449,7 +449,9 @@ otf2::definition::metric_class Trace::cpuid_metric_class()
 {
     if (!cpuid_metric_class_)
     {
-        cpuid_metric_class_ = metric_class();
+        cpuid_metric_class_ =
+            metric_classes_.emplace(metric_class_ref(), otf2::common::metric_occurence::sync,
+                                    otf2::common::recorder_kind::abstract);
 
         cpuid_metric_class_->add_member(metric_member("CPU", "CPU executing the task",
                                                       otf2::common::metric_mode::absolute_point,

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -449,9 +449,7 @@ otf2::definition::metric_class Trace::cpuid_metric_class()
 {
     if (!cpuid_metric_class_)
     {
-        cpuid_metric_class_ =
-            metric_classes_.emplace(metric_class_ref(), otf2::common::metric_occurence::sync,
-                                    otf2::common::recorder_kind::abstract);
+        cpuid_metric_class_ = metric_class();
 
         cpuid_metric_class_->add_member(metric_member("CPU", "CPU executing the task",
                                                       otf2::common::metric_mode::absolute_point,

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -357,7 +357,6 @@ void Trace::add_cpu(int cpuid)
         std::forward_as_tuple(location_group_ref(), name,
                               otf2::definition::location_group::location_group_type::unknown,
                               system_tree_cpu_nodes_.at(cpuid)));
-
 }
 otf2::writer::local& Trace::sample_writer(pid_t pid, pid_t tid)
 {
@@ -444,6 +443,20 @@ Trace::metric_instance(otf2::definition::metric_class metric_class,
                        otf2::definition::system_tree_node scope)
 {
     return metric_instances_.emplace(metric_instance_ref(), metric_class, recorder, scope);
+}
+
+otf2::definition::metric_class Trace::cpuid_metric_class()
+{
+    if (!cpuid_metric_class_)
+    {
+        cpuid_metric_class_ = metric_class();
+
+        cpuid_metric_class_->add_member(metric_member("CPU", "CPU executing the task",
+                                                      otf2::common::metric_mode::absolute_last,
+                                                      otf2::common::type::int64, "cpuid"));
+    }
+
+    return cpuid_metric_class_;
 }
 
 otf2::definition::metric_class Trace::metric_class()

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -452,7 +452,7 @@ otf2::definition::metric_class Trace::cpuid_metric_class()
         cpuid_metric_class_ = metric_class();
 
         cpuid_metric_class_->add_member(metric_member("CPU", "CPU executing the task",
-                                                      otf2::common::metric_mode::absolute_last,
+                                                      otf2::common::metric_mode::absolute_point,
                                                       otf2::common::type::int64, "cpuid"));
     }
 


### PR DESCRIPTION
The old mechanism for the cpu id metric was borked. Instead of parsing some file in proc, we actually ask perf for the correct cpu for every sample. This has the nice site effect that we can remove a virtual call.

