### PR TITLE
Issue 112 incorrect calling context

### DIFF
--- a/include/lo2s/monitor/process_monitor.hpp
+++ b/include/lo2s/monitor/process_monitor.hpp
@@ -50,7 +50,6 @@ public:
     void exit_thread(pid_t tid) override;
 
 private:
-    std::map<pid_t, ProcessInfo> processes_;
     std::map<pid_t, ThreadMonitor> threads_;
 };
 } // namespace monitor

--- a/include/lo2s/perf/sample/writer.hpp
+++ b/include/lo2s/perf/sample/writer.hpp
@@ -81,12 +81,7 @@ public:
 private:
     otf2::definition::calling_context::reference_type
     cctx_ref(const Reader::RecordSampleType* sample);
-    trace::IpRefMap::iterator find_ip_child(Address addr, pid_t pid, trace::IpRefMap& children);
-
-    otf2::definition::calling_context::reference_type next_ip_ref() const
-    {
-        return local_ip_refs_.size() + thread_calling_context_refs_.size();
-    }
+    trace::IpRefMap::iterator find_ip_child(Address addr, trace::IpRefMap& children);
 
     pid_t pid_;
     pid_t tid_;
@@ -102,7 +97,7 @@ private:
 
     std::unordered_map<pid_t, otf2::definition::calling_context::reference_type>
         thread_calling_context_refs_;
-    trace::IpRefMap local_ip_refs_;
+    trace::ThreadIpRefMap local_ip_refs_;
 
     RawMemoryMapCache cached_mmap_events_;
     std::unordered_map<pid_t, std::string> comms_;
@@ -122,6 +117,7 @@ private:
         leave
     };
     LastEventType last_event_type_ = LastEventType::leave;
+    size_t next_ip_ref_;
 };
 } // namespace sample
 } // namespace perf

--- a/include/lo2s/perf/sample/writer.hpp
+++ b/include/lo2s/perf/sample/writer.hpp
@@ -85,6 +85,7 @@ private:
 
     void update_current_thread(pid_t pid, pid_t tid, otf2::chrono::time_point tp);
     void leave_current_thread(pid_t pid, pid_t tid, otf2::chrono::time_point tp);
+    otf2::chrono::time_point adjust_timepoints(otf2::chrono::time_point tp);
 
     pid_t pid_;
     pid_t tid_;
@@ -98,9 +99,9 @@ private:
     otf2::definition::metric_instance cpuid_metric_instance_;
     otf2::event::metric cpuid_metric_event_;
 
-    trace::ThreadIpRefMap local_cctx_refs_;
+    trace::ThreadCctxRefMap local_cctx_refs_;
     size_t next_cctx_ref_;
-    trace::ThreadIpRefMap::value_type* current_thread_cctx_refs_ = nullptr;
+    std::pair<pid_t, trace::ThreadCctxRefs&>* current_thread_cctx_refs_ = nullptr;
 
     RawMemoryMapCache cached_mmap_events_;
     std::unordered_map<pid_t, std::string> comms_;

--- a/include/lo2s/perf/sample/writer.hpp
+++ b/include/lo2s/perf/sample/writer.hpp
@@ -84,7 +84,7 @@ private:
     trace::IpRefMap::iterator find_ip_child(Address addr, trace::IpRefMap& children);
 
     void update_current_thread(pid_t pid, pid_t tid, otf2::chrono::time_point tp);
-    void leave_current_thread(pid_t pid, pid_t tid, otf2::chrono::time_point tp);
+    void leave_current_thread(pid_t tid, otf2::chrono::time_point tp);
     otf2::chrono::time_point adjust_timepoints(otf2::chrono::time_point tp);
 
     pid_t pid_;
@@ -101,7 +101,7 @@ private:
 
     trace::ThreadCctxRefMap local_cctx_refs_;
     size_t next_cctx_ref_;
-    //std::pair<pid_t, trace::ThreadCctxRefs&>* current_thread_cctx_refs_ = nullptr;
+
     trace::ThreadCctxRefMap::value_type thread_monitoring_cctx_refs_;
     trace::ThreadCctxRefMap::value_type* current_thread_cctx_refs_ = nullptr;
 

