### PR TITLE
Improve LineInfo for IPs in unresolvable functions

### DIFF
--- a/include/lo2s/line_info.hpp
+++ b/include/lo2s/line_info.hpp
@@ -32,32 +32,61 @@ namespace lo2s
 {
 struct LineInfo
 {
+private:
+    static const std::string unknown_file_str;
+    static const std::string unknown_binary_str;
+    static const std::string unmapped_function_str;
+    static const std::string unknown_function_str;
+
+    static constexpr unsigned int UNKNOWN_LINE = 0;
+
     // Note: If line is not known, we write 1 anyway so the rest is shown in vampir
-    LineInfo(const std::string& fi, const std::string& fu, unsigned int l, const std::string& d)
-    : file(fi), function(fu), line(l ? l : 1), dso(boost::filesystem::path(d).filename().string())
+    // phijor 2018-11-08: I think this workaround is not needed anymore? vampir
+    // shows source code locations with line == 0 just fine.
+    LineInfo(const std::string& file, const std::string& function, unsigned int line,
+             const std::string& dso)
+    : file(file), function(function), line((line != UNKNOWN_LINE) ? line : 1), dso(dso)
     {
     }
 
-    LineInfo(const char* fi, const char* fu, unsigned int l, const std::string& d)
-    : LineInfo(fi ? std::string(fi) : unknown_str, fu ? std::string(fu) : unknown_str, l, d)
+public:
+    LineInfo() : LineInfo(unknown_file_str, unknown_function_str, UNKNOWN_LINE, unknown_binary_str)
     {
     }
 
-    LineInfo(Address addr) : LineInfo(addr, unknown_str)
+    static LineInfo for_function(const char* file, const char* function, unsigned int line,
+                                 const std::string& dso)
     {
+        return LineInfo((file != nullptr) ? std::string{ file } : unknown_file_str,
+                        (function != nullptr) ? std::string{ function } : unknown_function_str,
+                        line, boost::filesystem::path(dso).filename().string());
     }
 
-    LineInfo(Address addr, const std::string& d)
-    : LineInfo(unknown_str, str(fmt("?@%dx") % addr), 0, d)
+    static LineInfo for_unmapped_function()
     {
+        return LineInfo(unknown_file_str, unmapped_function_str, UNKNOWN_LINE, unknown_binary_str);
+    }
+
+    static LineInfo for_unknown_function()
+    {
+        return LineInfo(unknown_file_str, unknown_function_str, UNKNOWN_LINE, unknown_binary_str);
+    }
+
+    static LineInfo for_unknown_function_in_dso(const std::string& dso)
+    {
+        return LineInfo(unknown_file_str, unknown_function_str, UNKNOWN_LINE,
+                        boost::filesystem::path(dso).filename().string());
+    }
+
+    static LineInfo for_binary(const std::string& binary)
+    {
+        return LineInfo(binary, binary, UNKNOWN_LINE, binary);
     }
 
     std::string file;
     std::string function;
     unsigned int line;
     std::string dso;
-
-    static const std::string unknown_str;
 
     // For std::map
     bool operator<(const LineInfo& other) const

--- a/include/lo2s/line_info.hpp
+++ b/include/lo2s/line_info.hpp
@@ -50,10 +50,6 @@ private:
     }
 
 public:
-    LineInfo() : LineInfo(unknown_file_str, unknown_function_str, UNKNOWN_LINE, unknown_binary_str)
-    {
-    }
-
     static LineInfo for_function(const char* file, const char* function, unsigned int line,
                                  const std::string& dso)
     {

--- a/include/lo2s/line_info.hpp
+++ b/include/lo2s/line_info.hpp
@@ -21,23 +21,13 @@
 
 #pragma once
 
-#include <lo2s/address.hpp>
-
 #include <boost/filesystem.hpp>
-#include <boost/format.hpp>
-
-using fmt = boost::format;
 
 namespace lo2s
 {
 struct LineInfo
 {
 private:
-    static const std::string unknown_file_str;
-    static const std::string unknown_binary_str;
-    static const std::string unmapped_function_str;
-    static const std::string unknown_function_str;
-
     static constexpr unsigned int UNKNOWN_LINE = 0;
 
     // Note: If line is not known, we write 1 anyway so the rest is shown in vampir
@@ -49,28 +39,28 @@ private:
     {
     }
 
+    LineInfo(const char* file, const char* function, unsigned int line, const std::string& dso)
+    : file(file), function(function), line((line != UNKNOWN_LINE) ? line : 1), dso(dso)
+    {
+    }
+
 public:
     static LineInfo for_function(const char* file, const char* function, unsigned int line,
                                  const std::string& dso)
     {
-        return LineInfo((file != nullptr) ? std::string{ file } : unknown_file_str,
-                        (function != nullptr) ? std::string{ function } : unknown_function_str,
-                        line, boost::filesystem::path(dso).filename().string());
-    }
-
-    static LineInfo for_unmapped_function()
-    {
-        return LineInfo(unknown_file_str, unmapped_function_str, UNKNOWN_LINE, unknown_binary_str);
+        return LineInfo((file != nullptr) ? file : "<unknown file>",
+                        (function != nullptr) ? function : "<unknown function>", line,
+                        boost::filesystem::path(dso).filename().string());
     }
 
     static LineInfo for_unknown_function()
     {
-        return LineInfo(unknown_file_str, unknown_function_str, UNKNOWN_LINE, unknown_binary_str);
+        return LineInfo("<unknown file>", "<unknown function>", UNKNOWN_LINE, "<unknown binary>");
     }
 
     static LineInfo for_unknown_function_in_dso(const std::string& dso)
     {
-        return LineInfo(unknown_file_str, unknown_function_str, UNKNOWN_LINE,
+        return LineInfo("<unknown file>", "<unknown function>", UNKNOWN_LINE,
                         boost::filesystem::path(dso).filename().string());
     }
 

--- a/include/lo2s/mmap.hpp
+++ b/include/lo2s/mmap.hpp
@@ -87,7 +87,7 @@ public:
 
     virtual LineInfo lookup_line_info(Address) override
     {
-        return LineInfo(name(), name(), 0, name());
+        return LineInfo::for_binary(name());
     }
 };
 
@@ -126,7 +126,7 @@ public:
         }
         catch (bfdr::LookupError&)
         {
-            return LineInfo(ip, name());
+            return LineInfo::for_unknown_function_in_dso(name());
         }
     }
 

--- a/src/bfd_resolve.cpp
+++ b/src/bfd_resolve.cpp
@@ -28,7 +28,10 @@
 
 namespace lo2s
 {
-const std::string LineInfo::unknown_str = "(unknown)";
+const std::string LineInfo::unknown_file_str = "<unknown file>";
+const std::string LineInfo::unknown_binary_str = "<unknown binary>";
+const std::string LineInfo::unmapped_function_str = "<unmapped function>";
+const std::string LineInfo::unknown_function_str = "<unknown function>";
 
 namespace bfdr
 {
@@ -151,12 +154,12 @@ LineInfo Lib::lookup(Address addr) const
             auto demangled = bfd_demangle(handle_, func, DMGL_PARAMS | DMGL_ANSI);
             if (demangled != nullptr)
             {
-                std::string demangled_str(demangled);
+                LineInfo line_info = LineInfo::for_function(file, demangled, line, name_);
                 free(demangled);
-                return LineInfo(file, demangled_str.c_str(), line, name_);
+                return line_info;
             }
         }
-        return LineInfo(file, func, line, name_);
+        return LineInfo::for_function(file, func, line, name_);
     }
     catch (std::out_of_range&)
     {

--- a/src/bfd_resolve.cpp
+++ b/src/bfd_resolve.cpp
@@ -28,11 +28,6 @@
 
 namespace lo2s
 {
-const std::string LineInfo::unknown_file_str = "<unknown file>";
-const std::string LineInfo::unknown_binary_str = "<unknown binary>";
-const std::string LineInfo::unmapped_function_str = "<unmapped function>";
-const std::string LineInfo::unknown_function_str = "<unknown function>";
-
 namespace bfdr
 {
 

--- a/src/mmap.cpp
+++ b/src/mmap.cpp
@@ -169,7 +169,7 @@ LineInfo MemoryMap::lookup_line_info(Address ip) const
         // This will just happen a lot in practice
         Log::trace() << "no mapping found for address " << ip;
         // Graceful fallback
-        return LineInfo(ip.truncate_bits(48));
+        return LineInfo::for_unmapped_function();
     }
 }
 

--- a/src/mmap.cpp
+++ b/src/mmap.cpp
@@ -169,7 +169,7 @@ LineInfo MemoryMap::lookup_line_info(Address ip) const
         // This will just happen a lot in practice
         Log::trace() << "no mapping found for address " << ip;
         // Graceful fallback
-        return LineInfo::for_unmapped_function();
+        return LineInfo::for_unknown_function();
     }
 }
 

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -591,11 +591,12 @@ void Trace::merge_ips(IpRefMap& new_children, IpCctxMap& children,
         auto& ip = elem.first;
         auto& local_ref = elem.second.ref;
         auto& local_children = elem.second.children;
-        LineInfo line_info = LineInfo(ip);
+        LineInfo line_info = LineInfo::for_unknown_function();
 
-        if (infos.count(elem.second.pid) == 1)
+        auto info_it = infos.find(elem.second.pid);
+        if (info_it != infos.end())
         {
-            MemoryMap maps = infos.at(elem.second.pid).maps();
+            MemoryMap maps = info_it->second.maps();
             line_info = maps.lookup_line_info(ip);
         }
 


### PR DESCRIPTION
This fixes #102. I'm partial to calling these functions "unresolvable" instead of "unknown". 

----

The source code locations generated for instruction pointers which lie
unresolvable functions are now less cluttered.  Instead of generating
LineInfos (which will later be turned into SCLs and function regions)
that contain the IP, they are now melded together if IP resolution
failed in similar ways:

* IP does not lie in range of a memory map known to lo2s?  LineInfo for
    IP becomes "\<unmapped function\>", located in DSO "\<unknown binary\>".
* IP lies in range of a mapped DSO, but function name resolution fails
    (e.g. for stripped binaries)? LineInfo becomes "\<unknown function\>",
    located in the given DSO.

Including the IP when naming SCLs and function regions only introduces
visual clutter in trace analysis software, as it does not provide any
additionaly information about the sampled function.  Instead, we now
only note that function resolution failed while still indication the
IP's origin on a per-binary basis (if possible).