### PR TITLE
Adds perf record switch support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ CHECK_STRUCT_HAS_BITFIELD("struct perf_event_attr" context_switch linux/perf_eve
 CMAKE_DEPENDENT_OPTION(USE_RADARE "Enable Radare support." ON "Radare_FOUND" OFF)
 option(HW_BREAKPOINT_COMPAT "Time synchronization fallback for old kernels without hardware breakpoint support." OFF)
 option(USE_PERF_CLOCKID "Enables specifying a custom reference clock for recorded events" ON)
-option(USE_PERF_RECORD_SWITCH "Uses PERF_RECORD_SWITCH for CPU Context Switches instead of the older tracepoint based solution" ${HAVE_PERF_RECORD_SWITCH})
+CMAKE_DEPENDENT_OPTION(USE_PERF_RECORD_SWITCH "Uses PERF_RECORD_SWITCH for CPU Context Switches instead of the older tracepoint based solution" ON HAVE_PERF_RECORD_SWITCH OFF)
 option(IWYU "Developer option for include what you use." OFF)
 option(UML_LOOK "Generate graphs with an UML look" OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,7 @@ option(UML_LOOK "Generate graphs with an UML look" OFF)
 # system configuration checks
 CHECK_INCLUDE_FILES(linux/hw_breakpoint.h HAVE_HW_BREAKPOINT_H)
 CHECK_STRUCT_HAS_MEMBER("struct perf_event_attr" clockid linux/perf_event.h HAVE_PERF_EVENT_ATTR_CLOCKID)
+CHECK_STRUCT_HAS_MEMBER("struct perf_event_attr" context_switch linux/perf_event.h HAVE_PERF_RECORD_SWITCH)
 check_function_exists(clock_gettime CLOCK_GETTIME_FOUND)
 if(NOT CLOCK_GETTIME_FOUND)
     set(CMAKE_REQUIRED_LIBRARIES "rt")
@@ -145,10 +146,9 @@ set(SOURCE_FILES
     src/perf/counter/abstract_writer.cpp
 
     src/perf/sample/writer.cpp
-    src/perf/context_switch/writer.cpp
     src/perf/time/converter.cpp src/perf/time/reader.cpp
     src/perf/tracepoint/format.cpp src/perf/tracepoint/metric_monitor.cpp
-    src/perf/tracepoint/writer.cpp src/perf/tracepoint/switch_writer.cpp
+    src/perf/tracepoint/writer.cpp
     src/perf/tracepoint/exit_reader.cpp
 
     src/time/time.cpp
@@ -270,6 +270,13 @@ else()
     if (HAVE_PERF_EVENT_ATTR_CLOCKID)
         message(WARNING "The system claims to support custom reference clocks for perf events. Consider activating USE_PERF_CLOCKID to enable the options -k,--clockid.")
     endif()
+endif()
+
+if(HAVE_PERF_RECORD_SWITCH)
+    target_compile_definitions(lo2s PRIVATE USE_PERF_RECORD_SWITCH)
+    target_sources(lo2s PRIVATE src/perf/context_switch/writer.cpp)
+else()
+    target_sources(lo2s PRIVATE src/perf/tracepoint/switch_writer.cpp)
 endif()
 
 message(STATUS "Linux kernel version: ${LINUX_VERSION}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -275,7 +275,7 @@ else()
     endif()
 endif()
 
-if( USE_PERF_RECORD_SWITCH)
+if(USE_PERF_RECORD_SWITCH)
     target_compile_definitions(lo2s PRIVATE USE_PERF_RECORD_SWITCH)
     target_sources(lo2s PRIVATE src/perf/context_switch/writer.cpp)
 else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ set(SOURCE_FILES
     src/perf/counter/abstract_writer.cpp
 
     src/perf/sample/writer.cpp
+    src/perf/context_switch/writer.cpp
     src/perf/time/converter.cpp src/perf/time/reader.cpp
     src/perf/tracepoint/format.cpp src/perf/tracepoint/metric_monitor.cpp
     src/perf/tracepoint/writer.cpp src/perf/tracepoint/switch_writer.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ SET(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH}")
 
 include(cmake/DefaultBuildType.cmake)
 include(cmake/UnsetIfUpdated.cmake)
+include(cmake/CheckStructHasBitField.cmake)
 
 # Intialize git submodules if not done already
 include(cmake/GitSubmoduleUpdate.cmake)
@@ -100,17 +101,19 @@ find_package(Threads REQUIRED)
 find_package(Doxygen COMPONENTS dot)
 find_package(x86_energy 2.0 CONFIG)
 
+CHECK_STRUCT_HAS_BITFIELD("struct perf_event_attr" context_switch linux/perf_event.h HAVE_PERF_RECORD_SWITCH)
+
 # configurable options
 CMAKE_DEPENDENT_OPTION(USE_RADARE "Enable Radare support." ON "Radare_FOUND" OFF)
 option(HW_BREAKPOINT_COMPAT "Time synchronization fallback for old kernels without hardware breakpoint support." OFF)
 option(USE_PERF_CLOCKID "Enables specifying a custom reference clock for recorded events" ON)
+option(USE_PERF_RECORD_SWITCH "Uses PERF_RECORD_SWITCH for CPU Context Switches instead of the older tracepoint based solution" ${HAVE_PERF_RECORD_SWITCH})
 option(IWYU "Developer option for include what you use." OFF)
 option(UML_LOOK "Generate graphs with an UML look" OFF)
 
 # system configuration checks
 CHECK_INCLUDE_FILES(linux/hw_breakpoint.h HAVE_HW_BREAKPOINT_H)
 CHECK_STRUCT_HAS_MEMBER("struct perf_event_attr" clockid linux/perf_event.h HAVE_PERF_EVENT_ATTR_CLOCKID)
-CHECK_STRUCT_HAS_MEMBER("struct perf_event_attr" context_switch linux/perf_event.h HAVE_PERF_RECORD_SWITCH)
 check_function_exists(clock_gettime CLOCK_GETTIME_FOUND)
 if(NOT CLOCK_GETTIME_FOUND)
     set(CMAKE_REQUIRED_LIBRARIES "rt")
@@ -272,7 +275,7 @@ else()
     endif()
 endif()
 
-if(HAVE_PERF_RECORD_SWITCH)
+if( USE_PERF_RECORD_SWITCH)
     target_compile_definitions(lo2s PRIVATE USE_PERF_RECORD_SWITCH)
     target_sources(lo2s PRIVATE src/perf/context_switch/writer.cpp)
 else()

--- a/cmake/CheckStructHasBitField.cmake
+++ b/cmake/CheckStructHasBitField.cmake
@@ -1,6 +1,6 @@
 include(CheckCSourceCompiles)
 
-macro(CHECK_STRUCT_HAS_BITFIELD _STRUCT _MEMBER _HEADER _RESULT)
+function(CHECK_STRUCT_HAS_BITFIELD _STRUCT _MEMBER _HEADER _RESULT)
     set(_INCLUDE_FILES)
     foreach(it ${_HEADER})
         string(APPEND _INCLUDE_FILES "#include <${it}>\n")
@@ -17,4 +17,4 @@ macro(CHECK_STRUCT_HAS_BITFIELD _STRUCT _MEMBER _HEADER _RESULT)
     ")
 
     CHECK_C_SOURCE_COMPILES("${_CHECK_STRUCT_MEMBER_SOURCE_CODE}" ${_RESULT})
-endmacro()
+endfunction()

--- a/cmake/CheckStructHasBitField.cmake
+++ b/cmake/CheckStructHasBitField.cmake
@@ -1,0 +1,20 @@
+include(CheckCSourceCompiles)
+
+macro(CHECK_STRUCT_HAS_BITFIELD _STRUCT _MEMBER _HEADER _RESULT)
+    set(_INCLUDE_FILES)
+    foreach(it ${_HEADER})
+        string(APPEND _INCLUDE_FILES "#include <${it}>\n")
+    endforeach()
+
+    set(_CHECK_STRUCT_MEMBER_SOURCE_CODE "
+    ${_INCLUDE_FILES}
+    int main()
+    {
+        ${_STRUCT} test;
+        test.${_MEMBER} = 0;
+        return 0;
+    }
+    ")
+
+    CHECK_C_SOURCE_COMPILES("${_CHECK_STRUCT_MEMBER_SOURCE_CODE}" ${_RESULT})
+endmacro()

--- a/include/lo2s/monitor/cpu_switch_monitor.hpp
+++ b/include/lo2s/monitor/cpu_switch_monitor.hpp
@@ -24,8 +24,11 @@
 #include <lo2s/monitor/fd_monitor.hpp>
 
 #include <lo2s/perf/tracepoint/exit_reader.hpp>
-//#include <lo2s/perf/tracepoint/switch_writer.hpp>
+#ifdef USE_PERF_RECORD_SWITCH
 #include <lo2s/perf/context_switch/writer.hpp>
+#else
+#include <lo2s/perf/tracepoint/switch_writer.hpp>
+#endif
 #include <lo2s/trace/fwd.hpp>
 
 namespace lo2s
@@ -50,8 +53,11 @@ public:
 private:
     int cpu_;
 
-    //perf::tracepoint::SwitchWriter switch_writer_;
+#ifdef USE_PERF_RECORD_SWITCH
     perf::context_switch::Writer switch_writer_;
+#else
+    perf::tracepoint::SwitchWriter switch_writer_;
+#endif
     perf::tracepoint::ExitReader exit_reader_;
 };
 } // namespace monitor

--- a/include/lo2s/monitor/cpu_switch_monitor.hpp
+++ b/include/lo2s/monitor/cpu_switch_monitor.hpp
@@ -24,7 +24,8 @@
 #include <lo2s/monitor/fd_monitor.hpp>
 
 #include <lo2s/perf/tracepoint/exit_reader.hpp>
-#include <lo2s/perf/tracepoint/switch_writer.hpp>
+//#include <lo2s/perf/tracepoint/switch_writer.hpp>
+#include <lo2s/perf/context_switch/writer.hpp>
 #include <lo2s/trace/fwd.hpp>
 
 namespace lo2s
@@ -49,7 +50,8 @@ public:
 private:
     int cpu_;
 
-    perf::tracepoint::SwitchWriter switch_writer_;
+    //perf::tracepoint::SwitchWriter switch_writer_;
+    perf::context_switch::Writer switch_writer_;
     perf::tracepoint::ExitReader exit_reader_;
 };
 } // namespace monitor

--- a/include/lo2s/perf/context_switch/reader.hpp
+++ b/include/lo2s/perf/context_switch/reader.hpp
@@ -1,28 +1,36 @@
 /*
-  * This file is part of the lo2s software.
-  * Linux OTF2 sampling
-  *
-  * Copyright (c) 2016,
-  *    Technische Universitaet Dresden, Germany
-  *
-  * lo2s is free software: you can redistribute it and/or modify
-  * it under the terms of the GNU General Public License as published by
-  * the Free Software Foundation, either version 3 of the License, or
-  * (at your option) any later version.
-  *
-  * lo2s is distributed in the hope that it will be useful,
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  * GNU General Public License for more details.
-  *
-  * You should have received a copy of the GNU General Public License
-  * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
-  */
- 
- #pragma once
- 
- #include <lo2s/perf/event_reader.hpp>
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2016,
+ *    Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>
+ */
 
+#pragma once
+
+#include <lo2s/config.hpp>
+#include <lo2s/log.hpp>
+#include <lo2s/perf/event_reader.hpp>
+#include <lo2s/perf/util.hpp>
+
+extern "C" {
+#include <fcntl.h>
+#include <linux/perf_event.h>
+#include <sys/ioctl.h>
+}
 namespace lo2s
 {
 namespace perf
@@ -32,16 +40,16 @@ namespace context_switch
 template <class T>
 class Reader : public EventReader<T>
 {
-protected:
+public:
     using EventReader<T>::init_mmap;
     Reader(int cpuid)
     {
         struct perf_event_attr perf_attr;
-        memset(&attr, 0, sizeof(struct perf_event_attr));
+        memset(&perf_attr, 0, sizeof(struct perf_event_attr));
         perf_attr.type = PERF_TYPE_SOFTWARE;
         perf_attr.size = sizeof(struct perf_event_attr);
         perf_attr.config = PERF_COUNT_SW_DUMMY;
-        perf_attr.disable = 1;
+        perf_attr.disabled = 1;
         perf_attr.sample_period = 1;
         perf_attr.sample_type = PERF_SAMPLE_TIME;
 #if !defined(HW_BREAKPOINT_COMPAT) && defined(USE_PERF_CLOCKID)
@@ -50,12 +58,12 @@ protected:
 #endif
         perf_attr.context_switch = 1;
         
-        fd_ = perf_event_open(&perf_attr, -1, cpu, -1, 0);
+        fd_ = perf_event_open(&perf_attr, -1, cpuid, -1, 0);
         if(fd_ < 0)
         {
             Log::error() << "perf_event_open for context switches failed.";
         }
-        Log::debug() << "Opened perf_context_switch_reader for cpu " << cpu_;
+        Log::debug() << "Opened perf_context_switch_reader for cpu " << cpuid;
 
         try
         {
@@ -68,7 +76,7 @@ protected:
             init_mmap(fd_, config().mmap_pages);
             Log::debug() << "perf_context_switch_reader mmap initialized";
 
-            if(ioctl(fd_, PERF_EVENT_IOC_ENAVBLE) == -1)
+            if(ioctl(fd_, PERF_EVENT_IOC_ENABLE) == -1)
             {
                 throw_errno();
             }
@@ -87,9 +95,24 @@ protected:
             close(fd_);
         }
     }
+
+    int fd() const
+    {
+        return fd_;
+    }
+
+    void stop()
+    {
+        auto ret = ioctl(fd_, PERF_EVENT_IOC_DISABLE);
+        if(ret == -1)
+        {
+            throw_errno();
+        }
+        this->read();
+    }
 private:
     int fd_;
-}
+};
 }
 }
 }