--- a/include/lo2s/perf/sample/writer.hpp
+++ b/include/lo2s/perf/sample/writer.hpp
@@ -83,6 +83,9 @@ private:
     cctx_ref(const Reader::RecordSampleType* sample);
     trace::IpRefMap::iterator find_ip_child(Address addr, trace::IpRefMap& children);
 
+    void update_current_thread(pid_t pid, pid_t tid, otf2::chrono::time_point tp);
+    void leave_current_thread(pid_t pid, pid_t tid, otf2::chrono::time_point tp);
+
     pid_t pid_;
     pid_t tid_;
     int cpuid_;
@@ -95,9 +98,9 @@ private:
     otf2::definition::metric_instance cpuid_metric_instance_;
     otf2::event::metric cpuid_metric_event_;
 
-    std::unordered_map<pid_t, otf2::definition::calling_context::reference_type>
-        thread_calling_context_refs_;
-    trace::ThreadIpRefMap local_ip_refs_;
+    trace::ThreadIpRefMap local_cctx_refs_;
+    size_t next_cctx_ref_;
+    trace::ThreadIpRefMap::value_type* current_thread_cctx_refs_ = nullptr;
 
     RawMemoryMapCache cached_mmap_events_;
     std::unordered_map<pid_t, std::string> comms_;
@@ -107,17 +110,6 @@ private:
     bool first_event_ = true;
     otf2::chrono::time_point first_time_point_;
     otf2::chrono::time_point last_time_point_;
-
-    otf2::definition::calling_context::reference_type last_calling_context_ =
-        otf2::definition::calling_context::reference_type::undefined();
-
-    enum class LastEventType
-    {
-        enter,
-        leave
-    };
-    LastEventType last_event_type_ = LastEventType::leave;
-    size_t next_ip_ref_;
 };
 } // namespace sample
 } // namespace perf

--- a/include/lo2s/perf/sample/writer.hpp
+++ b/include/lo2s/perf/sample/writer.hpp
@@ -101,7 +101,9 @@ private:
 
     trace::ThreadCctxRefMap local_cctx_refs_;
     size_t next_cctx_ref_;
-    std::pair<pid_t, trace::ThreadCctxRefs&>* current_thread_cctx_refs_ = nullptr;
+    //std::pair<pid_t, trace::ThreadCctxRefs&>* current_thread_cctx_refs_ = nullptr;
+    trace::ThreadCctxRefMap::value_type thread_monitoring_cctx_refs_;
+    trace::ThreadCctxRefMap::value_type* current_thread_cctx_refs_ = nullptr;
 
     RawMemoryMapCache cached_mmap_events_;
     std::unordered_map<pid_t, std::string> comms_;

--- a/include/lo2s/perf/tracepoint/switch_writer.hpp
+++ b/include/lo2s/perf/tracepoint/switch_writer.hpp
@@ -28,6 +28,7 @@
 #include <lo2s/perf/time/converter.hpp>
 
 #include <lo2s/trace/fwd.hpp>
+#include <lo2s/trace/trace.hpp>
 
 #include <otf2xx/definition/calling_context.hpp>
 #include <otf2xx/definition/location.hpp>
@@ -66,7 +67,7 @@ private:
     const time::Converter time_converter_;
 
     using calling_context_ref = otf2::definition::calling_context::reference_type;
-    ThreadCctxRefMap thread_calling_context_refs_;
+    trace::ThreadCctxRefMap thread_calling_context_refs_;
     pid_t current_pid_ = -1;
     calling_context_ref current_calling_context_ = calling_context_ref::undefined();
 

--- a/include/lo2s/perf/tracepoint/switch_writer.hpp
+++ b/include/lo2s/perf/tracepoint/switch_writer.hpp
@@ -66,7 +66,7 @@ private:
     const time::Converter time_converter_;
 
     using calling_context_ref = otf2::definition::calling_context::reference_type;
-    std::unordered_map<pid_t, calling_context_ref> thread_calling_context_refs_;
+    ThreadCctxRefMap thread_calling_context_refs_;
     pid_t current_pid_ = -1;
     calling_context_ref current_calling_context_ = calling_context_ref::undefined();
 

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -320,6 +320,7 @@ private:
 
     std::map<pid_t, otf2::definition::comm> process_comms_;
 
