### PR TITLE
Use improved otf2xx metric event handling

### DIFF
--- a/include/lo2s/metric/x86_adapt/monitor.hpp
+++ b/include/lo2s/metric/x86_adapt/monitor.hpp
@@ -20,7 +20,8 @@
 #include <chrono>
 #include <thread>
 
-extern "C" {
+extern "C"
+{
 #include <sched.h>
 }
 
@@ -49,13 +50,13 @@ protected:
 private:
     ::x86_adapt::device device_;
 
-    otf2::writer::local otf2_writer_;
+    otf2::writer::local& otf2_writer_;
 
     std::vector<::x86_adapt::configuration_item> configuration_items_;
 
     otf2::definition::metric_instance metric_instance_;
-    std::vector<otf2::event::metric::value_container> metric_values_;
+    otf2::event::metric event_;
 };
-}
-}
-}
+} // namespace x86_adapt
+} // namespace metric
+} // namespace lo2s

--- a/include/lo2s/metric/x86_adapt/node_monitor.hpp
+++ b/include/lo2s/metric/x86_adapt/node_monitor.hpp
@@ -50,12 +50,12 @@ protected:
 private:
     ::x86_adapt::device device_;
 
-    otf2::writer::local otf2_writer_;
+    otf2::writer::local& otf2_writer_;
 
     std::vector<::x86_adapt::configuration_item> configuration_items_;
 
     otf2::definition::metric_instance metric_instance_;
-    std::vector<otf2::event::metric::value_container> metric_values_;
+    otf2::event::metric event_;
 };
 } // namespace x86_adapt
 } // namespace metric

--- a/include/lo2s/metric/x86_energy/monitor.hpp
+++ b/include/lo2s/metric/x86_energy/monitor.hpp
@@ -47,7 +47,7 @@ private:
     otf2::writer::local otf2_writer_;
 
     otf2::definition::metric_instance metric_instance_;
-    otf2::event::metric::value_container metric_value_;
+    otf2::event::metric metric_event_;
 };
 } // namespace x86_energy
 } // namespace metric

--- a/include/lo2s/metric/x86_energy/monitor.hpp
+++ b/include/lo2s/metric/x86_energy/monitor.hpp
@@ -44,7 +44,7 @@ private:
 
     int cpu_;
 
-    otf2::writer::local otf2_writer_;
+    otf2::writer::local& otf2_writer_;
 
     otf2::definition::metric_instance metric_instance_;
     otf2::event::metric metric_event_;

--- a/include/lo2s/perf/counter/abstract_writer.hpp
+++ b/include/lo2s/perf/counter/abstract_writer.hpp
@@ -45,7 +45,7 @@ protected:
     otf2::writer::local& writer_;
     otf2::definition::metric_instance metric_instance_;
     // XXX this should depend here!
-    std::vector<otf2::event::metric::value_container> values_;
+    otf2::event::metric metric_event_;
 };
 } // namespace counter
 } // namespace perf

--- a/include/lo2s/perf/tracepoint/writer.hpp
+++ b/include/lo2s/perf/tracepoint/writer.hpp
@@ -63,7 +63,7 @@ private:
 
     const time::Converter time_converter_;
 
-    std::vector<otf2::event::metric::value_container> counter_values_;
+    otf2::event::metric metric_event_;
 };
 }
 }

--- a/src/metric/plugin/channel.cpp
+++ b/src/metric/plugin/channel.cpp
@@ -57,7 +57,7 @@ Channel::Channel(const char* name, const char* description, const char* unit, wr
                                                  writer_.location().location_group().parent()),
                            trace.metric_member(name_, description_, wrapper::convert_mode(mode_),
                                                wrapper::convert_type(value_type_), unit_))),
-  event_(otf2::chrono::genesis(), metric_.metric_class())
+  event_(otf2::chrono::genesis(), metric_)
 {
 }
 