--- a/include/lo2s/perf/context_switch/reader.hpp
+++ b/include/lo2s/perf/context_switch/reader.hpp
@@ -1,0 +1,95 @@
+/*
+  * This file is part of the lo2s software.
+  * Linux OTF2 sampling
+  *
+  * Copyright (c) 2016,
+  *    Technische Universitaet Dresden, Germany
+  *
+  * lo2s is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * lo2s is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+  */
+ 
+ #pragma once
+ 
+ #include <lo2s/perf/event_reader.hpp>
+
+namespace lo2s
+{
+namespace perf
+{
+namespace context_switch
+{
+template <class T>
+class Reader : public EventReader<T>
+{
+protected:
+    using EventReader<T>::init_mmap;
+    Reader(int cpuid)
+    {
+        struct perf_event_attr perf_attr;
+        memset(&attr, 0, sizeof(struct perf_event_attr));
+        perf_attr.type = PERF_TYPE_SOFTWARE;
+        perf_attr.size = sizeof(struct perf_event_attr);
+        perf_attr.config = PERF_COUNT_SW_DUMMY;
+        perf_attr.disable = 1;
+        perf_attr.sample_period = 1;
+        perf_attr.sample_type = PERF_SAMPLE_TIME;
+#if !defined(HW_BREAKPOINT_COMPAT) && defined(USE_PERF_CLOCKID)
+        perf_attr.use_clockid = config().use_clockid;
+        perf_attr.clockid = config().clockid;
+#endif
+        perf_attr.context_switch = 1;
+        
+        fd_ = perf_event_open(&perf_attr, -1, cpu, -1, 0);
+        if(fd_ < 0)
+        {
+            Log::error() << "perf_event_open for context switches failed.";
+        }
+        Log::debug() << "Opened perf_context_switch_reader for cpu " << cpu_;
+
+        try
+        {
+            //asynchronous delivery
+            if(fcntl(fd_, F_SETFL, O_NONBLOCK))
+            {
+                throw_errno();
+            }
+
+            init_mmap(fd_, config().mmap_pages);
+            Log::debug() << "perf_context_switch_reader mmap initialized";
+
+            if(ioctl(fd_, PERF_EVENT_IOC_ENAVBLE) == -1)
+            {
+                throw_errno();
+            }
+        }
+        catch (...)
+        {
+            close(fd_);
+            throw;
+        }
+    }
+
+    ~Reader()
+    {
+        if(fd_ != -1)
+        {
+            close(fd_);
+        }
+    }
+private:
+    int fd_;
+}
+}
+}
+}