+    std::map<pid_t, std::string> process_names_;
     std::map<pid_t, IpCctxEntry> calling_context_tree_;
     otf2::definition::container<otf2::definition::calling_context> calling_contexts_;
     otf2::definition::container<otf2::definition::calling_context_property>

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -45,13 +45,21 @@ using IpMap = std::map<Address, RefMap>;
 
 struct IpRefEntry
 {
-    IpRefEntry(pid_t pid, otf2::definition::calling_context::reference_type r) : ref(r), pid(pid)
+    IpRefEntry(otf2::definition::calling_context::reference_type r) : ref(r)
     {
     }
 
     otf2::definition::calling_context::reference_type ref;
-    pid_t pid;
     IpMap<IpRefEntry> children;
+};
+
+struct ThreadIpRefs
+{
+    ThreadIpRefs(pid_t p) : pid(p)
+    {
+    }
+    pid_t pid;
+    IpMap<IpRefEntry> ip_refs;
 };
 
 struct IpCctxEntry
@@ -63,7 +71,7 @@ struct IpCctxEntry
     otf2::definition::calling_context cctx;
     IpMap<IpCctxEntry> children;
 };
-
+using ThreadIpRefMap = std::map<pid_t, ThreadIpRefs>;
 using IpRefMap = IpMap<IpRefEntry>;
 using IpCctxMap = IpMap<IpCctxEntry>;
 
@@ -142,7 +150,7 @@ public:
 
     otf2::definition::metric_class tracepoint_metric_class(const std::string& event_name);
     otf2::definition::mapping_table merge_calling_contexts(
-        IpRefMap& new_ips,
+        ThreadIpRefMap& new_ips, size_t num_ip_refs,
         const std::unordered_map<pid_t, otf2::definition::calling_context::reference_type>&
             thread_refs,
         std::map<pid_t, ProcessInfo>& infos);
@@ -153,7 +161,7 @@ public:
 
     void merge_ips(IpRefMap& new_children, IpCctxMap& children,
                    std::vector<uint32_t>& mapping_table, otf2::definition::calling_context parent,
-                   std::map<pid_t, ProcessInfo>& infos);
+                   std::map<pid_t, ProcessInfo>& infos, pid_t pid);
 
     void merge_thread_calling_contexts(
         const std::unordered_map<pid_t, otf2::definition::calling_context::reference_type>&

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -53,13 +53,13 @@ struct IpRefEntry
     IpMap<IpRefEntry> children;
 };
 
-struct ThreadIpRefs
+struct ThreadCctxRefs
 {
-    ThreadIpRefs(pid_t p) : pid(p)
+    ThreadCctxRefs(pid_t p, otf2::definition::calling_context::reference_type r) : pid(p), entry(r)
     {
     }
     pid_t pid;
-    IpMap<IpRefEntry> ip_refs;
+    IpRefEntry entry;
 };
 
 struct IpCctxEntry
@@ -71,7 +71,8 @@ struct IpCctxEntry
     otf2::definition::calling_context cctx;
     IpMap<IpCctxEntry> children;
 };
-using ThreadIpRefMap = std::map<pid_t, ThreadIpRefs>;
+
+using ThreadIpRefMap = std::map<pid_t, ThreadCctxRefs>;
 using IpRefMap = IpMap<IpRefEntry>;
 using IpCctxMap = IpMap<IpCctxEntry>;
 

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -103,8 +103,8 @@ private:
      *  This is a helper needed to avoid constant re-locking when adding
      *  multiple threads via #add_threads.
      **/
-    void add_thread_exclusive(pid_t tid, const std::string& name,
-                              const std::lock_guard<std::mutex>&);
+    otf2::definition::calling_context& add_thread_exclusive(pid_t tid, const std::string& name,
+                                                            const std::lock_guard<std::mutex>&);
 
     void update_process_name(pid_t pid, const otf2::definition::string& name);
     void update_thread_name(pid_t tid, const otf2::definition::string& name);
@@ -114,7 +114,7 @@ public:
 
     void add_process(pid_t pid, pid_t parent, const std::string& name = "");
 
-    void add_thread(pid_t tid, const std::string& name);
+    otf2::definition::calling_context& add_thread(pid_t tid, const std::string& name);
     void add_threads(const std::unordered_map<pid_t, std::string>& tid_map);
 
     void add_monitoring_thread(pid_t tid, const std::string& name, const std::string& group);

