### PR TITLE
Generate symlink to latest trace

### DIFF
--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -189,6 +189,8 @@ private:
 
     otf2::definition::string intern(const std::string&);
 
+    void create_symlink_to_latest();
+
     // This generates a contiguous set of IDs for all locations
     otf2::definition::location::reference_type location_ref() const
     {

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -253,22 +253,22 @@ void Trace::create_symlink_to_latest()
 {
     boost::filesystem::path symlink_path = nitro::env::get("LO2S_OUTPUT_LINK");
 
-    if (!symlink_path.empty())
+    if(symlink_path.empty())
     {
-        if (boost::filesystem::is_symlink(symlink_path) || !boost::filesystem::exists(symlink_path))
-        {
-            if (boost::filesystem::exists(symlink_path))
-            {
-                boost::filesystem::remove(symlink_path);
-            }
-            boost::filesystem::create_symlink(trace_name_, symlink_path);
-        }
-        else
-        {
-            Log::warn() << "The path " << symlink_path
-                        << " exists and isn't a symlink, refusing to create link to latest trace";
-        }
+        return;
     }
+
+    if (boost::filesystem::is_symlink(symlink_path))
+    {
+        boost::filesystem::remove(symlink_path);
+    }
+    else if(boost::filesystem::exists(symlink_path))
+    {
+        Log::warn() << "The path " << symlink_path
+                    << " exists and isn't a symlink, refusing to create link to latest trace";
+        return;
+    }
+    boost::filesystem::create_symlink(trace_name_, symlink_path);
 }
 
 std::map<std::string, otf2::definition::regions_group> Trace::regions_groups_sampling_dso()

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -37,6 +37,7 @@
 #include <nitro/env/hostname.hpp>
 
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/filesystem.hpp>
 #include <boost/format.hpp>
 
 #include <map>
@@ -244,6 +245,30 @@ Trace::~Trace()
     archive_ << metric_classes_;
     archive_ << metric_instances_;
     archive_ << system_tree_node_properties_;
+
+    create_symlink_to_latest();
+}
+
+void Trace::create_symlink_to_latest()
+{
+    boost::filesystem::path symlink_path = nitro::env::get("LO2S_OUTPUT_LINK");
+
+    if (!symlink_path.empty())
+    {
+        if (boost::filesystem::is_symlink(symlink_path) || !boost::filesystem::exists(symlink_path))
+        {
+            if (boost::filesystem::exists(symlink_path))
+            {
+                boost::filesystem::remove(symlink_path);
+            }
+            boost::filesystem::create_symlink(trace_name_, symlink_path);
+        }
+        else
+        {
+            Log::warn() << "The path " << symlink_path
+                        << " exists and isn't a symlink, refusing to create link to latest trace";
+        }
+    }
 }
 
 std::map<std::string, otf2::definition::regions_group> Trace::regions_groups_sampling_dso()


### PR DESCRIPTION
Fixes #95 

If the environment variable LO2S_OUTPUT_LINK is defined, generate a symlink to the latest
trace with $LO2S_OUTPUT_LINK as its name, but only if the path does not exist or is in itself a symlink