--- a/include/lo2s/perf/context_switch/reader.hpp
+++ b/include/lo2s/perf/context_switch/reader.hpp
@@ -56,12 +56,17 @@ public:
         perf_attr.use_clockid = config().use_clockid;
         perf_attr.clockid = config().clockid;
 #endif
+        perf_attr.sample_id_all = 1;
         perf_attr.context_switch = 1;
-        
+
+        perf_attr.watermark = 1;
+        perf_attr.wakeup_watermark = static_cast<uint32_t>(0.8 * config().mmap_pages * get_page_size());
+
         fd_ = perf_event_open(&perf_attr, -1, cpuid, -1, 0);
         if(fd_ < 0)
         {
             Log::error() << "perf_event_open for context switches failed.";
+            throw_errno();
         }
         Log::debug() << "Opened perf_context_switch_reader for cpu " << cpuid;
 

--- a/include/lo2s/perf/context_switch/reader.hpp
+++ b/include/lo2s/perf/context_switch/reader.hpp
@@ -49,7 +49,7 @@ public:
         struct perf_event_attr perf_attr;
         memset(&perf_attr, 0, sizeof(struct perf_event_attr));
 
-        //We only want the Context Switch samples, so set up a dummy sampling event
+        // We only want the Context Switch samples, so set up a dummy sampling event
         perf_attr.type = PERF_TYPE_SOFTWARE;
         perf_attr.size = sizeof(struct perf_event_attr);
         perf_attr.config = PERF_COUNT_SW_DUMMY;
@@ -61,14 +61,13 @@ public:
         perf_attr.use_clockid = config().use_clockid;
         perf_attr.clockid = config().clockid;
 #endif
-        //the perf_attr.sample_type information should also show up in context switches
+        // the perf_attr.sample_type information should also show up in context switches
         perf_attr.sample_id_all = 1;
         perf_attr.context_switch = 1;
 
         perf_attr.watermark = 1;
         perf_attr.wakeup_watermark =
             static_cast<uint32_t>(0.8 * config().mmap_pages * get_page_size());
