### PR TITLE
Add a special "pebs" clockid

### DIFF
--- a/include/lo2s/config.hpp
+++ b/include/lo2s/config.hpp
@@ -81,6 +81,7 @@ struct Config
 
     // time synchronization
     bool use_clockid;
+    bool use_pebs;
     clockid_t clockid;
     // x86_energy
     bool use_x86_energy;

--- a/include/lo2s/perf/sample/reader.hpp
+++ b/include/lo2s/perf/sample/reader.hpp
@@ -84,11 +84,12 @@ protected:
         Log::debug() << "initializing event_reader for tid: " << tid
                      << ", enable_on_exec: " << enable_on_exec;
         struct perf_event_attr perf_attr = common_perf_event_attrs();
-
-        if(config().use_pebs)
+#ifdef USE_PERF_CLOCKID
+        if (config().use_pebs)
         {
             perf_attr.use_clockid = 0;
         }
+#endif
 
         perf_attr.exclude_kernel = config().exclude_kernel;
         perf_attr.sample_period = config().sampling_period;

--- a/include/lo2s/perf/sample/reader.hpp
+++ b/include/lo2s/perf/sample/reader.hpp
@@ -85,6 +85,11 @@ protected:
                      << ", enable_on_exec: " << enable_on_exec;
         struct perf_event_attr perf_attr = common_perf_event_attrs();
 
+        if(config().use_pebs)
+        {
+            perf_attr.use_clockid = 0;
+        }
+
         perf_attr.exclude_kernel = config().exclude_kernel;
         perf_attr.sample_period = config().sampling_period;
 

--- a/include/lo2s/time/time.hpp
+++ b/include/lo2s/time/time.hpp
@@ -153,6 +153,10 @@ private:
             CLOCK_BOOTTIME_ALARM,
         },
 #endif
+        {
+            "pebs",
+            -1,
+        },
     };
 };
 

--- a/include/lo2s/time/time.hpp
+++ b/include/lo2s/time/time.hpp
@@ -153,11 +153,13 @@ private:
             CLOCK_BOOTTIME_ALARM,
         },
 #endif
+#ifdef HAVE_CLOCK_MONOTONIC_RAW
         {
             "pebs",
             -1,
         },
     };
+#endif
 };
 
 inline otf2::chrono::time_point now()

--- a/man/lo2s.1.pod
+++ b/man/lo2s.1.pod
@@ -177,6 +177,10 @@ minimize B<lo2s>'s overhead for your measurements.
 Set the internal reference clock used as a source of timestamps.
 See B<--list-clockids> for a list of supported arguments.
 
+Beyond standard clocks lo2s also supports a special "pebs" clock, which will
+give the same timestamps as "monotonic-raw", but is set up in a slightly different
+way to support the large PEBS feature of newer (Skylake+) Intel processors
+
 =item B<--list-clockids>
 
 List the names of clocks that can be used as I<CLOCKID> argument.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -497,6 +497,14 @@ void parse_program_options(int argc, const char** argv)
     config.use_clockid = false;
     try
     {
+        //large PEBS only works when the clockid isn't set, however the internal clock
+        //large PEBS uses should be equal to monotonic-raw, so use monotonic-raw outside
+        //of pebs and everything should be in sync
+        if(requested_clock_name == "pebs")
+        {
+            requested_clock_name = "monotonic-raw";
+            config.use_pebs = true;
+        }
         const auto& clock = lo2s::time::ClockProvider::get_clock_by_name(requested_clock_name);
 
         lo2s::Log::debug() << "Using clock \'" << clock.name << "\'.";

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -497,10 +497,10 @@ void parse_program_options(int argc, const char** argv)
     config.use_clockid = false;
     try
     {
-        //large PEBS only works when the clockid isn't set, however the internal clock
-        //large PEBS uses should be equal to monotonic-raw, so use monotonic-raw outside
-        //of pebs and everything should be in sync
-        if(requested_clock_name == "pebs")
+        // large PEBS only works when the clockid isn't set, however the internal clock
+        // large PEBS uses should be equal to monotonic-raw, so use monotonic-raw outside
+        // of pebs and everything should be in sync
+        if (requested_clock_name == "pebs")
         {
             requested_clock_name = "monotonic-raw";
             config.use_pebs = true;


### PR DESCRIPTION
Add a special "pebs" clock, which will give the same timestamps as "monotonic-raw", but is set up in a slightly different way to support the large PEBS feature of newer (Skylake+) Intel processors