--- a/src/metric/x86_adapt/monitor.cpp
+++ b/src/metric/x86_adapt/monitor.cpp
@@ -20,16 +20,10 @@ Monitor::Monitor(::x86_adapt::device device, std::chrono::nanoseconds sampling_i
   device_(std::move(device)), otf2_writer_(trace.metric_writer(name())),
   configuration_items_(configuration_items),
   metric_instance_(trace.metric_instance(metric_class, otf2_writer_.location(),
-                                         trace.system_tree_cpu_node(device_.id())))
-// (WOW this is (almost) better than LISP)
+                                         trace.system_tree_cpu_node(device_.id()))),
+  event_(otf2::chrono::genesis(), metric_instance_)
 {
     assert(device_.type() == X86_ADAPT_CPU);
-
-    metric_values_.resize(configuration_items.size());
-    for (std::size_t i = 0; i < configuration_items_.size(); i++)
-    {
-        metric_values_[i].metric = metric_instance_.metric_class()[i];
-    }
 }
 
 void Monitor::initialize_thread()
@@ -39,15 +33,21 @@ void Monitor::initialize_thread()
 
 void Monitor::monitor()
 {
-    auto read_time = time::now();
+    // update timestamp
+    event_.timestamp(time::now());
+
+    // update event values from configuration items
     for (const auto& index_ci : nitro::lang::enumerate(configuration_items_))
     {
-        metric_values_[index_ci.index()].set(device_(index_ci.value()));
+        auto i = index_ci.index();
+        auto configuration_item = index_ci.value();
+
+        event_.raw_values()[i] = device_(configuration_item);
     }
 
-    // TODO optimize! (avoid copy, avoid shared pointers...)
-    otf2_writer_.write(otf2::event::metric(read_time, metric_instance_, metric_values_));
+    // write event to archive
+    otf2_writer_.write(event_);
 }
-}
-}
-}
+} // namespace x86_adapt
+} // namespace metric
+} // namespace lo2s

--- a/src/metric/x86_energy/monitor.cpp
+++ b/src/metric/x86_energy/monitor.cpp
@@ -20,7 +20,7 @@ Monitor::Monitor(::x86_energy::SourceCounter counter, int cpu,
 : IntervalMonitor(trace, std::to_string(cpu), sampling_interval), counter_(std::move(counter)),
   cpu_(cpu), otf2_writer_(trace.metric_writer(name())),
   metric_instance_(trace.metric_instance(metric_class, otf2_writer_.location(), stn)),
-  metric_event_(otf2::chrono::genesis(), metric_instance)
+  metric_event_(otf2::chrono::genesis(), metric_instance_)
 // (WOW this is (almost) better than LISP)
 {
 }
@@ -33,7 +33,7 @@ void Monitor::initialize_thread()
 void Monitor::monitor()
 {
     metric_event_.timestamp(time::now());
-    metric_event_.raw_values()[0] = counter_.read()
+    metric_event_.raw_values()[0] = counter_.read();
 
     otf2_writer_.write(metric_event_);
 }

--- a/src/metric/x86_energy/monitor.cpp
+++ b/src/metric/x86_energy/monitor.cpp
@@ -19,10 +19,10 @@ Monitor::Monitor(::x86_energy::SourceCounter counter, int cpu,
                  const otf2::definition::system_tree_node& stn)
 : IntervalMonitor(trace, std::to_string(cpu), sampling_interval), counter_(std::move(counter)),
   cpu_(cpu), otf2_writer_(trace.metric_writer(name())),
-  metric_instance_(trace.metric_instance(metric_class, otf2_writer_.location(), stn))
+  metric_instance_(trace.metric_instance(metric_class, otf2_writer_.location(), stn)),
+  metric_event_(otf2::chrono::genesis(), metric_instance)
 // (WOW this is (almost) better than LISP)
 {
-    metric_value_.metric = metric_instance_.metric_class()[0];
 }
 
 void Monitor::initialize_thread()
@@ -32,11 +32,10 @@ void Monitor::initialize_thread()
 
 void Monitor::monitor()
 {
-    auto read_time = time::now();
-    metric_value_.set(counter_.read());
+    metric_event_.timestamp(time::now());
+    metric_event_.raw_values()[0] = counter_.read()
 
-    // TODO optimize! (avoid copy, avoid shared pointers...)
-    otf2_writer_.write(otf2::event::metric(read_time, metric_instance_, { metric_value_ }));
+    otf2_writer_.write(metric_event_);
 }
 } // namespace x86_energy
 } // namespace metric

