### PR TITLE
Refactor switch writer to use calling_context_enter/leave

### DIFF
--- a/include/lo2s/perf/tracepoint/switch_writer.hpp
+++ b/include/lo2s/perf/tracepoint/switch_writer.hpp
@@ -29,8 +29,8 @@
 
 #include <lo2s/trace/fwd.hpp>
 
+#include <otf2xx/definition/calling_context.hpp>
 #include <otf2xx/definition/location.hpp>
-#include <otf2xx/definition/region.hpp>
 #include <otf2xx/writer/local.hpp>
 
 #include <unordered_map>
@@ -58,17 +58,17 @@ public:
     bool handle(const Reader::RecordSampleType* sample);
 
 private:
-    otf2::definition::region::reference_type thread_region_ref(pid_t tid);
+    otf2::definition::calling_context::reference_type thread_calling_context_ref(pid_t tid);
 
 private:
     otf2::writer::local& otf2_writer_;
     trace::Trace& trace_;
     const time::Converter time_converter_;
 
-    using region_ref = otf2::definition::region::reference_type;
-    std::unordered_map<pid_t, region_ref> thread_region_refs_;
+    using calling_context_ref = otf2::definition::calling_context::reference_type;
+    std::unordered_map<pid_t, calling_context_ref> thread_calling_context_refs_;
     pid_t current_pid_ = -1;
-    region_ref current_region_ = region_ref::undefined();
+    calling_context_ref current_calling_context_ = calling_context_ref::undefined();
 
     EventField prev_pid_field_;
     EventField next_pid_field_;

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -147,8 +147,9 @@ public:
                    std::vector<uint32_t>& mapping_table, otf2::definition::calling_context parent,
                    std::map<pid_t, ProcessInfo>& infos);
 
-    otf2::definition::mapping_table merge_thread_regions(
-        const std::unordered_map<pid_t, otf2::definition::region::reference_type>& local_refs);
+    otf2::definition::mapping_table merge_thread_calling_contexts(
+        const std::unordered_map<pid_t, otf2::definition::calling_context::reference_type>&
+            local_refs);
 
     const otf2::definition::interrupt_generator& interrupt_generator() const
     {
@@ -255,6 +256,11 @@ private:
         return strings_.size();
     }
 
+    otf2::definition::calling_context::reference_type calling_context_ref() const
+    {
+        return calling_contexts_.size() + calling_contexts_thread_.size();
+    }
+
     otf2::definition::system_tree_node& intern_process_node(pid_t pid);
 
     void attach_process_location_group(const otf2::definition::system_tree_node& parent, pid_t id,
@@ -306,6 +312,7 @@ private:
 
     IpCctxMap calling_context_tree_;
     otf2::definition::container<otf2::definition::calling_context> calling_contexts_;
+    std::map<int, otf2::definition::calling_context> calling_contexts_thread_;
     otf2::definition::container<otf2::definition::calling_context_property>
         calling_context_properties_;
     otf2::definition::container<otf2::definition::metric_member> metric_members_;

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -318,13 +318,13 @@ void Trace::attach_process_location_group(const otf2::definition::system_tree_no
 
     auto r_cg = process_comm_groups_.emplace(
         std::piecewise_construct, std::forward_as_tuple(id),
-        std::forward_as_tuple(group_ref(), iname, otf2::common::paradigm_type::pthread,
+        std::forward_as_tuple(otf2::definition::comm_group::reference_type(group_ref()), iname,
+                              otf2::common::paradigm_type::pthread,
                               otf2::common::group_flag_type::none));
     assert(r_cg.second);
     const auto& group = r_cg.first->second;
-    auto r_c = process_comms_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(id),
-        std::forward_as_tuple(comm_ref(), iname, group, otf2::definition::comm::undefined()));
+    auto r_c = process_comms_.emplace(std::piecewise_construct, std::forward_as_tuple(id),
+                                      std::forward_as_tuple(comm_ref(), iname, group));
     assert(r_c.second);
     (void)(r_c.second);
 }


### PR DESCRIPTION
This also updates otf2xx to the latest commit on master.
And fixes the DSO resolution bug (see #90)