-
 
         fd_ = perf_event_open(&perf_attr, -1, cpuid, -1, 0);
         if (fd_ < 0)

--- a/include/lo2s/perf/context_switch/reader.hpp
+++ b/include/lo2s/perf/context_switch/reader.hpp
@@ -44,7 +44,6 @@ template <class T>
 class Reader : public EventReader<T>
 {
 public:
-    using EventReader<T>::init_mmap;
     Reader(int cpuid)
     {
         struct perf_event_attr perf_attr;
@@ -124,6 +123,9 @@ public:
         }
         this->read();
     }
+
+protected:
+    using EventReader<T>::init_mmap;
 
 private:
     int fd_;

--- a/include/lo2s/perf/context_switch/writer.hpp
+++ b/include/lo2s/perf/context_switch/writer.hpp
@@ -49,7 +49,7 @@ private:
     trace::Trace& trace_;
     std::unordered_map<pid_t, otf2::definition::calling_context::reference_type> thread_calling_context_refs_;
 
-    pid_t last_pid_;
+    otf2::definition::calling_context::reference_type last_calling_context_ = 0;
     otf2::chrono::time_point last_time_point_ = otf2::chrono::genesis();
 
     enum class LastEventType

--- a/include/lo2s/perf/context_switch/writer.hpp
+++ b/include/lo2s/perf/context_switch/writer.hpp
@@ -1,0 +1,45 @@
+ /* 
+  * This file is part of the lo2s software.
+  * Linux OTF2 sampling
+  *
+  * Copyright (c) 2016,
+  *    Technische Universitaet Dresden, Germany
+  *
+  * lo2s is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * lo2s is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+  */
+
+#pragma once
+
+#include <lo2s/perf/switch/reader.hpp>
+
+namespace lo2s
+{
+namespace perf
+{
+namespace context_switch
+{
+
+class Writer : public Reader<Writer>
+{
+public:
+    Writer(int cpu, trace::Trace& trace);
+    bool handle(const Reader::RecordSwitchCpuWideType *context_switch)
+private:
+    otf2::writer::local& otf2_writer_;
+    const time::Converter time_converter_;
+    std::map<pid_t, otf2::definition::region::reference_type> thread_region_refs;
+}
+}
+}
+}

