### PR TITLE
Also write Calling Context Enter/Leaves in process_mode

### DIFF
--- a/include/lo2s/perf/event_reader.hpp
+++ b/include/lo2s/perf/event_reader.hpp
@@ -106,6 +106,14 @@ public:
         uint64_t time;
         // struct sample_id sample_id;
     };
+    struct RecordSwitchType
+    {
+        struct perf_event_header header;
+        uint32_t pid, tid;
+        uint64_t time;
+        uint32_t cpu, res;
+        // struct sample_id sample_id;
+    };
     struct RecordSwitchCpuWideType
     {
         struct perf_event_header header;
@@ -216,6 +224,9 @@ public:
                     stop = crtp_this->handle((const RecordMmap2Type*)event_header_p);
                     break;
 #ifdef USE_PERF_RECORD_SWITCH
+                case PERF_RECORD_SWITCH:
+                    stop = crtp_this->handle((const RecordSwitchType*)event_header_p);
+                    break;
                 case PERF_RECORD_SWITCH_CPU_WIDE:
                     stop = crtp_this->handle((const RecordSwitchCpuWideType*)event_header_p);
                     break;

--- a/include/lo2s/perf/sample/reader.hpp
+++ b/include/lo2s/perf/sample/reader.hpp
@@ -124,10 +124,7 @@ protected:
         perf_attr.comm = 1;
 
 #ifdef USE_PERF_RECORD_SWITCH
-        if (cpu != -1)
-        {
-            perf_attr.context_switch = 1;
-        }
+        perf_attr.context_switch = 1;
 #endif
         // We need this to get all mmap_events
         if (enable_on_exec)

--- a/include/lo2s/perf/sample/writer.hpp
+++ b/include/lo2s/perf/sample/writer.hpp
@@ -86,6 +86,8 @@ private:
 
     void update_current_thread(pid_t pid, pid_t tid, otf2::chrono::time_point tp);
     void leave_current_thread(pid_t tid, otf2::chrono::time_point tp);
+    void update_calling_context(pid_t pid, pid_t tid, otf2::chrono::time_point tp, bool switch_out);
+
     otf2::chrono::time_point adjust_timepoints(otf2::chrono::time_point tp);
 
     pid_t pid_;

--- a/include/lo2s/perf/sample/writer.hpp
+++ b/include/lo2s/perf/sample/writer.hpp
@@ -105,7 +105,6 @@ private:
     trace::ThreadCctxRefMap local_cctx_refs_;
     size_t next_cctx_ref_ = 0;
 
-    trace::ThreadCctxRefMap::value_type thread_monitoring_cctx_refs_;
     trace::ThreadCctxRefMap::value_type* current_thread_cctx_refs_ = nullptr;
 
     RawMemoryMapCache cached_mmap_events_;

--- a/include/lo2s/perf/sample/writer.hpp
+++ b/include/lo2s/perf/sample/writer.hpp
@@ -65,6 +65,7 @@ public:
     bool handle(const Reader::RecordCommType* comm);
 #ifdef USE_PERF_RECORD_SWITCH
     bool handle(const Reader::RecordSwitchCpuWideType* context_switch);
+    bool handle(const Reader::RecordSwitchType* context_switch);
 #endif
 
     otf2::writer::local& otf2_writer()

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -183,6 +183,14 @@ public:
         return system_tree_root_node_;
     }
 
+    void adjust_stop_time(otf2::chrono::time_point tp)
+    {
+        if (tp > stopping_time_)
+        {
+            stopping_time_ = tp;
+        }
+    }
+
     otf2::definition::regions_group regions_group_executable(const std::string& name);
     otf2::definition::regions_group regions_group_monitoring(const std::string& name);
     otf2::definition::comm process_comm(pid_t pid);

