### PR TITLE
Introduce time interval based metric recording

### DIFF
--- a/man/lo2s.1.pod
+++ b/man/lo2s.1.pod
@@ -276,32 +276,23 @@ Enable a set of default events for metric recording.
 
 =item B<--metric-leader> I<EVENT>
 
-The leading metric event that controls how often metric events are read from
-shared buffers.
+The leading metric event when using event count based metric recording, use in conjunction with
+B<--metric-count> to control the number of events that have to elapse before a metric read is performed
 
 =item B<--metric-count> I<N>
 
-Instruct B<lo2s> to read metrics from kernel buffers every time I<N> metric
-leader events (see B<--metric-leader>) have occured.
+Controls the number of events that have to elapse before a metric read is performed by the kernel when using event
+count based metric recording with B<--metric-leader>.
 Higher values reduce the overhead incurred by B<lo2s>, but may lead to the
 kernel buffers overflowing, in which case B<lo2s> will miss some metric events.
 Use in conjunction with B<-m> to increase internal buffer sizes to reduce
 overhead and risk of missing events.
+This can only be used in conjunction with B<--metric-leader>
 
 =item B<--metric-frequency> I<HZ>
 
-Instruct B<lo2s> to read metrics with a frequency of approximately I<HZ> Hz,
-i.e. 1 / I<HZ> times per second.
-
-=over 6
-
-=item B<NOTE:>
-
-The quality of this approximation depends on kernel heuristics and the selected
-leading metric event (see B<--metric-leader>).
-Prefer specifying B<--metric-count> over this option.
-
-=back
+This is used to set the frequency in time interval based metric recording, i.e. one readout every 1/I<HZ> seconds.
+Can not be used in conjunction with B<--metric-leader>
 
 =back
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -572,10 +572,16 @@ void parse_program_options(int argc, const char** argv)
         }
         catch (const perf::EventProvider::InvalidEvent& e)
         {
-            Log::warn()
-                << "cpu-clock isn't available, try using a custom --metric-leader like cpu-cycles";
-            // Will be handled later in collect_requested_events
-            config.metric_leader.clear();
+            Log::warn() << "cpu-clock isn't available, trying to use a fallback event";
+            try
+            {
+                config.metric_leader = perf::EventProvider::get_default_metric_leader_event().name;
+            }
+            catch (const perf::EventProvider::InvalidEvent& e)
+            {
+                // Will be handled later in collect_requested_events
+                config.metric_leader.clear();
+            }
         }
         config.metric_use_frequency = true;
         config.metric_frequency = metric_frequency;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -320,11 +320,11 @@ void parse_program_options(int argc, const char** argv)
         ("metric-count",
             po::value(&metric_count)
                 ->value_name("N"),
-            "Number of metric leader events to elapse before reading metric buffer. Prefer this setting over --metric-freqency")
+            "Number of metric leader events to elapse before reading metric buffer. Has to be used in conjunction with --metric-leader")
         ("metric-frequency",
             po::value(&metric_frequency)
                 ->value_name("HZ"),
-            "Number of metric buffer reads per second. When given, it will be used to set an approximate value for --metric-count");
+            "Number of metric buffer reads per second. Can not be used with --metric-leader");
 
     x86_adapt_options.add_options()
         ("x86-adapt-knob,x",
@@ -551,41 +551,38 @@ void parse_program_options(int argc, const char** argv)
         config.disassemble = false;
 #endif
     }
+    if (vm.count("metric-count") && !vm.count("metric-leader"))
+    {
+        Log::error() << "--metric-count can only be used in conjunction with a --metric-leader";
+        std::exit(EXIT_FAILURE);
+    }
 
-    // Determine a suitable default metric leader event if none was given on the
-    // command line.
+    if (vm.count("metric-frequency") && vm.count("metric-leader"))
+    {
+        Log::error() << "--metric-frequency can only be used with the default --metric-leader";
+        std::exit(EXIT_FAILURE);
+    }
+    // Use time interval based metric recording as a default
     if (!vm.count("metric-leader"))
     {
-        Log::debug() << "guessing metric leader event as none was given by the user...";
+        Log::debug() << "checking if cpu-clock is available...";
         try
         {
-            config.metric_leader = perf::EventProvider::get_default_metric_leader_event().name;
+            config.metric_leader = perf::EventProvider::get_event_by_name("cpu-clock").name;
         }
         catch (const perf::EventProvider::InvalidEvent& e)
         {
+            Log::warn() << "cpu-clock isn't available, try using a custom metric leader";
             // Will be handled later in collect_requested_events
             config.metric_leader.clear();
         }
-    }
-
-    if (vm.count("metric-count"))
-    {
-        if (vm.count("metric-frequency"))
-        {
-            lo2s::Log::error()
-                << "Cannot specify metric read period and frequency at the same time.";
-            std::exit(EXIT_FAILURE);
-        }
-        else
-        {
-            config.metric_use_frequency = false;
-            config.metric_count = metric_count;
-        }
+        config.metric_use_frequency = true;
+        config.metric_frequency = metric_frequency;
     }
     else
     {
-        config.metric_use_frequency = true;
-        config.metric_frequency = metric_frequency;
+        config.metric_use_frequency = false;
+        config.metric_count = metric_count;
     }
 
     config.exclude_kernel = false;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -572,7 +572,8 @@ void parse_program_options(int argc, const char** argv)
         }
         catch (const perf::EventProvider::InvalidEvent& e)
         {
-            Log::warn() << "cpu-clock isn't available, try using a custom metric leader";
+            Log::warn()
+                << "cpu-clock isn't available, try using a custom --metric-leader like cpu-cycles";
             // Will be handled later in collect_requested_events
             config.metric_leader.clear();
         }

--- a/src/perf/event_provider.cpp
+++ b/src/perf/event_provider.cpp
@@ -269,7 +269,6 @@ const CounterDescription& EventProvider::get_default_metric_leader_event()
              "ref-cycles",
              "cpu-cycles",
              "bus-cycles",
-             "cpu-clock",
          })
     {
         try


### PR DESCRIPTION
This PR is still somewhat of a request for comments

Time interval based metric recording (TIBMR) is the new default
`--metric-frequency` controls the frequency in TIBMR
Event count based metric recording (ECBMR) is now only used if a `--metric-leader`
is given
`--metric-count` controls the number of events that have to elapse in
ECBMR

`--metric-frequency` can only be used in TIBMR
`--metric-count` can only be used with a `--metric-leader` in ECBMR

Both can  be ommitted as both have default values

When cpu-clock isn't available we try to fallback to the old default metric leaders and print a warning

This fixes #121 