--- a/include/lo2s/perf/context_switch/writer.hpp
+++ b/include/lo2s/perf/context_switch/writer.hpp
@@ -1,23 +1,23 @@
- /* 
-  * This file is part of the lo2s software.
-  * Linux OTF2 sampling
-  *
-  * Copyright (c) 2016,
-  *    Technische Universitaet Dresden, Germany
-  *
-  * lo2s is free software: you can redistribute it and/or modify
-  * it under the terms of the GNU General Public License as published by
-  * the Free Software Foundation, either version 3 of the License, or
-  * (at your option) any later version.
-  *
-  * lo2s is distributed in the hope that it will be useful,
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  * GNU General Public License for more details.
-  *
-  * You should have received a copy of the GNU General Public License
-  * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
-  */
+/*
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2016,
+ *    Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #pragma once
 
@@ -41,14 +41,18 @@ public:
     ~Writer();
 
     using Reader<Writer>::handle;
-    bool handle(const Reader::RecordSwitchCpuWideType *context_switch);
+    bool handle(const Reader::RecordSwitchCpuWideType* context_switch);
+
 private:
     otf2::writer::local& otf2_writer_;
     const time::Converter time_converter_;
-    trace::Trace &trace_;
+    trace::Trace& trace_;
     std::map<pid_t, otf2::definition::region::reference_type> thread_region_refs_;
-    bool first_enter_ = false;
+
+    bool last_enter_closed_ = true;
+    pid_t last_pid_;
+    otf2::chrono::time_point last_time_point_ = otf2::chrono::genesis();
 };
-}
-}
-}
+} // namespace context_switch
+} // namespace perf
+} // namespace lo2s

--- a/include/lo2s/perf/context_switch/writer.hpp
+++ b/include/lo2s/perf/context_switch/writer.hpp
@@ -52,12 +52,12 @@ private:
     pid_t last_pid_;
     otf2::chrono::time_point last_time_point_ = otf2::chrono::genesis();
 
-    enum LAST_EVENT_TYPE
+    enum class LastEventType
     {
-        ENTER,
-        LEAVE
+        enter,
+        leave
     };
-    int last_event_type = LEAVE;
+    LastEventType last_event_type = LastEventType::leave;
 };
 } // namespace context_switch
 } // namespace perf

--- a/include/lo2s/perf/context_switch/writer.hpp
+++ b/include/lo2s/perf/context_switch/writer.hpp
@@ -25,7 +25,7 @@
 #include <lo2s/perf/time/converter.hpp>
 #include <lo2s/trace/trace.hpp>
 
-#include <otf2xx/definition/region.hpp>
+#include <otf2xx/definition/calling_context.hpp>
 #include <otf2xx/writer/local.hpp>
 namespace lo2s
 {
@@ -47,7 +47,7 @@ private:
     otf2::writer::local& otf2_writer_;
     const time::Converter time_converter_;
     trace::Trace& trace_;
-    std::map<pid_t, otf2::definition::region::reference_type> thread_region_refs_;
+    std::unordered_map<pid_t, otf2::definition::calling_context::reference_type> thread_calling_context_refs_;
 
     pid_t last_pid_;
     otf2::chrono::time_point last_time_point_ = otf2::chrono::genesis();

--- a/include/lo2s/perf/context_switch/writer.hpp
+++ b/include/lo2s/perf/context_switch/writer.hpp
@@ -47,9 +47,11 @@ private:
     otf2::writer::local& otf2_writer_;
     const time::Converter time_converter_;
     trace::Trace& trace_;
-    std::unordered_map<pid_t, otf2::definition::calling_context::reference_type> thread_calling_context_refs_;
+    std::unordered_map<pid_t, otf2::definition::calling_context::reference_type>
+        thread_calling_context_refs_;
 
-    otf2::definition::calling_context::reference_type last_calling_context_ = otf2::definition::calling_context::reference_type::undefined();
+    otf2::definition::calling_context::reference_type last_calling_context_ =
+        otf2::definition::calling_context::reference_type::undefined();
     otf2::chrono::time_point last_time_point_;
 
     enum class LastEventType

--- a/include/lo2s/perf/context_switch/writer.hpp
+++ b/include/lo2s/perf/context_switch/writer.hpp
@@ -49,9 +49,15 @@ private:
     trace::Trace& trace_;
     std::map<pid_t, otf2::definition::region::reference_type> thread_region_refs_;
 
-    bool last_enter_closed_ = true;
     pid_t last_pid_;
     otf2::chrono::time_point last_time_point_ = otf2::chrono::genesis();
+
+    enum LAST_EVENT_TYPE
+    {
+        ENTER,
+        LEAVE
+    };
+    int last_event_type = LEAVE;
 };
 } // namespace context_switch
 } // namespace perf

--- a/include/lo2s/perf/context_switch/writer.hpp
+++ b/include/lo2s/perf/context_switch/writer.hpp
@@ -21,8 +21,12 @@
 
 #pragma once
 
-#include <lo2s/perf/switch/reader.hpp>
+#include <lo2s/perf/context_switch/reader.hpp>
+#include <lo2s/perf/time/converter.hpp>
+#include <lo2s/trace/trace.hpp>
 
+#include <otf2xx/definition/region.hpp>
+#include <otf2xx/writer/local.hpp>
 namespace lo2s
 {
 namespace perf
@@ -34,12 +38,16 @@ class Writer : public Reader<Writer>
 {
 public:
     Writer(int cpu, trace::Trace& trace);
-    bool handle(const Reader::RecordSwitchCpuWideType *context_switch)
+    ~Writer();
+
+    using Reader<Writer>::handle;
+    bool handle(const Reader::RecordSwitchCpuWideType *context_switch);
 private:
     otf2::writer::local& otf2_writer_;
     const time::Converter time_converter_;
-    std::map<pid_t, otf2::definition::region::reference_type> thread_region_refs;
-}
+    trace::Trace &trace_;
+    std::map<pid_t, otf2::definition::region::reference_type> thread_region_refs_;
+};
 }
 }
 }

--- a/include/lo2s/perf/context_switch/writer.hpp
+++ b/include/lo2s/perf/context_switch/writer.hpp
@@ -49,8 +49,8 @@ private:
     trace::Trace& trace_;
     std::unordered_map<pid_t, otf2::definition::calling_context::reference_type> thread_calling_context_refs_;
 
-    otf2::definition::calling_context::reference_type last_calling_context_ = 0;
-    otf2::chrono::time_point last_time_point_ = otf2::chrono::genesis();
+    otf2::definition::calling_context::reference_type last_calling_context_ = otf2::definition::calling_context::reference_type::undefined();
+    otf2::chrono::time_point last_time_point_;
 
     enum class LastEventType
     {

--- a/include/lo2s/perf/context_switch/writer.hpp
+++ b/include/lo2s/perf/context_switch/writer.hpp
@@ -57,7 +57,7 @@ private:
         enter,
         leave
     };
-    LastEventType last_event_type = LastEventType::leave;
+    LastEventType last_event_type_ = LastEventType::leave;
 };
 } // namespace context_switch
 } // namespace perf

--- a/include/lo2s/perf/context_switch/writer.hpp
+++ b/include/lo2s/perf/context_switch/writer.hpp
@@ -47,6 +47,7 @@ private:
     const time::Converter time_converter_;
     trace::Trace &trace_;
     std::map<pid_t, otf2::definition::region::reference_type> thread_region_refs_;
+    bool first_enter_ = false;
 };
 }
 }

--- a/include/lo2s/perf/event_reader.hpp
+++ b/include/lo2s/perf/event_reader.hpp
@@ -23,9 +23,9 @@
 
 #include <lo2s/error.hpp>
 #include <lo2s/log.hpp>
+#include <lo2s/mmap.hpp>
 #include <lo2s/platform.hpp>
 #include <lo2s/util.hpp>
-#include <lo2s/mmap.hpp>
 
 #include <algorithm>
 #include <cassert>

--- a/include/lo2s/perf/event_reader.hpp
+++ b/include/lo2s/perf/event_reader.hpp
@@ -104,6 +104,14 @@ public:
         uint64_t time;
         // struct sample_id sample_id;
     };
+    struct RecordSwitchCpuWideType
+    {
+        struct perf_event_header header;
+        uint32_t next_prev_pid;
+        uint32_t next_prev_tid;
+        uint64_t time;
+        // struct sample_id sample_id;
+    };
 
     /**
      * \brief structure for PERF_RECORD_COMM events
@@ -202,6 +210,9 @@ public:
                     break;
                 case PERF_RECORD_MMAP2:
                     stop = crtp_this->handle((const RecordMmap2Type*)event_header_p);
+                    break;
+                case PERF_RECORD_SWITCH_CPU_WIDE:
+                    stop = crtp_this->handle((const RecordSwitchCpuWideType*)event_header_p);
                     break;
                 case PERF_RECORD_THROTTLE: /* fall-through */
                 case PERF_RECORD_UNTHROTTLE:

--- a/include/lo2s/perf/event_reader.hpp
+++ b/include/lo2s/perf/event_reader.hpp
@@ -211,9 +211,11 @@ public:
                 case PERF_RECORD_MMAP2:
                     stop = crtp_this->handle((const RecordMmap2Type*)event_header_p);
                     break;
+#ifdef USE_PERF_RECORD_SWITCH
                 case PERF_RECORD_SWITCH_CPU_WIDE:
                     stop = crtp_this->handle((const RecordSwitchCpuWideType*)event_header_p);
                     break;
+#endif
                 case PERF_RECORD_THROTTLE: /* fall-through */
                 case PERF_RECORD_UNTHROTTLE:
                     throttle_samples++;

--- a/include/lo2s/perf/tracepoint/reader.hpp
+++ b/include/lo2s/perf/tracepoint/reader.hpp
@@ -112,7 +112,6 @@ public:
         RecordDynamicFormat raw_data;
     };
 
-    using EventReader<T>::init_mmap;
 
     Reader(int cpu, int event_id, size_t mmap_pages) : cpu_(cpu)
     {
@@ -197,6 +196,9 @@ public:
         }
         this->read();
     }