--- a/src/perf/sample/writer.cpp
+++ b/src/perf/sample/writer.cpp
@@ -66,12 +66,6 @@ Writer::Writer(pid_t pid, pid_t tid, int cpu, monitor::MainMonitor& Monitor, tra
 {
     // Must monitor either a CPU or (exclusive) a tid/pid
     assert((cpu == -1) ^ (pid == -1 && tid == -1));
-    if (tid != -1)
-    {
-        // TODO create empty cctx root for thread monitoring
-        thread_monitoring_cctx_refs_.second.pid = pid;
-        current_thread_cctx_refs_ = &thread_monitoring_cctx_refs_;
-    }
 }
 
 Writer::~Writer()
@@ -136,13 +130,6 @@ bool Writer::handle(const Reader::RecordSampleType* sample)
     auto tp = time_converter_(sample->time);
     tp = adjust_timepoints(tp);
 
-    if (first_event_ && cpuid_ == -1)
-    {
-        first_time_point_ = std::min(first_time_point_, tp);
-        otf2_writer_ << otf2::event::thread_begin(first_time_point_, trace_.process_comm(pid_), -1);
-        first_event_ = false;
-    }
-
     update_current_thread(sample->pid, sample->tid, tp);
 
     cpuid_metric_event_.timestamp(tp);
@@ -174,29 +161,12 @@ bool Writer::handle(const Reader::RecordMmapType* mmap_event)
 
 void Writer::update_current_thread(pid_t pid, pid_t tid, otf2::chrono::time_point tp)
 {
+    if (first_event_ && cpuid_ == -1)
+    {
+        otf2_writer_ << otf2::event::thread_begin(tp, trace_.process_comm(pid_), -1);
+        first_event_ = false;
+    }
 
-    // if (tid_ != -1)
-    // {
-    //     if (tid != tid_ || pid != pid_)
-    //     {
-    //         Log::warn() << "Sample outside of monitored process";
-    //     }
-    //     assert(tid == tid_ && pid == pid_);
-    //
-    //     auto ret = local_cctx_refs_.emplace(std::piecewise_construct, std::forward_as_tuple(tid),
-    //                                         std::forward_as_tuple(pid, next_cctx_ref_));
-    //
-    //     if (ret.second)
-    //     {
-    //         next_cctx_ref_++;
-    //     }
-    //
-    //     current_thread_cctx_refs_ = &(*ret.first);
-    //     return;
-    // }
-    tp = adjust_timepoints(tp);
-
-    // CPU monitoring
     if (current_thread_cctx_refs_ && current_thread_cctx_refs_->first == tid)
     {
         // current thread is unchanged
@@ -222,13 +192,6 @@ void Writer::update_current_thread(pid_t pid, pid_t tid, otf2::chrono::time_poin
 
 void Writer::leave_current_thread(pid_t tid, otf2::chrono::time_point tp)
 {
-    // if (tid_ != -1)
-    // {
-    //     // should not happen (TM)
-    //     assert(false);
-    //     return;
-    // }
-
     if (current_thread_cctx_refs_ == nullptr)
     {
         // Already not in a thread
@@ -239,8 +202,6 @@ void Writer::leave_current_thread(pid_t tid, otf2::chrono::time_point tp)
     {
         Log::debug() << "inconsistent leave thread"; // will probably set to trace sooner or later
     }
-    tp = adjust_timepoints(tp);
-
     otf2_writer_.write_calling_context_leave(tp, current_thread_cctx_refs_->second.entry.ref);
     current_thread_cctx_refs_ = nullptr;
 }
@@ -263,15 +224,10 @@ bool Writer::handle(const Reader::RecordSwitchCpuWideType* context_switch)
 {
     assert(cpuid_ != -1);
     auto tp = time_converter_(context_switch->time);
+    tp = adjust_timepoints(tp);
 
-    if (context_switch->header.misc & PERF_RECORD_MISC_SWITCH_OUT)
-    {
-        leave_current_thread(context_switch->tid, tp);
-    }
-    else
-    {
-        update_current_thread(context_switch->pid, context_switch->tid, tp);
-    }
+    update_calling_context(context_switch->pid, context_switch->tid, tp,
+                           context_switch->header.misc & PERF_RECORD_MISC_SWITCH_OUT);
 
     return false;
 }
@@ -281,26 +237,19 @@ bool Writer::handle(const Reader::RecordSwitchType* context_switch)
     assert(cpuid_ == -1);
 
     auto tp = time_converter_(context_switch->time);
+    tp = adjust_timepoints(tp);
 
-    if (first_event_)
-    {
-        first_time_point_ = std::min(first_time_point_, tp);
-        otf2_writer_ << otf2::event::thread_begin(first_time_point_, trace_.process_comm(pid_), -1);
-        first_event_ = false;
-    }
+    update_calling_context(context_switch->pid, context_switch->tid, tp,
+                           context_switch->header.misc & PERF_RECORD_MISC_SWITCH_OUT);
 
     if (context_switch->header.misc & PERF_RECORD_MISC_SWITCH_OUT)
     {
-        leave_current_thread(context_switch->tid, tp);
-
         cpuid_metric_event_.timestamp(tp);
         cpuid_metric_event_.raw_values()[0] = -1;
         otf2_writer_ << cpuid_metric_event_;
     }
     else
     {
-        update_current_thread(context_switch->pid, context_switch->tid, tp);
-
         cpuid_metric_event_.timestamp(tp);
         cpuid_metric_event_.raw_values()[0] = context_switch->cpu;
         otf2_writer_ << cpuid_metric_event_;
@@ -308,8 +257,20 @@ bool Writer::handle(const Reader::RecordSwitchType* context_switch)
 
     return false;
 }
-#endif
 
+void Writer::update_calling_context(pid_t pid, pid_t tid, otf2::chrono::time_point tp,
+                                    bool switch_out)
+{
+    if (switch_out)
+    {
+        leave_current_thread(tid, tp);
+    }
+    else
+    {
+        update_current_thread(pid, tid, tp);
+    }
+}
+#endif
 bool Writer::handle(const Reader::RecordCommType* comm)
 {
     if (cpuid_ == -1)
@@ -343,7 +304,6 @@ void Writer::end()
     if (cpuid_ == -1)
     {
         adjust_timepoints(lo2s::time::now());
-
         // If we have never written any samples on this location, we also never
         // got to write the thread_begin event.  Make sure we do that now.
         if (first_event_)

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -86,7 +86,8 @@ std::string get_trace_name(std::string prefix = "")
 }
 
 Trace::Trace()
-: trace_name_(get_trace_name(config().trace_path)), archive_(trace_name_, "traces"),
+: stopping_time_(time::now()), trace_name_(get_trace_name(config().trace_path)),
+  archive_(trace_name_, "traces"),
   system_tree_root_node_(0, intern(nitro::env::hostname()), intern("machine")),
   interrupt_generator_(0u, intern("perf HW_INSTRUCTIONS"),
                        otf2::common::interrupt_generator_mode_type::count,
@@ -171,7 +172,7 @@ void Trace::begin_record()
 
 void Trace::end_record()
 {
-    stopping_time_ = time::now();
+    adjust_stop_time(time::now());
     Log::info() << "Recording done. Start finalization...";
 }
 


### PR DESCRIPTION
This results in a more accurate depiction of when which process was active

This Fixes #135 