--- a/src/perf/counter/process_writer.cpp
+++ b/src/perf/counter/process_writer.cpp
@@ -35,7 +35,6 @@ ProcessWriter::ProcessWriter(pid_t pid, pid_t tid, otf2::writer::local& writer,
                  enable_on_exec)
 {
 }
-
 } // namespace counter
 } // namespace perf
 } // namespace lo2s

--- a/src/perf/sample/writer.cpp
+++ b/src/perf/sample/writer.cpp
@@ -57,11 +57,9 @@ Writer::Writer(pid_t pid, pid_t tid, int cpu, monitor::ThreadMonitor& Monitor, t
   otf2_writer_(otf2_writer),
   cpuid_metric_instance_(trace.metric_instance(trace.cpuid_metric_class(), otf2_writer.location(),
                                                otf2_writer.location())),
-  cpuid_metric_event_(otf2::chrono::genesis(), cpuid_metric_instance_,
-                      { otf2::event::metric::value_container() }),
+  cpuid_metric_event_(otf2::chrono::genesis(), cpuid_metric_instance_),
   time_converter_(perf::time::Converter::instance()), first_time_point_(lo2s::time::now())
 {
-    cpuid_metric_event_.values()[0].metric = trace.cpuid_metric_class()[0];
 
     CounterDescription sampling_event =
         EventProvider::get_event_by_name(config().sampling_event); // config parser has already
@@ -163,9 +161,8 @@ bool Writer::handle(const Reader::RecordSampleType* sample)
         first_event_ = false;
     }
 
-    // TODO optimize metric event writing
     cpuid_metric_event_.timestamp(tp);
-    cpuid_metric_event_.values()[0].value.signed_int = sample->cpu;
+    cpuid_metric_event_.raw_values()[0] = sample->cpu;
     otf2_writer_ << cpuid_metric_event_;
 
     otf2_writer_.write_calling_context_sample(tp, cctx_ref(sample), 2,

--- a/src/perf/tracepoint/writer.cpp
+++ b/src/perf/tracepoint/writer.cpp
@@ -21,7 +21,7 @@ Writer::Writer(int cpu, const EventFormat& event, trace::Trace& trace_,
   metric_instance_(
       trace_.metric_instance(metric_class, writer_.location(), trace_.system_tree_cpu_node(cpu))),
   time_converter_(perf::time::Converter::instance()),
-  metric_event_(otf2::chrono::genesis(), metric_class)
+  metric_event_(otf2::chrono::genesis(), metric_instance_)
 {
 }
 

--- a/src/perf/tracepoint/writer.cpp
+++ b/src/perf/tracepoint/writer.cpp
@@ -27,20 +27,17 @@ Writer::Writer(int cpu, const EventFormat& event, trace::Trace& trace_,
 
 bool Writer::handle(const Reader::RecordSampleType* sample)
 {
-    auto tp = time_converter_(sample->time);
+    metric_event_.timestamp(time_converter_(sample->time));
 
-    metric_event_.timestamp(tp);
-    for (const auto& index_field : nitro::lang::enumerate(event_.fields()))
+    std::size_t index = 0;
+    for (const auto& field : event_.fields())
     {
-        auto i = index_field.index();
-        auto field = index_field.value();
-
         if (!field.is_integer())
         {
             continue;
         }
 
-        metric_event_.raw_values()[i] = sample->raw_data.get(field);
+        metric_event_.raw_values()[index++] = sample->raw_data.get(field);
     }
     writer_.write(metric_event_);
     return false;


### PR DESCRIPTION
This should improve performance for writing any metric to otf2 traces