+
+protected:
+    using EventReader<T>::init_mmap;
 
 private:
     int cpu_;

--- a/include/lo2s/perf/tracepoint/reader.hpp
+++ b/include/lo2s/perf/tracepoint/reader.hpp
@@ -35,7 +35,8 @@
 
 #include <ios>
 
-extern "C" {
+extern "C"
+{
 #include <fcntl.h>
 #include <linux/perf_event.h>
 #include <sys/ioctl.h>
@@ -111,7 +112,6 @@ public:
         // char data[size];
         RecordDynamicFormat raw_data;
     };
-
 
     Reader(int cpu, int event_id, size_t mmap_pages) : cpu_(cpu)
     {
@@ -208,6 +208,6 @@ private:
 
 template <typename T>
 const fs::path Reader<T>::base_path = fs::path("/sys/kernel/debug/tracing/events");
-}
-}
-}
+} // namespace tracepoint
+} // namespace perf
+} // namespace lo2s

--- a/src/perf/context_switch/writer.cpp
+++ b/src/perf/context_switch/writer.cpp
@@ -39,7 +39,7 @@ Writer::Writer(int cpu, trace::Trace& trace)
 {
 }
 
-Writer::~Wrtier()
+Writer::~Writer()
 {
     if(!thread_region_refs_.empty())
     {
@@ -51,22 +51,24 @@ Writer::~Wrtier()
 bool Writer::handle(const Reader::RecordSwitchCpuWideType *context_switch)
 {
     auto tp = time_converter_(context_switch->time);
-    
+    std::cout << tp << std::endl;
     auto elem =  thread_region_refs_.emplace(std::piecewise_construct, std::forward_as_tuple(context_switch->next_prev_pid), std::forward_as_tuple(thread_region_refs_.size()));
 
     //Check if we left the region
-    if(context_switch->misc & PERF_RECORD_MISC_SWITCH_OUT)
+    if(context_switch->header.misc & PERF_RECORD_MISC_SWITCH_OUT)
     {
+        std::cout << "Left region :" << elem.first->second << std::endl;
         otf2_writer_.write_leave(tp, elem.first->second);
     }
     else
     {
+        std::cout << "Entered region :" << elem.first->second << std::endl;
         otf2_writer_.write_enter(tp, elem.first->second);
 
         summary().register_process(context_switch->next_prev_pid);
     }
 
-    return false
+    return false;
 }
 }
 }

--- a/src/perf/context_switch/writer.cpp
+++ b/src/perf/context_switch/writer.cpp
@@ -1,27 +1,28 @@
- /* 
-  * This file is part of the lo2s software.
-  * Linux OTF2 sampling
-  *
-  * Copyright (c) 2016,
-  *    Technische Universitaet Dresden, Germany
-  *
-  * lo2s is free software: you can redistribute it and/or modify
-  * it under the terms of the GNU General Public License as published by
-  * the Free Software Foundation, either version 3 of the License, or
-  * (at your option) any later version.
-  *
-  * lo2s is distributed in the hope that it will be useful,
-  * but WITHOUT ANY WARRANTY; without even the implied warranty of
-  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-  * GNU General Public License for more details.
-  *
-  * You should have received a copy of the GNU General Public License
-  * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
-  */
+/*
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2016,
+ *    Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include <lo2s/perf/context_switch/writer.hpp>
 
 #include <lo2s/summary.hpp>
+#include <lo2s/time/time.hpp>
 #include <lo2s/trace/trace.hpp>
 
 namespace lo2s
@@ -32,48 +33,60 @@ namespace context_switch
 {
 
 Writer::Writer(int cpu, trace::Trace& trace)
- : Reader(cpu),
-   otf2_writer_(trace.cpu_writer(cpu)),
-   time_converter_(time::Converter::instance()),
-   trace_(trace)
+: Reader(cpu), otf2_writer_(trace.cpu_writer(cpu)), time_converter_(time::Converter::instance()),
+  trace_(trace)
 {
 }
 
 Writer::~Writer()
 {
-    if(!thread_region_refs_.empty())
+    // Always close the last entered region
+    if (!last_enter_closed_)
+    {
+        auto elem =
+            thread_region_refs_.emplace(std::piecewise_construct, std::forward_as_tuple(last_pid_),
+                                        std::forward_as_tuple(thread_region_refs_.size()));
+
+        otf2_writer_.write_leave(std::max(last_time_point_, lo2s::time::now()), elem.first->second);
+    }
+
+    if (!thread_region_refs_.empty())
     {
         const auto& mapping = trace_.merge_tids(thread_region_refs_);
         otf2_writer_ << mapping;
     }
 }
 
-bool Writer::handle(const Reader::RecordSwitchCpuWideType *context_switch)
+bool Writer::handle(const Reader::RecordSwitchCpuWideType* context_switch)
 {
-    if(context_switch->next_prev_pid == 0)
+    if (context_switch->next_prev_pid == 0)
     {
         return false;
     }
 
     auto tp = time_converter_(context_switch->time);
-    auto elem =  thread_region_refs_.emplace(std::piecewise_construct, std::forward_as_tuple(context_switch->next_prev_pid), std::forward_as_tuple(thread_region_refs_.size()));
+    auto elem = thread_region_refs_.emplace(std::piecewise_construct,
+                                            std::forward_as_tuple(context_switch->next_prev_pid),
+                                            std::forward_as_tuple(thread_region_refs_.size()));
 
-    //Check if we left the region
-    if((context_switch->header.misc & PERF_RECORD_MISC_SWITCH_OUT) && first_enter_ == true)
+    // Check if we left the region
+    if ((context_switch->header.misc & PERF_RECORD_MISC_SWITCH_OUT) && last_enter_closed_ == true)
     {
+        last_enter_closed_ = true;
         otf2_writer_.write_leave(tp, elem.first->second);
     }
     else
     {
-        //Vampir doesn't like it when records start with a LEAVE
-        first_enter_ = true;
+        last_enter_closed_ = false;
         otf2_writer_.write_enter(tp, elem.first->second);
 
         summary().register_process(context_switch->next_prev_pid);
     }
 
+    last_time_point_ = tp;
+    last_pid_ = context_switch->next_prev_pid;
     return false;
 }
-}
-}
-}
+} // namespace context_switch
+} // namespace perf
+} // namespace lo2s

--- a/src/perf/context_switch/writer.cpp
+++ b/src/perf/context_switch/writer.cpp
@@ -1,0 +1,73 @@
+ /* 
+  * This file is part of the lo2s software.
+  * Linux OTF2 sampling
+  *
+  * Copyright (c) 2016,
+  *    Technische Universitaet Dresden, Germany
+  *
+  * lo2s is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+  *
+  * lo2s is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+  *
+  * You should have received a copy of the GNU General Public License
+  * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+  */
+
+#include <lo2s/perf/context_switch/writer.hpp>
+
+#include <lo2s/summary.hpp>
+#include <lo2s/trace/trace.hpp>
+
+namespace lo2s
+{
+namespace perf
+{
+namespace context_switch
+{
+
+Writer::Writer(int cpu, trace::Trace& trace)
+ : Reader(cpu),
+   otf2_writer_(trace.cpu_writer(cpu)),
+   time_converter_(time::Converter::instance()),
+   trace_(trace)
+{
+}
+
+Writer::~Wrtier()
+{
+    if(!thread_region_refs_.empty())
+    {
+        const auto& mapping = trace_.merge_tids(thread_region_refs_);
+        otf2_writer_ << mapping;
+    }
+}
+
+bool Writer::handle(const Reader::RecordSwitchCpuWideType *context_switch)
+{
+    auto tp = time_converter_(context_switch->time);
+    
+    auto elem =  thread_region_refs_.emplace(std::piecewise_construct, std::forward_as_tuple(context_switch->next_prev_pid), std::forward_as_tuple(thread_region_refs_.size()));
+
+    //Check if we left the region
+    if(context_switch->misc & PERF_RECORD_MISC_SWITCH_OUT)
+    {
+        otf2_writer_.write_leave(tp, elem.first->second);
+    }
+    else
+    {
+        otf2_writer_.write_enter(tp, elem.first->second);
+
+        summary().register_process(context_switch->next_prev_pid);
+    }
+
+    return false
+}
+}
+}
+}

