### PR TITLE
Removed get_metric_class from MainMonitor

### DIFF
--- a/include/lo2s/monitor/main_monitor.hpp
+++ b/include/lo2s/monitor/main_monitor.hpp
@@ -28,7 +28,6 @@
 #ifdef HAVE_X86_ENERGY
 #include <lo2s/metric/x86_energy/metrics.hpp>
 #endif
-#include <lo2s/perf/time/converter.hpp>
 #include <lo2s/trace/trace.hpp>
 
 namespace lo2s
@@ -55,19 +54,12 @@ public:
     {
         return trace_;
     }
-    otf2::definition::metric_class get_metric_class()
-    {
-        return metric_class_;
-    }
 
 protected:
-    otf2::definition::metric_class generate_metric_class();
-
     trace::Trace trace_;
 
     metric::plugin::Metrics metrics_;
     std::unique_ptr<perf::tracepoint::MetricMonitor> tracepoint_metrics_;
-    otf2::definition::metric_class metric_class_;
 #ifdef HAVE_X86_ADAPT
     std::unique_ptr<metric::x86_adapt::Metrics> x86_adapt_metrics_;
 #endif

--- a/include/lo2s/perf/counter/cpu_writer.hpp
+++ b/include/lo2s/perf/counter/cpu_writer.hpp
@@ -33,7 +33,8 @@ class CpuWriter : public AbstractWriter
 public:
     CpuWriter(int cpuid, otf2::writer::local& writer, monitor::MainMonitor& parent)
     : AbstractWriter(-1, cpuid, writer,
-                     parent.trace().metric_instance(parent.get_metric_class(), writer.location(),
+                     parent.trace().metric_instance(parent.trace().perf_metric_class(),
+                                                    writer.location(),
                                                     parent.trace().cpu_writer(cpuid).location()),
                      false)
     {

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -116,6 +116,7 @@ public:
                                                       otf2::definition::system_tree_node scope);
 
     otf2::definition::metric_class cpuid_metric_class();
+    otf2::definition::metric_class perf_metric_class();
 
     otf2::definition::mapping_table merge_ips(IpRefMap& new_ips, uint64_t ip_count,
                                               const MemoryMap& maps);
@@ -289,6 +290,7 @@ private:
     otf2::definition::container<otf2::definition::metric_member> metric_members_;
     otf2::definition::container<otf2::definition::metric_class> metric_classes_;
     otf2::definition::detail::weak_ref<otf2::definition::metric_class> cpuid_metric_class_;
+    otf2::definition::detail::weak_ref<otf2::definition::metric_class> perf_metric_class_;
     otf2::definition::container<otf2::definition::metric_instance> metric_instances_;
     otf2::definition::container<otf2::definition::system_tree_node_property>
         system_tree_node_properties_;

--- a/src/monitor/main_monitor.cpp
+++ b/src/monitor/main_monitor.cpp
@@ -23,7 +23,7 @@
 
 #include <lo2s/config.hpp>
 #include <lo2s/log.hpp>
-#include <lo2s/perf/event_collection.hpp>
+#include <lo2s/perf/time/converter.hpp>
 #include <lo2s/trace/trace.hpp>
 
 #include <lo2s/perf/tracepoint/metric_monitor.hpp>
@@ -32,7 +32,7 @@ namespace lo2s
 {
 namespace monitor
 {
-MainMonitor::MainMonitor() : trace_(), metrics_(trace_), metric_class_(generate_metric_class())
+MainMonitor::MainMonitor() : trace_(), metrics_(trace_)
 {
     perf::time::Converter::instance();
 
@@ -87,36 +87,6 @@ MainMonitor::MainMonitor() : trace_(), metrics_(trace_), metric_class_(generate_
         }
     }
 #endif
-}
-
-otf2::definition::metric_class MainMonitor::generate_metric_class()
-{
-    auto c = trace_.metric_class();
-
-    const perf::EventCollection& event_collection = perf::requested_events();
-
-    if (!event_collection.events.empty())
-    {
-        c.add_member(trace_.metric_member(
-            event_collection.leader.name, event_collection.leader.name,
-            otf2::common::metric_mode::accumulated_start, otf2::common::type::Double, "#"));
-
-        for (const auto& ev : event_collection.events)
-        {
-            c.add_member(trace_.metric_member(ev.name, ev.name,
-                                              otf2::common::metric_mode::accumulated_start,
-                                              otf2::common::type::Double, "#"));
-        }
-
-        c.add_member(trace_.metric_member("time_enabled", "time event active",
-                                          otf2::common::metric_mode::accumulated_start,
-                                          otf2::common::type::uint64, "ns"));
-        c.add_member(trace_.metric_member("time_running", "time event on CPU",
-                                          otf2::common::metric_mode::accumulated_start,
-                                          otf2::common::type::uint64, "ns"));
-    }
-
-    return c;
 }
 
 MainMonitor::~MainMonitor()

--- a/src/perf/counter/process_writer.cpp
+++ b/src/perf/counter/process_writer.cpp
@@ -29,7 +29,8 @@ namespace counter
 ProcessWriter::ProcessWriter(pid_t pid, pid_t tid, otf2::writer::local& writer,
                              monitor::MainMonitor& parent, bool enable_on_exec)
 : AbstractWriter(tid, -1, writer,
-                 parent.trace().metric_instance(parent.get_metric_class(), writer.location(),
+                 parent.trace().metric_instance(parent.trace().perf_metric_class(),
+                                                writer.location(),
                                                 parent.trace().sample_writer(pid, tid).location()),
                  enable_on_exec)
 {


### PR DESCRIPTION
Instead, it is basically in the Trace now.

The not so nice thing right now is, that the Trace needs to know about perf or the EventCollection, but that is better than the MainMonitor is coupled with output logic. Maybe I find a different location to initialize the perf_metric_class(), but I doubt that.