### PR TITLE
List x86_adapt cpu knobs only if they are not node knobs, also print description

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,10 +103,10 @@ matrix:
 
 cache:
   directories:
-    - ${TRAVIS_BUILD_DIR}/deps/otf2-2.1
+    - ${TRAVIS_BUILD_DIR}/deps/otf2-2.2
 
 install:
-  - OTF2_VERSION=2.1 # Update cache too when changing this!
+  - OTF2_VERSION=2.2 # Update cache too when changing this!
   - OTF2_DIR=${TRAVIS_BUILD_DIR}/deps/otf2-${OTF2_VERSION}
   - |
     if [ -z "$(ls -A ${OTF2_DIR})" ]; then

--- a/include/lo2s/io.hpp
+++ b/include/lo2s/io.hpp
@@ -36,6 +36,7 @@
 #include <map>
 #include <string>
 
+#include <boost/algorithm/string.hpp>
 #include <lo2s/time/time.hpp>
 
 namespace lo2s
@@ -127,8 +128,15 @@ operator<<(std::ostream& os, const ArgumentList<std::map<std::string, std::strin
         }
         for (auto it = list.first_; it != list.last_; ++it)
         {
-            os << "  " << std::left << std::setw(max_string_length + 2) << it->first << it->second
+            std::vector<std::string> lines;
+            boost::split(lines, it->second, [](char c) { return c == '\n'; });
+            os << "  " << std::left << std::setw(max_string_length + 2) << it->first << lines[0]
                << '\n';
+            lines.erase(lines.begin());
+            for (const auto& line : lines)
+            {
+                os << "  " << std::left << std::setw(max_string_length + 2) << "" << line << "\n";
+            }
         }
     }
     else

--- a/include/lo2s/io.hpp
+++ b/include/lo2s/io.hpp
@@ -30,8 +30,11 @@
 
 #pragma once
 
+#include <algorithm>
+#include <iomanip>
 #include <iostream>
 #include <string>
+#include <map>
 
 #include <lo2s/time/time.hpp>
 
@@ -108,5 +111,31 @@ inline std::ostream& operator<<(std::ostream& os, const ArgumentList<InputIterat
     os << '\n';
     return os;
 }
+
+#ifdef HAVE_X86_ADAPT
+template<>
+inline std::ostream& operator<<(std::ostream& os, const ArgumentList<std::map<std::string, std::string>::iterator>& list)
+{
+    os << "\nList of " << list.description_ << ":\n\n";
+    if(list.first_ != list.last_)
+    {
+        size_t max_string_length = 0;
+        for (auto it = list.first_; it != list.last_; ++it)
+        {
+            max_string_length = std::max(max_string_length, it->first.length());
+        }
+        for (auto it = list.first_; it != list.last_; ++it)
+        {
+            os << "  " << std::left << std::setw(max_string_length + 2) << it->first << it->second << '\n';
+        }
+    }
+    else
+    {
+        os << "  (none available)\n";
+    }
+    os << '\n';
+    return os;
+}
+#endif
 } // namespace io
 } // namespace lo2s

--- a/include/lo2s/io.hpp
+++ b/include/lo2s/io.hpp
@@ -33,8 +33,8 @@
 #include <algorithm>
 #include <iomanip>
 #include <iostream>
-#include <string>
 #include <map>
+#include <string>
 
 #include <lo2s/time/time.hpp>
 
@@ -113,11 +113,12 @@ inline std::ostream& operator<<(std::ostream& os, const ArgumentList<InputIterat
 }
 
 #ifdef HAVE_X86_ADAPT