--- a/src/perf/context_switch/writer.cpp
+++ b/src/perf/context_switch/writer.cpp
@@ -43,11 +43,7 @@ Writer::~Writer()
     // Always close the last entered region
     if (last_event_type_ == LastEventType::enter)
     {
-        auto elem =
-            thread_calling_context_refs_.emplace(std::piecewise_construct, std::forward_as_tuple(last_pid_),
-                                        std::forward_as_tuple(thread_calling_context_refs_.size()));
-
-        otf2_writer_.write_calling_context_leave(std::max(last_time_point_, lo2s::time::now()), elem.first->second);
+        otf2_writer_.write_calling_context_leave(std::max(last_time_point_, lo2s::time::now()), last_calling_context_);
     }
 
     if (!thread_calling_context_refs_.empty())
@@ -83,7 +79,7 @@ bool Writer::handle(const Reader::RecordSwitchCpuWideType* context_switch)
     {
         if(last_event_type_ == LastEventType::enter)
         {
-            otf2_writer_.write_calling_context_leave(tp, last_pid_);
+            otf2_writer_.write_calling_context_leave(tp, elem.first->second);
         }
         otf2_writer_.write_calling_context_enter(tp, elem.first->second, 2);
 
@@ -92,7 +88,7 @@ bool Writer::handle(const Reader::RecordSwitchCpuWideType* context_switch)
     }
 
     last_time_point_ = tp;
-    last_pid_ = context_switch->next_prev_pid;
+    last_calling_context_ = elem.first->second;
     return false;
 }
 } // namespace context_switch

--- a/src/perf/context_switch/writer.cpp
+++ b/src/perf/context_switch/writer.cpp
@@ -44,15 +44,15 @@ Writer::~Writer()
     if (last_event_type == ENTER)
     {
         auto elem =
-            thread_region_refs_.emplace(std::piecewise_construct, std::forward_as_tuple(last_pid_),
-                                        std::forward_as_tuple(thread_region_refs_.size()));
+            thread_calling_context_refs_.emplace(std::piecewise_construct, std::forward_as_tuple(last_pid_),
+                                        std::forward_as_tuple(thread_calling_context_refs_.size()));
 
         otf2_writer_.write_leave(std::max(last_time_point_, lo2s::time::now()), elem.first->second);
     }
 
-    if (!thread_region_refs_.empty())
+    if (!thread_calling_context_refs_.empty())
     {
-        const auto& mapping = trace_.merge_tids(thread_region_refs_);
+        const auto& mapping = trace_.merge_thread_calling_contexts(thread_calling_context_refs_);
         otf2_writer_ << mapping;
     }
 }
@@ -65,9 +65,9 @@ bool Writer::handle(const Reader::RecordSwitchCpuWideType* context_switch)
     }
 
     auto tp = time_converter_(context_switch->time);
-    auto elem = thread_region_refs_.emplace(std::piecewise_construct,
+    auto elem = thread_calling_context_refs_.emplace(std::piecewise_construct,
                                             std::forward_as_tuple(context_switch->next_prev_pid),
-                                            std::forward_as_tuple(thread_region_refs_.size()));
+                                            std::forward_as_tuple(thread_calling_context_refs_.size()));
 
     // Check if we left the region
     if (context_switch->header.misc & PERF_RECORD_MISC_SWITCH_OUT)

