### PR TITLE
early FD cleanup

### DIFF
--- a/include/lo2s/perf/sample/reader.hpp
+++ b/include/lo2s/perf/sample/reader.hpp
@@ -208,7 +208,7 @@ protected:
         }
         catch (...)
         {
-            close(fd_);
+            close();
             throw;
         }
     }
@@ -231,7 +231,17 @@ protected:
                            "extend to prevent the kernel from doing that"
                            " or you can increase your sampling period.";
         }
-        close(fd_);
+        close();
+    }
+
+public:
+    void close()
+    {
+        if (fd_ != -1)
+        {
+            ::close(fd_);
+            fd_ = -1;
+        }
     }
 
 protected:

--- a/src/monitor/thread_monitor.cpp
+++ b/src/monitor/thread_monitor.cpp
@@ -75,6 +75,8 @@ void ThreadMonitor::stop()
 
     stop_pipe_.write();
     thread_.join();
+    stop_pipe_.close();
+    sample_writer_->close();
 }
 
 void ThreadMonitor::check_affinity(bool force)


### PR DESCRIPTION
for #137 
close stop pipe when ThreadMonitor is stopped
close fd of perf::sample::Reader early