--- a/src/monitor/process_monitor.cpp
+++ b/src/monitor/process_monitor.cpp
@@ -41,6 +41,8 @@ void ProcessMonitor::insert_process(pid_t pid, pid_t ppid, std::string proc_name
 
 void ProcessMonitor::insert_thread(pid_t pid, pid_t tid, std::string name, bool spawn)
 {
+    trace_.add_thread(tid, name);
+
     if (config().sampling)
     {
         process_infos_.emplace(std::piecewise_construct, std::forward_as_tuple(pid),

--- a/src/perf/sample/writer.cpp
+++ b/src/perf/sample/writer.cpp
@@ -306,7 +306,7 @@ bool Writer::handle(const Reader::RecordCommType* comm)
     {
         summary().register_process(comm->pid);
 
-        comms_[comm->pid] = comm->comm;
+        comms_[comm->tid] = comm->comm;
     }
 
     return false;

--- a/src/perf/sample/writer.cpp
+++ b/src/perf/sample/writer.cpp
@@ -136,13 +136,6 @@ bool Writer::handle(const Reader::RecordSampleType* sample)
     auto tp = time_converter_(sample->time);
     tp = adjust_timepoints(tp);
 
-    if (sample->pid == 0)
-    {
-        // WHY???
-        Log::trace() << "sample from pid 0?";
-        return false;
-    }
-
     if (first_event_ && cpuid_ == -1)
     {
         first_time_point_ = std::min(first_time_point_, tp);
@@ -316,7 +309,7 @@ void Writer::end()
 {
     if (cpuid_ == -1)
     {
-        last_time_point_ = adjust_timepoints(lo2s::time::now());
+        adjust_timepoints(lo2s::time::now());
 
         // If we have never written any samples on this location, we also never
         // got to write the thread_begin event.  Make sure we do that now.

--- a/src/perf/tracepoint/switch_writer.cpp
+++ b/src/perf/tracepoint/switch_writer.cpp
@@ -27,6 +27,7 @@
 
 #include <lo2s/config.hpp>
 #include <lo2s/log.hpp>
+#include <lo2s/process_info.hpp>
 #include <lo2s/summary.hpp>
 #include <lo2s/time/time.hpp>
 #include <lo2s/trace/trace.hpp>
@@ -75,7 +76,9 @@ SwitchWriter::~SwitchWriter()
 
     if (!thread_calling_context_refs_.empty())
     {
-        const auto& mapping = trace_.merge_thread_calling_contexts(thread_calling_context_refs_);
+        std::map<pid_t, ProcessInfo> m;
+        const auto& mapping = trace_.merge_calling_contexts(thread_calling_context_refs_,
+                                                            thread_calling_context_refs_.size(), m);
         otf2_writer_ << mapping;
     }
 }
@@ -115,7 +118,7 @@ SwitchWriter::thread_calling_context_ref(pid_t tid)
     auto ret = thread_calling_context_refs_.emplace(
         std::piecewise_construct, std::forward_as_tuple(tid),
         std::forward_as_tuple(-1, thread_calling_context_refs_.size()));
-    return ret.second->first.entry.ref;
+    return ret.first->second.entry.ref;
 }
 } // namespace tracepoint
 } // namespace perf

--- a/src/perf/tracepoint/switch_writer.cpp
+++ b/src/perf/tracepoint/switch_writer.cpp
@@ -112,16 +112,10 @@ bool SwitchWriter::handle(const Reader::RecordSampleType* sample)
 otf2::definition::calling_context::reference_type
 SwitchWriter::thread_calling_context_ref(pid_t tid)
 {
-    auto it = thread_calling_context_refs_.find(tid);
-    if (it == thread_calling_context_refs_.end())
-    {
-        // If we ever merge interrupt samples and switch events we must use a common counter here!
-        otf2::definition::calling_context::reference_type ref(thread_calling_context_refs_.size());
-        auto ret = thread_calling_context_refs_.emplace(tid, ref);
-        assert(ret.second);
-        it = ret.first;
-    }
-    return it->second;
+    auto ret = thread_calling_context_refs_.emplace(
+        std::piecewise_construct, std::forward_as_tuple(tid),
+        std::forward_as_tuple(-1, thread_calling_context_refs_.size()));
+    return ret.second->first.entry.ref;
 }
 } // namespace tracepoint
 } // namespace perf

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -709,15 +709,15 @@ otf2::definition::mapping_table Trace::merge_calling_contexts(ThreadCctxRefMap& 
         {
             if (tid != 0)
             {
-                // Threads rarely have their own name, in that case use the processes name
-                auto process_cctx = calling_context_tree_.find(local_thread_cctx.second.pid);
-                if(process_cctx == calling_context_tree_.end())
+                // Threads rarely have their own name, in that case, use the process' name
+                auto process_name = process_names_.find(local_thread_cctx.second.pid);
+                if (process_name == process_names_.end())
                 {
-                        add_thread(tid, "<unknown>");
+                    add_thread(tid, "<unknown thread>");
                 }
                 else
                 {
-                    add_thread(tid,  process_cctx->second.cctx.region().name().str());
+                    add_thread(tid, process_name->second);
                 }
             }
             else
@@ -746,6 +746,9 @@ otf2::definition::mapping_table Trace::merge_calling_contexts(ThreadCctxRefMap& 
 void Trace::add_thread_exclusive(pid_t tid, const std::string& name,
                                  const std::lock_guard<std::mutex>&)
 {
+    process_names_.emplace(std::piecewise_construct, std::forward_as_tuple(tid),
+                           std::forward_as_tuple(name));
+
     auto iname = intern((boost::format("%s (%d)") % name % tid).str());
     auto ret = regions_thread_.emplace(
         std::piecewise_construct, std::forward_as_tuple(tid),

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -704,20 +704,25 @@ otf2::definition::mapping_table Trace::merge_calling_contexts(ThreadCctxRefMap& 
         auto local_ref = local_thread_cctx.second.entry.ref;
 
         auto global_thread_cctx = calling_context_tree_.find(tid);
+
         if (global_thread_cctx == calling_context_tree_.end())
         {
-            // Threads rarely have their own name, in that case use the process name
-            global_thread_cctx = calling_context_tree_.find(local_thread_cctx.second.pid);
-            if (global_thread_cctx == calling_context_tree_.end())
+            if (tid != 0)
             {
-                if (tid != 0)
+                // Threads rarely have their own name, in that case use the processes name
+                auto process_cctx = calling_context_tree_.find(local_thread_cctx.second.pid);
+                if(process_cctx == calling_context_tree_.end())
                 {
-                    add_thread(tid, "<unknown>");
+                        add_thread(tid, "<unknown>");
                 }
                 else
                 {
-                    add_thread(tid, "<idle>");
+                    add_thread(tid,  process_cctx->second.cctx.region().name().str());
                 }
+            }
+            else
+            {
+                add_thread(tid, "<idle>");
             }
             global_thread_cctx = calling_context_tree_.find(tid);
         }

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -714,6 +714,7 @@ otf2::definition::mapping_table Trace::merge_calling_contexts(ThreadCctxRefMap& 
             {
                 add_thread(tid, "<idle>");
             }
+            global_thread_cctx = calling_context_tree_.find(tid);
         }
         mappings.at(local_ref) = global_thread_cctx->second.cctx.ref();
 

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -706,13 +706,18 @@ otf2::definition::mapping_table Trace::merge_calling_contexts(ThreadCctxRefMap& 
         auto global_thread_cctx = calling_context_tree_.find(tid);
         if (global_thread_cctx == calling_context_tree_.end())
         {
-            if (tid != 0)
+            // Threads rarely have their own name, in that case use the process name
+            global_thread_cctx = calling_context_tree_.find(local_thread_cctx.second.pid);
+            if (global_thread_cctx == calling_context_tree_.end())
             {
-                add_thread(tid, "<unknown>");
-            }
-            else
-            {
-                add_thread(tid, "<idle>");
+                if (tid != 0)
+                {
+                    add_thread(tid, "<unknown>");
+                }
+                else
+                {
+                    add_thread(tid, "<idle>");
+                }
             }
             global_thread_cctx = calling_context_tree_.find(tid);
         }


### PR DESCRIPTION
This fixes #112 

This PR adds thread nodes to the calling context tree which serve as parents to the calling context nodes, which previously were directly attached to the trees root

This also fixes an issue in call graph mode (-g) where the calling context reference number was not increased when inner calling context nodes where inserted

[trace_cctx.zip](https://cloudstore.zih.tu-dresden.de/index.php/s/jnoAqmOWoih9r3h) contains a small example trace showcasing the new feature.