-template<>
-inline std::ostream& operator<<(std::ostream& os, const ArgumentList<std::map<std::string, std::string>::iterator>& list)
+template <>
+inline std::ostream&
+operator<<(std::ostream& os, const ArgumentList<std::map<std::string, std::string>::iterator>& list)
 {
     os << "\nList of " << list.description_ << ":\n\n";
-    if(list.first_ != list.last_)
+    if (list.first_ != list.last_)
     {
         size_t max_string_length = 0;
         for (auto it = list.first_; it != list.last_; ++it)
@@ -126,7 +127,8 @@ inline std::ostream& operator<<(std::ostream& os, const ArgumentList<std::map<st
         }
         for (auto it = list.first_; it != list.last_; ++it)
         {
-            os << "  " << std::left << std::setw(max_string_length + 2) << it->first << it->second << '\n';
+            os << "  " << std::left << std::setw(max_string_length + 2) << it->first << it->second
+               << '\n';
         }
     }
     else

--- a/include/lo2s/metric/x86_adapt/knobs.hpp
+++ b/include/lo2s/metric/x86_adapt/knobs.hpp
@@ -1,0 +1,74 @@
+/*
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2017,
+ *    Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <x86_adapt_cxx/exception.hpp>
+#include <x86_adapt_cxx/x86_adapt.hpp>
+
+#include <algorithm>
+
+namespace lo2s
+{
+namespace metric
+{
+namespace x86_adapt
+{
+
+std::map<std::string, std::string> x86_adapt_node_knobs()
+{
+    std::map<std::string, std::string> knobs;
+    try
+    {
+        ::x86_adapt::x86_adapt x86_adapt;
+        auto node_cfg_items = x86_adapt.node_configuration_items();
+
+        for (const auto& item : node_cfg_items)
+        {
+            knobs.emplace(std::piecewise_construct, std::forward_as_tuple(item.name()),
+                          std::forward_as_tuple(item.description()));
+        }
+    }
+    catch (const ::x86_adapt::x86_adapt_error& e)
+    {
+        Log::debug() << "Failed to access x86_adapt node knobs! (error: " << e.what() << ")";
+    }
+    return knobs;
+}
+
+std::map<std::string, std::string> x86_adapt_cpu_knobs()
+{
+    std::map<std::string, std::string> node_knobs = x86_adapt_node_knobs();
+    std::map<std::string, std::string> cpu_knobs;
+    ::x86_adapt::x86_adapt x86_adapt;
+
+    auto cpu_cfg_items = x86_adapt.cpu_configuration_items();
+    for (const auto& item : cpu_cfg_items)
+    {
+        cpu_knobs.emplace(std::piecewise_construct, std::forward_as_tuple(item.name()),
+                          std::forward_as_tuple(item.description()));
+    }
+    std::set_difference(cpu_knobs.begin(), cpu_knobs.end(), node_knobs.begin(), node_knobs.end(),
+                        std::inserter(cpu_knobs, cpu_knobs.end()), cpu_knobs.value_comp());
+    return cpu_knobs;
+}
+} // namespace x86_adapt
+} // namespace metric
+} // namespace lo2s

--- a/lib/x86_adapt/include/x86_adapt_cxx/configuration_items.hpp
+++ b/lib/x86_adapt/include/x86_adapt_cxx/configuration_items.hpp
@@ -85,7 +85,7 @@ public:
             return configuration_item(type_, id_);
         }
 
-        bool operator!=(const iterator& other)
+        bool operator!=(const iterator& other) const
         {
             return id_ != other.id_;
         }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -34,14 +34,12 @@
 #include <nitro/lang/optional.hpp>
 
 #ifdef HAVE_X86_ADAPT
-#include <x86_adapt_cxx/exception.hpp>
-#include <x86_adapt_cxx/x86_adapt.hpp>
+#include <lo2s/metric/x86_adapt/knobs.hpp>
 #endif
 
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
 
-#include <algorithm>
 #include <cstdlib>
 #include <ctime>   // for CLOCK_* macros
 #include <iomanip> // for std::setw
@@ -85,73 +83,6 @@ static inline void list_arguments_sorted(std::ostream& os, const std::string& de
 {
     std::sort(items.begin(), items.end());
     os << io::make_argument_list(description, items.begin(), items.end());
-}
-static inline std::map<std::string, std::string> x86_adapt_node_knobs()
-{
-    std::map<std::string, std::string> knobs;
-#ifdef HAVE_X86_ADAPT
-    try
-    {
-        ::x86_adapt::x86_adapt x86_adapt;
-        auto node_cfg_items = x86_adapt.node_configuration_items();
-
-        for (const auto& item : node_cfg_items)
-        {
-            knobs.emplace(std::piecewise_construct, std::forward_as_tuple(item.name()),
-                          std::forward_as_tuple(item.description()));
-        }
-    }
-    catch (const ::x86_adapt::x86_adapt_error& e)
-    {
-        Log::debug() << "Failed to access x86_adapt node knobs! (error: " << e.what() << ")";
-    }
-#endif
-    return knobs;
-}
-static inline void list_x86_adapt_node_knobs(std::ostream& os)
-{
-#ifdef HAVE_X86_ADAPT
-    std::map<std::string, std::string> knobs = x86_adapt_node_knobs();
-    os << io::make_argument_list("x86_adapt node knobs", knobs.begin(), knobs.end());
-#else
-    (void)os;
-    std::cerr << "lo2s was built without support for x86_adapt; cannot read node knobs.\n";
-    std::exit(EXIT_FAILURE);
-#endif
-}
-
-static inline void list_x86_adapt_cpu_knobs(std::ostream& os)
-{
-#ifdef HAVE_X86_ADAPT
-    std::map<std::string, std::string> cpu_knobs;
-    std::map<std::string, std::string> node_knobs = x86_adapt_node_knobs();
-    std::map<std::string, std::string> cpu_only_knobs;
-    try
-    {
-        ::x86_adapt::x86_adapt x86_adapt;
-        auto cpu_cfg_items = x86_adapt.cpu_configuration_items();
-
-        for (const auto& item : cpu_cfg_items)
-        {
-            cpu_knobs.emplace(std::piecewise_construct, std::forward_as_tuple(item.name()),
-                              std::forward_as_tuple(item.description()));
-        }
-        std::set_difference(cpu_knobs.begin(), cpu_knobs.end(), node_knobs.begin(),
-                            node_knobs.end(), std::inserter(cpu_only_knobs, cpu_only_knobs.end()),
-                            cpu_knobs.value_comp());
-    }
-    catch (const ::x86_adapt::x86_adapt_error& e)
-    {
-        Log::debug() << "Failed to access x86_adapt CPU knobs! (error: " << e.what() << ")";
-    }
-
-    os << io::make_argument_list("x86_adapt CPU knobs", cpu_only_knobs.begin(),
-                                 cpu_only_knobs.end());
-#else
-    (void)os;
-    std::cerr << "lo2s was built without support for x86_adapt; cannot read CPU knobs.\n";
-    std::exit(EXIT_FAILURE);
-#endif
 }
 
 static inline void print_version(std::ostream& os)
@@ -460,8 +391,20 @@ void parse_program_options(int argc, const char** argv)
 
         if (list_knobs)
         {
-            list_x86_adapt_cpu_knobs(std::cout);
-            list_x86_adapt_node_knobs(std::cout);
+#ifdef HAVE_X86_ADAPT
+
+            std::map<std::string, std::string> node_knobs =
+                metric::x86_adapt::x86_adapt_node_knobs();
+            std::cout << io::make_argument_list("x86_adapt node knobs", node_knobs.begin(),
+                                                node_knobs.end());
+
+            std::map<std::string, std::string> cpu_knobs = metric::x86_adapt::x86_adapt_cpu_knobs();
+            std::cout << io::make_argument_list("x86_adapt CPU knobs", cpu_knobs.begin(),
+                                                cpu_knobs.end());
+#else
+            std::cerr << "lo2s was built without support for x86_adapt; cannot read node knobs.\n";
+            std::exit(EXIT_FAILURE);
+#endif
             std::exit(EXIT_SUCCESS);
         }
     }

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -41,6 +41,7 @@
 #include <boost/optional.hpp>
 #include <boost/program_options.hpp>
 
+#include <algorithm>
 #include <cstdlib>
 #include <ctime>   // for CLOCK_* macros
 #include <iomanip> // for std::setw
@@ -85,27 +86,32 @@ static inline void list_arguments_sorted(std::ostream& os, const std::string& de
     std::sort(items.begin(), items.end());
     os << io::make_argument_list(description, items.begin(), items.end());
 }
-
-static inline void list_x86_adapt_cpu_knobs(std::ostream& os)
+static inline std::map<std::string, std::string> x86_adapt_cpu_knobs()
 {
+    std::map<std::string, std::string> knobs;
 #ifdef HAVE_X86_ADAPT
-    std::vector<std::string> knobs;
     try
     {
         ::x86_adapt::x86_adapt x86_adapt;
         auto cpu_cfg_items = x86_adapt.cpu_configuration_items();
 
-        knobs.reserve(cpu_cfg_items.size());
         for (const auto& item : cpu_cfg_items)
         {
-            knobs.emplace_back(item.name());
+            knobs.emplace(std::piecewise_construct, std::forward_as_tuple(item.name()), std::forward_as_tuple(item.description()));
+    
         }
     }
     catch (const ::x86_adapt::x86_adapt_error& e)
     {
         Log::debug() << "Failed to access x86_adapt CPU knobs! (error: " << e.what() << ")";
     }
-
+#endif
+    return knobs;
+}
+static inline void list_x86_adapt_cpu_knobs(std::ostream& os)
+{
+#ifdef HAVE_X86_ADAPT
+    std::map<std::string, std::string> knobs = x86_adapt_cpu_knobs();
     os << io::make_argument_list("x86_adapt CPU knobs", knobs.begin(), knobs.end());
 #else
     (void)os;
@@ -117,24 +123,30 @@ static inline void list_x86_adapt_cpu_knobs(std::ostream& os)
 static inline void list_x86_adapt_node_knobs(std::ostream& os)
 {
 #ifdef HAVE_X86_ADAPT
-    std::vector<std::string> knobs;
+    std::map<std::string, std::string> node_knobs;
+    std::map<std::string, std::string> cpu_knobs = x86_adapt_cpu_knobs();
+    std::map<std::string, std::string> node_only_knobs;
     try
     {
         ::x86_adapt::x86_adapt x86_adapt;
         auto node_cfg_items = x86_adapt.node_configuration_items();
 
-        knobs.reserve(node_cfg_items.size());
         for (const auto& item : node_cfg_items)
         {
-            knobs.emplace_back(item.name());
+            node_knobs.emplace(std::piecewise_construct, std::forward_as_tuple(item.name()), std::forward_as_tuple(item.description()));
         }
+        std::set_difference(
+                node_knobs.begin(), node_knobs.end(),
+                cpu_knobs.begin(), cpu_knobs.end(),
+                std::inserter(node_only_knobs, std::next(node_only_knobs.begin()))
+                );
     }
     catch (const ::x86_adapt::x86_adapt_error& e)
     {
         Log::debug() << "Failed to access x86_adapt node knobs! (error: " << e.what() << ")";
     }
 
-    os << io::make_argument_list("x86_adapt node knobs", knobs.begin(), knobs.end());
+    os << io::make_argument_list("x86_adapt node knobs", node_only_knobs.begin(), node_only_knobs.end());
 #else
     (void)os;
     std::cerr << "lo2s was built without support for x86_adapt; cannot read node knobs.\n";


### PR DESCRIPTION
With this PR, CPU x86_adapt events are only listed if they aren't available as a node event, furthermore print a description for every event

This fixes #125 