--- a/src/perf/context_switch/writer.cpp
+++ b/src/perf/context_switch/writer.cpp
@@ -33,7 +33,7 @@ namespace context_switch
 {
 
 Writer::Writer(int cpu, trace::Trace& trace)
-: Reader(cpu), otf2_writer_(trace.cpu_writer(cpu)), time_converter_(time::Converter::instance()),
+: Reader(cpu), otf2_writer_(trace.cpu_sample_writer(cpu)), time_converter_(time::Converter::instance()),
   trace_(trace)
 {
 }

--- a/src/perf/context_switch/writer.cpp
+++ b/src/perf/context_switch/writer.cpp
@@ -41,7 +41,7 @@ Writer::Writer(int cpu, trace::Trace& trace)
 Writer::~Writer()
 {
     // Always close the last entered region
-    if (last_event_type == LastEventType::enter)
+    if (last_event_type_ == LastEventType::enter)
     {
         auto elem =
             thread_calling_context_refs_.emplace(std::piecewise_construct, std::forward_as_tuple(last_pid_),
@@ -72,23 +72,23 @@ bool Writer::handle(const Reader::RecordSwitchCpuWideType* context_switch)
     // Check if we left the region
     if (context_switch->header.misc & PERF_RECORD_MISC_SWITCH_OUT)
     {
-        if(last_event_type == LastEventType::leave)
+        if(last_event_type_ == LastEventType::leave)
         {
             otf2_writer_.write_calling_context_enter(tp, elem.first->second, 2);
         }
         otf2_writer_.write_calling_context_leave(tp, elem.first->second);
-        last_event_type = LastEventType::leave;
+        last_event_type_ = LastEventType::leave;
     }
     else
     {
-        if(last_event_type == LastEventType::enter)
+        if(last_event_type_ == LastEventType::enter)
         {
             otf2_writer_.write_calling_context_leave(tp, last_pid_);
         }
         otf2_writer_.write_calling_context_enter(tp, elem.first->second, 2);
 
         summary().register_process(context_switch->next_prev_pid);
-        last_event_type = LastEventType::enter;
+        last_event_type_ = LastEventType::enter;
     }
 
     last_time_point_ = tp;

--- a/src/perf/context_switch/writer.cpp
+++ b/src/perf/context_switch/writer.cpp
@@ -41,7 +41,7 @@ Writer::Writer(int cpu, trace::Trace& trace)
 Writer::~Writer()
 {
     // Always close the last entered region
-    if (last_event_type == ENTER)
+    if (last_event_type == LastEventType::enter)
     {
         auto elem =
             thread_calling_context_refs_.emplace(std::piecewise_construct, std::forward_as_tuple(last_pid_),
@@ -72,23 +72,23 @@ bool Writer::handle(const Reader::RecordSwitchCpuWideType* context_switch)
     // Check if we left the region
     if (context_switch->header.misc & PERF_RECORD_MISC_SWITCH_OUT)
     {
-        if(last_event_type == LEAVE)
+        if(last_event_type == LastEventType::leave)
         {
             otf2_writer_.write_calling_context_enter(tp, elem.first->second, 2);
         }
         otf2_writer_.write_calling_context_leave(tp, elem.first->second);
-        last_event_type = LEAVE;
+        last_event_type = LastEventType::leave;
     }
     else
     {
-        if(last_event_type == ENTER)
+        if(last_event_type == LastEventType::enter)
         {
             otf2_writer_.write_calling_context_leave(tp, last_pid_);
         }
         otf2_writer_.write_calling_context_enter(tp, elem.first->second, 2);
 
         summary().register_process(context_switch->next_prev_pid);
-        last_event_type = ENTER;
+        last_event_type = LastEventType::enter;
     }
 
     last_time_point_ = tp;

--- a/src/perf/context_switch/writer.cpp
+++ b/src/perf/context_switch/writer.cpp
@@ -47,7 +47,7 @@ Writer::~Writer()
             thread_calling_context_refs_.emplace(std::piecewise_construct, std::forward_as_tuple(last_pid_),
                                         std::forward_as_tuple(thread_calling_context_refs_.size()));
 
-        otf2_writer_.write_leave(std::max(last_time_point_, lo2s::time::now()), elem.first->second);
+        otf2_writer_.write_calling_context_leave(std::max(last_time_point_, lo2s::time::now()), elem.first->second);
     }
 
     if (!thread_calling_context_refs_.empty())
@@ -74,18 +74,18 @@ bool Writer::handle(const Reader::RecordSwitchCpuWideType* context_switch)
     {
         if(last_event_type == LEAVE)
         {
-            otf2_writer_.write_enter(tp, elem.first->second);
+            otf2_writer_.write_calling_context_enter(tp, elem.first->second, 2);
         }
-        otf2_writer_.write_leave(tp, elem.first->second);
+        otf2_writer_.write_calling_context_leave(tp, elem.first->second);
         last_event_type = LEAVE;
     }
     else
     {
         if(last_event_type == ENTER)
         {
-            otf2_writer_.write_leave(tp, last_pid_);
+            otf2_writer_.write_calling_context_leave(tp, last_pid_);
         }
-        otf2_writer_.write_enter(tp, elem.first->second);
+        otf2_writer_.write_calling_context_enter(tp, elem.first->second, 2);
 
         summary().register_process(context_switch->next_prev_pid);
         last_event_type = ENTER;

--- a/src/perf/context_switch/writer.cpp
+++ b/src/perf/context_switch/writer.cpp
@@ -33,7 +33,7 @@ namespace context_switch
 {
 
 Writer::Writer(int cpu, trace::Trace& trace)
-: Reader(cpu), otf2_writer_(trace.cpu_sample_writer(cpu)), time_converter_(time::Converter::instance()),
+: Reader(cpu), otf2_writer_(trace.cpu_switch_writer(cpu)), time_converter_(time::Converter::instance()),
   trace_(trace)
 {
 }

--- a/src/perf/tracepoint/switch_writer.cpp
+++ b/src/perf/tracepoint/switch_writer.cpp
@@ -109,6 +109,7 @@ bool SwitchWriter::handle(const Reader::RecordSampleType* sample)
     last_time_point_ = tp;
 
     summary().register_process(next_pid);
+
     return false;
 }
 

--- a/src/perf/tracepoint/switch_writer.cpp
+++ b/src/perf/tracepoint/switch_writer.cpp
@@ -109,7 +109,6 @@ bool SwitchWriter::handle(const Reader::RecordSampleType* sample)
     last_time_point_ = tp;
 
     summary().register_process(next_pid);
-
     return false;
 }
 


### PR DESCRIPTION
This fixes #79.

This PR implements recording of ContextSwitch Events using PERF_RECORD_SWITCH instead of the older tracepoint based SwitchWriter, which has the advantage of working without root privileges. 

The only remaining thing that needs root privileges in system-wide mode is the ExitReader, which we should replace shortly with a PERF_RECORD_COMM based solution similar to #84

As PERF_RECORD_SWITCH events were only introduced in Kernel 4.3, use of this feature is guarded by a cmake check and the cmake option USE_PERF_RECORD_SWITCH
