### PR TITLE
Issue 124 trace cpp with registry

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "lib/otf2xx"]
 	path = lib/otf2xx
-	url = https://github.com/tud-zih-energy/otf2xx.git
-	branch = lo2s
+    url = https://github.com/tud-zih-energy/otf2xx.git
 [submodule "lib/nitro"]
 	path = lib/nitro
 	url = https://github.com/tud-zih-energy/nitro.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "lib/otf2xx"]
 	path = lib/otf2xx
-    url = https://github.com/tud-zih-energy/otf2xx.git
+	url = https://github.com/tud-zih-energy/otf2xx.git
 [submodule "lib/nitro"]
 	path = lib/nitro
 	url = https://github.com/tud-zih-energy/nitro.git

--- a/include/lo2s/trace/reg_keys.hpp
+++ b/include/lo2s/trace/reg_keys.hpp
@@ -1,0 +1,187 @@
+
+/*
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2016,
+ *    Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <lo2s/address.hpp>
+#include <lo2s/line_info.hpp>
+
+#include <otf2xx/otf2.hpp>
+
+#include <string>
+
+extern "C"
+{
+#include <sys/types.h>
+}
+namespace lo2s
+{
+namespace trace
+{
+
+template <typename KeyType, typename tag>
+struct SimpleKeyType
+{
+    using key_type = KeyType;
+    key_type key;
+
+    explicit SimpleKeyType(key_type key) : key(key)
+    {
+    }
+};
+
+struct ByCore
+{
+    using key_type = typename std::pair<int, int>;
+    key_type key;
+
+    ByCore(int core, int package) : key(std::make_pair(core, package))
+    {
+    }
+};
+
+// Can i haz strong typedef
+struct ByPackageTag
+{
+};
+using ByPackage = SimpleKeyType<int, ByPackageTag>;
+
+struct ByCpuTag
+{
+};
+using ByCpu = SimpleKeyType<int, ByCpuTag>;
+
+struct ByThreadTag
+{
+};
+using ByThread = SimpleKeyType<pid_t, ByThreadTag>;
+
+struct ByProcessTag
+{
+};
+using ByProcess = SimpleKeyType<pid_t, ByProcessTag>;
+
+struct ByCpuSwitchWriterTag
+{
+};
+using ByCpuSwitchWriter = SimpleKeyType<int, ByCpuSwitchWriterTag>;
+
+struct ByCpuMetricWriterTag
+{
+};
+using ByCpuMetricWriter = SimpleKeyType<int, ByCpuMetricWriterTag>;
+
+struct ByCpuSampleWriterTag
+{
+};
+using ByCpuSampleWriter = SimpleKeyType<int, ByCpuSampleWriterTag>;
+
+struct ByThreadMetricWriterTag
+{
+};
+using ByThreadMetricWriter = SimpleKeyType<int, ByThreadMetricWriterTag>;
+
+struct ByThreadSampleWriterTag
+{
+};
+using ByThreadSampleWriter = SimpleKeyType<int, ByThreadSampleWriterTag>;
+
+struct ByStringTag
+{
+};
+using ByString = SimpleKeyType<std::string, ByStringTag>;
+
+struct ByAddressTag
+{
+};
+using ByAddress = SimpleKeyType<Address, ByAddressTag>;
+
+struct ByLineInfoTag
+{
+};
+using ByLineInfo = SimpleKeyType<LineInfo, ByLineInfoTag>;
+
+template <typename Definition>
+struct MyHolder
+{
+    using type = typename otf2::get_default_holder<Definition>::type;
+};
+
+template <>
+struct MyHolder<otf2::definition::system_tree_node>
+{
+    using type = otf2::lookup_definition_holder<otf2::definition::system_tree_node, ByCore,
+                                                ByProcess, ByCpu, ByPackage>;
+};
+template <>
+struct MyHolder<otf2::definition::regions_group>
+{
+    using type = otf2::lookup_definition_holder<otf2::definition::regions_group, ByString>;
+};
+template <>
+struct MyHolder<otf2::definition::metric_class>
+{
+    using type = otf2::lookup_definition_holder<otf2::definition::metric_class, ByString>;
+};
+template <>
+struct MyHolder<otf2::definition::string>
+{
+    using type = otf2::lookup_definition_holder<otf2::definition::string, ByString>;
+};
+template <>
+struct MyHolder<otf2::definition::location_group>
+{
+    using type = otf2::lookup_definition_holder<otf2::definition::location_group, ByProcess, ByCpu>;
+};
+template <>
+struct MyHolder<otf2::definition::location>
+{
+    using type = otf2::lookup_definition_holder<otf2::definition::location, ByCpuSwitchWriter,
+                                                ByCpuMetricWriter, ByCpuSampleWriter,
+                                                ByThreadMetricWriter, ByThreadSampleWriter>;
+};
+template <>
+struct MyHolder<otf2::definition::region>
+{
+    using type = otf2::lookup_definition_holder<otf2::definition::region, ByThread, ByLineInfo>;
+};
+template <>
+struct MyHolder<otf2::definition::calling_context>
+{
+    using type = otf2::lookup_definition_holder<otf2::definition::calling_context, ByThread>;
+};
+template <>
+struct MyHolder<otf2::definition::source_code_location>
+{
+    using type = otf2::lookup_definition_holder<otf2::definition::source_code_location, ByLineInfo>;
+};
+template <>
+struct MyHolder<otf2::definition::comm>
+{
+    using type = otf2::lookup_definition_holder<otf2::definition::comm, ByProcess>;
+};
+template <>
+struct MyHolder<otf2::definition::comm_group>
+{
+    using type = otf2::lookup_definition_holder<otf2::definition::comm_group, ByProcess>;
+};
+} // namespace trace
+} // namespace lo2s

--- a/include/lo2s/trace/reg_keys.hpp
+++ b/include/lo2s/trace/reg_keys.hpp
@@ -120,66 +120,66 @@ struct ByLineInfoTag
 using ByLineInfo = SimpleKeyType<LineInfo, ByLineInfoTag>;
 
 template <typename Definition>
-struct MyHolder
+struct Holder
 {
     using type = typename otf2::get_default_holder<Definition>::type;
 };
 
 template <>
-struct MyHolder<otf2::definition::system_tree_node>
+struct Holder<otf2::definition::system_tree_node>
 {
     using type = otf2::lookup_definition_holder<otf2::definition::system_tree_node, ByCore,
                                                 ByProcess, ByCpu, ByPackage>;
 };
 template <>
-struct MyHolder<otf2::definition::regions_group>
+struct Holder<otf2::definition::regions_group>
 {
     using type = otf2::lookup_definition_holder<otf2::definition::regions_group, ByString>;
 };
 template <>
-struct MyHolder<otf2::definition::metric_class>
+struct Holder<otf2::definition::metric_class>
 {
     using type = otf2::lookup_definition_holder<otf2::definition::metric_class, ByString>;
 };
 template <>
-struct MyHolder<otf2::definition::string>
+struct Holder<otf2::definition::string>
 {
     using type = otf2::lookup_definition_holder<otf2::definition::string, ByString>;
 };
 template <>
-struct MyHolder<otf2::definition::location_group>
+struct Holder<otf2::definition::location_group>
 {
     using type = otf2::lookup_definition_holder<otf2::definition::location_group, ByProcess, ByCpu>;
 };
 template <>
-struct MyHolder<otf2::definition::location>
+struct Holder<otf2::definition::location>
 {
     using type = otf2::lookup_definition_holder<otf2::definition::location, ByCpuSwitchWriter,
                                                 ByCpuMetricWriter, ByCpuSampleWriter,
                                                 ByThreadMetricWriter, ByThreadSampleWriter>;
 };
 template <>
-struct MyHolder<otf2::definition::region>
+struct Holder<otf2::definition::region>
 {
     using type = otf2::lookup_definition_holder<otf2::definition::region, ByThread, ByLineInfo>;
 };
 template <>
-struct MyHolder<otf2::definition::calling_context>
+struct Holder<otf2::definition::calling_context>
 {
     using type = otf2::lookup_definition_holder<otf2::definition::calling_context, ByThread>;
 };
 template <>
-struct MyHolder<otf2::definition::source_code_location>
+struct Holder<otf2::definition::source_code_location>
 {
     using type = otf2::lookup_definition_holder<otf2::definition::source_code_location, ByLineInfo>;
 };
 template <>
-struct MyHolder<otf2::definition::comm>
+struct Holder<otf2::definition::comm>
 {
     using type = otf2::lookup_definition_holder<otf2::definition::comm, ByProcess>;
 };
 template <>
-struct MyHolder<otf2::definition::comm_group>
+struct Holder<otf2::definition::comm_group>
 {
     using type = otf2::lookup_definition_holder<otf2::definition::comm_group, ByProcess>;
 };

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -166,7 +166,7 @@ public:
     }
     otf2::definition::comm& process_comm(pid_t pid)
     {
-        return registry_.find<otf2::definition::comm>(ByProcess(pid));
+        return registry_.get<otf2::definition::comm>(ByProcess(pid));
     }
 
 private:
@@ -196,15 +196,15 @@ private:
     static constexpr pid_t METRIC_PID = 0;
 
     std::string trace_name_;
-    otf2::writer::Archive<otf2::lookup_registry<MyHolder>> archive_;
-    otf2::lookup_registry<MyHolder>& registry_;
+    otf2::writer::Archive<otf2::lookup_registry<Holder>> archive_;
+    otf2::lookup_registry<Holder>& registry_;
 
     std::recursive_mutex mutex_;
 
     otf2::chrono::time_point starting_time_;
     otf2::chrono::time_point stopping_time_;
 
-    otf2::definition::interrupt_generator interrupt_generator_;
+    otf2::definition::interrupt_generator& interrupt_generator_;
 
     // TODO add location groups (processes), read path from /proc/self/exe symlink
 

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -19,13 +19,13 @@
  * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
  */
 #pragma once
-
 #include <lo2s/address.hpp>
 #include <lo2s/bfd_resolve.hpp>
 #include <lo2s/config.hpp>
 #include <lo2s/line_info.hpp>
 #include <lo2s/mmap.hpp>
 #include <lo2s/process_info.hpp>
+#include <lo2s/trace/reg_keys.hpp>
 
 #include <otf2xx/otf2.hpp>
 
@@ -64,11 +64,11 @@ struct ThreadCctxRefs
 
 struct IpCctxEntry
 {
-    IpCctxEntry(otf2::definition::calling_context c) : cctx(c)
+    IpCctxEntry(otf2::definition::calling_context& c) : cctx(c)
     {
     }
 
-    otf2::definition::calling_context cctx;
+    otf2::definition::calling_context& cctx;
     IpMap<IpCctxEntry> children;
 };
 
@@ -76,11 +76,9 @@ using ThreadCctxRefMap = std::map<pid_t, ThreadCctxRefs>;
 using IpRefMap = IpMap<IpRefEntry>;
 using IpCctxMap = IpMap<IpCctxEntry>;
 
-// TODO Group and sort the mess in this class definition and trace.cpp
 class Trace
 {
 public:
-    static constexpr pid_t METRIC_PID = 0;
     static constexpr pid_t NO_PARENT_PROCESS_PID =
         0; //<! sentinel value for an inserted process that has no known parent
 
@@ -93,26 +91,6 @@ public:
     otf2::chrono::time_point record_from() const;
     otf2::chrono::time_point record_to() const;
 
-    otf2::writer::archive& archive()
-    {
-        return archive_;
-    }
-
-private:
-    /** Add a thread with the required lock (#mutex_) held.
-     *
-     *  This is a helper needed to avoid constant re-locking when adding
-     *  multiple threads via #add_threads.
-     **/
-    void add_thread_exclusive(pid_t tid, const std::string& name,
-                              const std::lock_guard<std::recursive_mutex>&);
-
-    void update_process_name(pid_t pid, const otf2::definition::string& name);
-    void update_thread_name(pid_t tid, const otf2::definition::string& name);
-
-public:
-    void add_cpu(int cpuid);
-
     void add_process(pid_t pid, pid_t parent, const std::string& name = "");
 
     void add_thread(pid_t tid, const std::string& name);
@@ -122,6 +100,10 @@ public:
 
     void update_process_name(pid_t pid, const std::string& name);
     void update_thread_name(pid_t tid, const std::string& name);
+
+    otf2::definition::mapping_table merge_calling_contexts(ThreadCctxRefMap& new_ips,
+                                                           size_t num_ip_refs,
+                                                           std::map<pid_t, ProcessInfo>& infos);
 
     otf2::writer::local& thread_sample_writer(pid_t pid, pid_t tid);
     otf2::writer::local& cpu_sample_writer(int cpuid);
@@ -136,213 +118,106 @@ public:
                   const std::string& unit, std::int64_t exponent = 0,
                   otf2::common::base_type base = otf2::common::base_type::decimal);
 
-    otf2::definition::metric_class metric_class();
+    otf2::definition::metric_class& metric_class();
 
-    otf2::definition::metric_instance metric_instance(otf2::definition::metric_class metric_class,
-                                                      otf2::definition::location recorder,
-                                                      otf2::definition::location scope);
+    otf2::definition::metric_instance
+    metric_instance(const otf2::definition::metric_class& metric_class,
+                    const otf2::definition::location& recorder,
+                    const otf2::definition::location& scope);
 
-    otf2::definition::metric_instance metric_instance(otf2::definition::metric_class metric_class,
-                                                      otf2::definition::location recorder,
-                                                      otf2::definition::system_tree_node scope);
+    otf2::definition::metric_instance
+    metric_instance(const otf2::definition::metric_class& metric_class,
+                    const otf2::definition::location& recorder,
+                    const otf2::definition::system_tree_node& scope);
 
-    otf2::definition::metric_class cpuid_metric_class();
-    otf2::definition::metric_class perf_metric_class();
+    otf2::definition::metric_class& cpuid_metric_class()
+    {
+        return cpuid_metric_class_;
+    }
+    otf2::definition::metric_class& perf_metric_class()
+    {
+        return perf_metric_class_;
+    }
 
-    otf2::definition::metric_class tracepoint_metric_class(const std::string& event_name);
-    otf2::definition::mapping_table merge_calling_contexts(ThreadCctxRefMap& new_ips,
-                                                           size_t num_ip_refs,
-                                                           std::map<pid_t, ProcessInfo>& infos);
-
-    void merge_ips(IpRefMap& new_children, IpCctxMap& children,
-                   std::vector<uint32_t>& mapping_table, otf2::definition::calling_context parent,
-                   std::map<pid_t, ProcessInfo>& infos, pid_t pid);
+    otf2::definition::metric_class& tracepoint_metric_class(const std::string& event_name);
 
     const otf2::definition::interrupt_generator& interrupt_generator() const
     {
         return interrupt_generator_;
     }
-
     const otf2::definition::system_tree_node& system_tree_cpu_node(int cpuid) const
     {
-        return system_tree_cpu_nodes_.at(cpuid);
+        return registry_.get<otf2::definition::system_tree_node>(ByCpu(cpuid));
     }
 
     const otf2::definition::system_tree_node& system_tree_core_node(int coreid, int packageid) const
     {
-        return system_tree_core_nodes_.at(std::make_pair(coreid, packageid));
+        return registry_.get<otf2::definition::system_tree_node>(ByCore(coreid, packageid));
     }
 
     const otf2::definition::system_tree_node& system_tree_package_node(int packageid) const
     {
-        return system_tree_package_nodes_.at(packageid);
+        return registry_.get<otf2::definition::system_tree_node>(ByPackage(packageid));
     }
 
     const otf2::definition::system_tree_node& system_tree_root_node() const
     {
         return system_tree_root_node_;
     }
-
-    void adjust_stop_time(otf2::chrono::time_point tp)
+    otf2::definition::comm& process_comm(pid_t pid)
     {
-        if (tp > stopping_time_)
-        {
-            stopping_time_ = tp;
-        }
+        return registry_.find<otf2::definition::comm>(ByProcess(pid));
     }
-
-    otf2::definition::regions_group regions_group_executable(const std::string& name);
-    otf2::definition::regions_group regions_group_monitoring(const std::string& name);
-    otf2::definition::comm process_comm(pid_t pid);
 
 private:
-    std::map<std::string, otf2::definition::regions_group> regions_groups_sampling_dso();
+    /** Add a thread with the required lock (#mutex_) held.
+     *
+     *  This is a helper needed to avoid constant re-locking when adding
+     *  multiple threads via #add_threads.
+     **/
+    void add_thread_exclusive(pid_t tid, const std::string& name,
+                              const std::lock_guard<std::recursive_mutex>&);
 
-    otf2::definition::source_code_location intern_scl(const LineInfo&);
+    void merge_ips(IpRefMap& new_children, IpCctxMap& children,
+                   std::vector<uint32_t>& mapping_table, otf2::definition::calling_context& parent,
+                   std::map<pid_t, ProcessInfo>& infos, pid_t pid);
 
-    otf2::definition::region intern_region(const LineInfo&);
+    const otf2::definition::source_code_location& intern_scl(const LineInfo&);
 
-    otf2::definition::string intern(const std::string&);
+    const otf2::definition::region& intern_region(const LineInfo&);
 
-    void create_symlink_to_latest();
+    const otf2::definition::system_tree_node& intern_process_node(pid_t pid);
 
-    // This generates a contiguous set of IDs for all locations
-    otf2::definition::location::reference_type location_ref() const
-    {
-        return thread_sample_locations_.size() + cpu_sample_locations_.size() +
-               cpu_switch_locations_.size() + thread_metric_locations_.size() +
-               named_metric_locations_.size() + cpu_metric_locations_.size();
-    }
-
-    otf2::definition::location_group::reference_type location_group_ref() const
-    {
-        return location_groups_process_.size() + location_groups_cpu_.size();
-    }
-
-    otf2::definition::system_tree_node::reference_type system_tree_ref() const
-    {
-        // + for system_tree_root_node_
-        return 1 + system_tree_package_nodes_.size() + system_tree_core_nodes_.size() +
-               system_tree_cpu_nodes_.size() + system_tree_process_nodes_.size();
-    }
-
-    otf2::definition::region::reference_type region_ref() const
-    {
-        return regions_line_info_.size() + regions_thread_.size();
-    }
-
-    otf2::definition::regions_group::reference_type group_ref() const
-    {
-        // + 1 for locations_group_
-        // use static_cast because we are narrowing from std::size_t
-        return static_cast<otf2::definition::regions_group::reference_type>(
-            1 + regions_groups_executable_.size() + regions_groups_monitoring_.size() +
-            process_comm_groups_.size());
-    }
-
-    otf2::definition::comm::reference_type comm_ref() const
-    {
-        return process_comms_.size();
-    }
-
-    otf2::definition::metric_member::reference_type metric_member_ref() const
-    {
-        return metric_members_.size();
-    }
-
-    // metric classes and metric instances share a reference space
-    otf2::definition::metric_class::reference_type metric_class_ref() const
-    {
-        return static_cast<otf2::definition::metric_class::reference_type>(
-            metric_instances_.size() + metric_classes_.size() + tracepoint_metric_classes_.size());
-    }
-
-    otf2::definition::metric_instance::reference_type metric_instance_ref() const
-    {
-        return static_cast<otf2::definition::metric_instance::reference_type>(
-            metric_instances_.size() + metric_classes_.size() + tracepoint_metric_classes_.size());
-    }
-
-    otf2::definition::source_code_location::reference_type scl_ref() const
-    {
-        return source_code_locations_.size();
-    }
-
-    otf2::definition::string::reference_type string_ref() const
-    {
-        return strings_.size();
-    }
-
-    otf2::definition::calling_context::reference_type calling_context_ref() const
-    {
-        return calling_contexts_.size() + calling_context_tree_.size();
-    }
-
-    otf2::definition::system_tree_node& intern_process_node(pid_t pid);
-
-    void attach_process_location_group(const otf2::definition::system_tree_node& parent, pid_t id,
-                                       const otf2::definition::string& iname);
+    const otf2::definition::string& intern(const std::string&);
 
     void add_lo2s_property(const std::string& name, const std::string& value);
 
 private:
+    static constexpr pid_t METRIC_PID = 0;
+
+    std::string trace_name_;
+    otf2::writer::Archive<otf2::lookup_registry<MyHolder>> archive_;
+    otf2::lookup_registry<MyHolder>& registry_;
+
     std::recursive_mutex mutex_;
 
     otf2::chrono::time_point starting_time_;
     otf2::chrono::time_point stopping_time_;
 
-    std::string trace_name_;
-
-    otf2::writer::archive archive_;
-
-    std::map<std::string, otf2::definition::string> strings_;
-
-    otf2::definition::system_tree_node system_tree_root_node_;
-
-    std::map<int, otf2::definition::system_tree_node> system_tree_package_nodes_;
-    std::map<std::pair<int, int>, otf2::definition::system_tree_node> system_tree_core_nodes_;
-    std::map<int, otf2::definition::system_tree_node> system_tree_cpu_nodes_;
-    std::map<pid_t, otf2::definition::system_tree_node> system_tree_process_nodes_;
-
-    otf2::definition::container<otf2::definition::system_tree_node_domain>
-        system_tree_node_domains_;
-
     otf2::definition::interrupt_generator interrupt_generator_;
 
-    std::map<pid_t, otf2::definition::location_group> location_groups_process_;
-    std::map<int, otf2::definition::location_group> location_groups_cpu_;
-
     // TODO add location groups (processes), read path from /proc/self/exe symlink
-    std::map<pid_t, otf2::definition::location> thread_sample_locations_;
-    std::map<int, otf2::definition::location> cpu_sample_locations_;
-    std::map<pid_t, otf2::definition::location> thread_metric_locations_;
-    std::map<int, otf2::definition::location> cpu_metric_locations_;
-    std::map<int, otf2::definition::location> cpu_switch_locations_;
-    otf2::definition::container<otf2::definition::location> named_metric_locations_;
-
-    std::map<LineInfo, otf2::definition::source_code_location> source_code_locations_;
-    std::map<LineInfo, otf2::definition::region> regions_line_info_;
-    std::map<pid_t, otf2::definition::region> regions_thread_;
-
-    std::map<std::string, otf2::definition::regions_group> regions_groups_executable_;
-    std::map<std::string, otf2::definition::regions_group> regions_groups_monitoring_;
-    std::map<pid_t, otf2::definition::comm_group> process_comm_groups_;
-
-    std::map<pid_t, otf2::definition::comm> process_comms_;
 
     std::map<pid_t, std::string> process_names_;
     std::map<pid_t, IpCctxEntry> calling_context_tree_;
-    otf2::definition::container<otf2::definition::calling_context> calling_contexts_;
-    otf2::definition::container<otf2::definition::calling_context_property>
-        calling_context_properties_;
-    otf2::definition::container<otf2::definition::metric_member> metric_members_;
-    std::map<std::string, otf2::definition::metric_class> tracepoint_metric_classes_;
-    otf2::definition::container<otf2::definition::metric_class> metric_classes_;
-    otf2::definition::detail::weak_ref<otf2::definition::metric_class> cpuid_metric_class_;
-    otf2::definition::detail::weak_ref<otf2::definition::metric_class> perf_metric_class_;
-    otf2::definition::container<otf2::definition::metric_instance> metric_instances_;
-    otf2::definition::container<otf2::definition::system_tree_node_property>
-        system_tree_node_properties_;
+
+    otf2::definition::comm_locations_group& comm_locations_group_;
+    otf2::definition::regions_group& lo2s_regions_group_;
+
+    otf2::definition::metric_class& perf_metric_class_;
+    otf2::definition::metric_class& cpuid_metric_class_;
+
+    const otf2::definition::system_tree_node& system_tree_root_node_;
 };
 } // namespace trace
 } // namespace lo2s

--- a/src/metric/x86_adapt/metrics.cpp
+++ b/src/metric/x86_adapt/metrics.cpp
@@ -12,8 +12,8 @@ namespace x86_adapt
 
 Metrics::Metrics(trace::Trace& trace, const std::vector<std::string>& item_names)
 {
-    auto mc = trace.metric_class();
-    auto node_mc = trace.metric_class();
+    auto& mc = trace.metric_class();
+    auto& node_mc = trace.metric_class();
 
     std::vector<::x86_adapt::configuration_item> cpu_configuration_items;
     std::vector<::x86_adapt::configuration_item> node_configuration_items;

--- a/src/metric/x86_energy/metrics.cpp
+++ b/src/metric/x86_energy/metrics.cpp
@@ -70,7 +70,7 @@ Metrics::Metrics(trace::Trace& trace)
 
         std::string metric_name = str.str();
 
-        auto mc = trace.metric_class();
+        auto& mc = trace.metric_class();
         // According to the developers, x86_energy gives values in J, not mJ!
         // No scaling needed
         mc.add_member(trace.metric_member(metric_name, metric_name,

--- a/src/monitor/cpu_set_monitor.cpp
+++ b/src/monitor/cpu_set_monitor.cpp
@@ -48,8 +48,6 @@ CpuSetMonitor::CpuSetMonitor() : MainMonitor()
 
     for (const auto& cpu : Topology::instance().cpus())
     {
-        trace_.add_cpu(cpu.id);
-
         Log::debug() << "Create cstate recorder for cpu #" << cpu.id;
 
         monitors_.emplace(std::piecewise_construct, std::forward_as_tuple(cpu.id),

--- a/src/monitor/tracepoint_monitor.cpp
+++ b/src/monitor/tracepoint_monitor.cpp
@@ -38,7 +38,7 @@ TracepointMonitor::TracepointMonitor(trace::Trace& trace, int cpuid)
 {
     for (const auto& event_name : config().tracepoint_events)
     {
-        auto mc = trace.tracepoint_metric_class(event_name);
+        auto& mc = trace.tracepoint_metric_class(event_name);
         perf::tracepoint::EventFormat event(event_name);
         std::unique_ptr<perf::tracepoint::Writer> writer =
             std::make_unique<perf::tracepoint::Writer>(cpuid, event, trace, mc);

--- a/src/perf/sample/writer.cpp
+++ b/src/perf/sample/writer.cpp
@@ -79,7 +79,6 @@ Writer::~Writer()
                                                             monitor_.get_process_infos());
         otf2_writer_ << mapping;
     }
-    trace_.adjust_stop_time(last_time_point_);
 }
 
 trace::IpRefMap::iterator Writer::find_ip_child(Address addr, trace::IpRefMap& children)

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -47,8 +47,6 @@
 #include <stdexcept>
 #include <tuple>
 
-using namespace std::literals::string_literals;
-
 namespace lo2s
 {
 namespace trace
@@ -86,13 +84,52 @@ std::string get_trace_name(std::string prefix = "")
 }
 
 Trace::Trace()
-: stopping_time_(time::now()), trace_name_(get_trace_name(config().trace_path)),
-  archive_(trace_name_, "traces"),
-  system_tree_root_node_(0, intern(nitro::env::hostname()), intern("machine")),
-  interrupt_generator_(0u, intern("perf " + config().sampling_event),
+: trace_name_(get_trace_name(config().trace_path)), archive_(trace_name_, "traces"),
+  registry_(archive_.registry()),
+  interrupt_generator_(0u, intern("perf HW_INSTRUCTIONS"),
                        otf2::common::interrupt_generator_mode_type::count,
-                       otf2::common::base_type::decimal, 0, config().sampling_period)
+                       otf2::common::base_type::decimal, 0, config().sampling_period),
+
+  comm_locations_group_(registry_.create<otf2::definition::comm_locations_group>(
+      intern("All pthread locations"), otf2::common::paradigm_type::pthread,
+      otf2::common::group_flag_type::none)),
+  lo2s_regions_group_(registry_.create<otf2::definition::regions_group>(
+      intern("lo2s"), otf2::common::paradigm_type::user, otf2::common::group_flag_type::none)),
+
+  perf_metric_class_(registry_.create<otf2::definition::metric_class>(
+      otf2::common::metric_occurence::async, otf2::common::recorder_kind::abstract)),
+  cpuid_metric_class_(registry_.create<otf2::definition::metric_class>(
+      otf2::common::metric_occurence::async, otf2::common::recorder_kind::abstract)),
+  system_tree_root_node_(registry_.create<otf2::definition::system_tree_node>(
+      intern(nitro::env::hostname()), intern("machine")))
 {
+
+    cpuid_metric_class_.add_member(metric_member("CPU", "CPU executing the task",
+                                                 otf2::common::metric_mode::absolute_point,
+                                                 otf2::common::type::int64, "cpuid"));
+
+    const perf::EventCollection& event_collection = perf::requested_events();
+    if (!event_collection.events.empty())
+    {
+        perf_metric_class_.add_member(metric_member(
+            event_collection.leader.name, event_collection.leader.name,
+            otf2::common::metric_mode::accumulated_start, otf2::common::type::Double, "#"));
+
+        for (const auto& ev : event_collection.events)
+        {
+            perf_metric_class_.add_member(
+                metric_member(ev.name, ev.name, otf2::common::metric_mode::accumulated_start,
+                              otf2::common::type::Double, "#"));
+        }
+
+        perf_metric_class_.add_member(metric_member("time_enabled", "time event active",
+                                                    otf2::common::metric_mode::accumulated_start,
+                                                    otf2::common::type::uint64, "ns"));
+        perf_metric_class_.add_member(metric_member("time_running", "time event on CPU",
+                                                    otf2::common::metric_mode::accumulated_start,
+                                                    otf2::common::type::uint64, "ns"));
+    }
+
     Log::info() << "Using trace directory: " << trace_name_;
     summary().set_trace_dir(trace_name_);
 
@@ -106,62 +143,51 @@ Trace::Trace()
     add_lo2s_property("UNAME::VERSION", std::string{ uname.version });
     add_lo2s_property("UNAME::MACHINE", std::string{ uname.machine });
 
-    // TODO clean this up, avoid side effect comm stuff
-    attach_process_location_group(system_tree_root_node_, METRIC_PID,
-                                  intern("Metric Location Group"));
+    registry_.create<otf2::definition::location_group>(
+        ByProcess(METRIC_PID), intern("Metric Location Group"),
+        otf2::definition::location_group::location_group_type::process, system_tree_root_node_);
 
-    system_tree_node_domains_.emplace(system_tree_root_node_,
-                                      otf2::common::system_tree_node_domain::shared_memory);
-
+    registry_.create<otf2::definition::system_tree_node_domain>(
+        system_tree_root_node_, otf2::common::system_tree_node_domain::shared_memory);
     const auto& sys = Topology::instance();
     for (auto& package : sys.packages())
     {
         Log::debug() << "Registering package " << package.id;
-        const auto& parent = system_tree_root_node_;
-        auto res = system_tree_package_nodes_.emplace(
-            std::piecewise_construct, std::forward_as_tuple(package.id),
-            std::forward_as_tuple(system_tree_ref(), intern(std::to_string(package.id)),
-                                  intern("package"), parent));
-        system_tree_node_domains_.emplace(res.first->second,
-                                          otf2::common::system_tree_node_domain::socket);
+        const auto& res = registry_.create<otf2::definition::system_tree_node>(
+            ByPackage(package.id), intern(std::to_string(package.id)), intern("package"),
+            system_tree_root_node_);
+
+        registry_.create<otf2::definition::system_tree_node_domain>(
+            res, otf2::common::system_tree_node_domain::socket);
     }
     for (auto& core : sys.cores())
     {
         Log::debug() << "Registering core " << core.id << "@" << core.package_id;
-        const auto& parent = system_tree_package_nodes_.at(core.package_id);
-        auto res = system_tree_core_nodes_.emplace(
-            std::piecewise_construct, std::forward_as_tuple(core.id, core.package_id),
-            std::forward_as_tuple(
-                system_tree_ref(),
-                intern(std::to_string(core.package_id) + ":"s + std::to_string(core.id)),
-                intern("core"), parent));
 
-        system_tree_node_domains_.emplace(res.first->second,
-                                          otf2::common::system_tree_node_domain::core);
+        const auto& res = registry_.create<otf2::definition::system_tree_node>(
+            ByCore(core.id, core.package_id),
+            intern(std::to_string(core.package_id) + ":" + std::to_string(core.id)), intern("core"),
+            registry_.get<otf2::definition::system_tree_node>(ByPackage(core.package_id)));
+
+        registry_.create<otf2::definition::system_tree_node_domain>(
+            res, otf2::common::system_tree_node_domain::core);
     }
     for (auto& cpu : sys.cpus())
     {
         Log::debug() << "Registering cpu " << cpu.id << "@" << cpu.core_id << ":" << cpu.package_id;
-        const auto& parent =
-            system_tree_core_nodes_.at(std::make_pair(cpu.core_id, cpu.package_id));
-        auto res = system_tree_cpu_nodes_.emplace(
-            std::piecewise_construct, std::forward_as_tuple(cpu.id),
-            std::forward_as_tuple(system_tree_ref(), intern(std::to_string(cpu.id)), intern("cpu"),
-                                  parent));
-        system_tree_node_domains_.emplace(res.first->second,
-                                          otf2::common::system_tree_node_domain::pu);
-    }
-}
+        const auto& res = registry_.create<otf2::definition::system_tree_node>(
+            ByCpu(cpu.id), intern(std::to_string(cpu.id)), intern("cpu"),
+            registry_.get<otf2::definition::system_tree_node>(ByCore(cpu.core_id, cpu.package_id)));
 
-template <class IT, class DT>
-otf2::writer::archive& operator<<(otf2::writer::archive& ar, const std::map<IT, DT>& map)
-{
-    static_assert(otf2::traits::is_definition<DT>::value, "not a definition type.");
-    for (const auto& elem : map)
-    {
-        ar << elem.second;
+        registry_.create<otf2::definition::system_tree_node_domain>(
+            res, otf2::common::system_tree_node_domain::pu);
+
+        const auto& name = intern((boost::format("cpu %d") % cpu.id).str());
+
+        registry_.create<otf2::definition::location_group>(
+            ByCpu(cpu.id), name, otf2::definition::location_group::location_group_type::process,
+            registry_.get<otf2::definition::system_tree_node>(ByCpu(cpu.id)));
     }
-    return ar;
 }
 
 void Trace::begin_record()
@@ -172,7 +198,7 @@ void Trace::begin_record()
 
 void Trace::end_record()
 {
-    adjust_stop_time(time::now());
+    stopping_time_ = time::now();
     Log::info() << "Recording done. Start finalization...";
 }
 
@@ -188,91 +214,9 @@ otf2::chrono::time_point Trace::record_to() const
 
 Trace::~Trace()
 {
-    auto sampling_function_groups_ = regions_groups_sampling_dso();
-    otf2::definition::comm_locations_group comm_locations_group(
-        0, intern("All pthread locations"), otf2::common::paradigm_type::pthread,
-        otf2::common::group_flag_type::none);
-    for (const auto& location : cpu_switch_locations_)
-    {
-        comm_locations_group.add_member(location.second);
-    }
 
-    for (const auto& location : cpu_sample_locations_)
-    {
-        comm_locations_group.add_member(location.second);
-    }
-    for (const auto& location : thread_sample_locations_)
-    {
-        comm_locations_group.add_member(location.second);
-    }
     archive_ << otf2::definition::clock_properties(starting_time_, stopping_time_);
-    archive_ << strings_;
-    archive_ << system_tree_root_node_;
-    archive_ << system_tree_package_nodes_;
-    archive_ << system_tree_core_nodes_;
-    archive_ << system_tree_cpu_nodes_;
-    archive_ << system_tree_process_nodes_;
-    archive_ << system_tree_node_domains_;
-    archive_ << location_groups_process_;
-    archive_ << location_groups_cpu_;
 
-    for (const auto& location : thread_sample_locations_)
-    {
-        archive_ << location.second;
-    }
-    for (const auto& location : cpu_sample_locations_)
-    {
-        archive_ << location.second;
-    }
-    for (const auto& location : cpu_switch_locations_)
-    {
-        archive_ << location.second;
-    }
-    for (const auto& location : thread_metric_locations_)
-    {
-        archive_ << location.second;
-    }
-    for (const auto& location : cpu_metric_locations_)
-    {
-        archive_ << location.second;
-    }
-    archive_ << named_metric_locations_;
-
-    archive_ << source_code_locations_;
-    archive_ << regions_line_info_;
-    archive_ << regions_thread_;
-
-    archive_ << comm_locations_group;
-    archive_ << process_comm_groups_;
-    archive_ << sampling_function_groups_;
-    archive_ << regions_groups_executable_;
-    archive_ << regions_groups_monitoring_;
-
-    archive_ << process_comms_;
-
-    archive_ << interrupt_generator();
-    archive_ << calling_contexts_;
-
-    for (auto& thread_cctx : calling_context_tree_)
-    {
-        archive_ << thread_cctx.second.cctx;
-    }
-
-    archive_ << calling_context_properties_;
-    archive_ << metric_members_;
-    archive_ << metric_classes_;
-    for (auto& tracepoint_metric_class : tracepoint_metric_classes_)
-    {
-        archive_ << tracepoint_metric_class.second;
-    }
-    archive_ << metric_instances_;
-    archive_ << system_tree_node_properties_;
-
-    create_symlink_to_latest();
-}
-
-void Trace::create_symlink_to_latest()
-{
     boost::filesystem::path symlink_path = nitro::env::get("LO2S_OUTPUT_LINK");
 
     if (symlink_path.empty())
@@ -293,33 +237,11 @@ void Trace::create_symlink_to_latest()
     boost::filesystem::create_symlink(trace_name_, symlink_path);
 }
 
-std::map<std::string, otf2::definition::regions_group> Trace::regions_groups_sampling_dso()
+const otf2::definition::system_tree_node& Trace::intern_process_node(pid_t pid)
 {
-    std::map<std::string, otf2::definition::regions_group> groups;
-    for (const auto& elem : regions_line_info_)
+    if (registry_.has<otf2::definition::system_tree_node>(ByProcess(pid)))
     {
-        const auto& info = elem.first;
-        const auto& name = info.dso;
-        const auto& region = elem.second;
-        if (groups.count(name) == 0)
-        {
-            groups.emplace(std::piecewise_construct, std::forward_as_tuple(name),
-                           std::forward_as_tuple(groups.size() + group_ref(), intern(name),
-                                                 otf2::common::paradigm_type::sampling,
-                                                 otf2::common::group_flag_type::none));
-        }
-        groups.at(name).add_member(region);
-    }
-    return groups;
-}
-
-otf2::definition::system_tree_node& Trace::intern_process_node(pid_t pid)
-{
-    auto node_it = system_tree_process_nodes_.find(pid);
-
-    if (node_it != system_tree_process_nodes_.end())
-    {
-        return node_it->second;
+        return registry_.get<otf2::definition::system_tree_node>(ByProcess(pid));
     }
     else
     {
@@ -330,76 +252,42 @@ otf2::definition::system_tree_node& Trace::intern_process_node(pid_t pid)
 
 void Trace::add_process(pid_t pid, pid_t parent, const std::string& name)
 {
-    auto iname = intern(name);
-    const auto& parent_node =
-        (parent == NO_PARENT_PROCESS_PID) ? system_tree_root_node_ : intern_process_node(parent);
 
-    auto emplace_result = system_tree_process_nodes_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(pid),
-        std::forward_as_tuple(system_tree_ref(), iname, intern("process"), parent_node));
-
-    if (!emplace_result.second) /* emplace failed */
+    if (registry_.has<otf2::definition::system_tree_node>(ByProcess(pid)))
     {
-        // process already exists process tree; update its name.
-        update_process_name(pid, iname);
+        update_process_name(pid, name);
         return;
     }
-
-    const auto& emplaced_node = emplace_result.first->second;
-    attach_process_location_group(emplaced_node, pid, iname);
-}
-
-void Trace::attach_process_location_group(const otf2::definition::system_tree_node& parent,
-                                          pid_t id, const otf2::definition::string& iname)
-{
-    auto r_lg = location_groups_process_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(id),
-        std::forward_as_tuple(location_group_ref(), iname,
-                              otf2::definition::location_group::location_group_type::process,
-                              parent));
-    if (!r_lg.second)
+    else
     {
-        const auto err = boost::format("failed to attach process location group for pid %d (%s)") %
-                         id % iname.str();
-        throw std::runtime_error(err.str());
-    }
+        const auto& iname = intern(name);
+        const auto& parent_node = (parent == NO_PARENT_PROCESS_PID) ? system_tree_root_node_ :
+                                                                      intern_process_node(parent);
 
-    auto r_cg = process_comm_groups_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(id),
-        std::forward_as_tuple(otf2::definition::comm_group::reference_type(group_ref()), iname,
-                              otf2::common::paradigm_type::pthread,
-                              otf2::common::group_flag_type::none));
-    assert(r_cg.second);
-    const auto& group = r_cg.first->second;
-    auto r_c = process_comms_.emplace(std::piecewise_construct, std::forward_as_tuple(id),
-                                      std::forward_as_tuple(comm_ref(), iname, group));
-    assert(r_c.second);
-    (void)(r_c.second);
+        const auto& ret = registry_.emplace<otf2::definition::system_tree_node>(
+            ByProcess(pid), iname, intern("process"), parent_node);
+
+        registry_.emplace<otf2::definition::location_group>(
+            ByProcess(pid), iname, otf2::definition::location_group::location_group_type::process,
+            ret);
+
+        const auto& comm_group = registry_.emplace<otf2::definition::comm_group>(
+            ByProcess(pid), iname, otf2::common::paradigm_type::pthread,
+            otf2::common::group_flag_type::none);
+
+        registry_.emplace<otf2::definition::comm>(ByProcess(pid), iname, comm_group);
+    }
 }
 
-void Trace::update_process_name(pid_t pid, const otf2::definition::string& name)
+void Trace::update_process_name(pid_t pid, const std::string& name)
 {
+    const auto& iname = intern(name);
     try
     {
-        // we probably need that lock while fiddling with the more complex changes :(
-        std::lock_guard<std::recursive_mutex> guard(mutex_);
-
-        system_tree_process_nodes_.at(pid).name(name);
-        location_groups_process_.at(pid).name(name);
-
-        process_comm_groups_.at(pid).name(name);
-        process_comms_.at(pid).name(name);
-
-        std::string n = (boost::format("%s (tid %d)") % name.str() % pid).str();
-        auto region = regions_thread_.at(pid);
-        region.name(intern(n));
-        auto group = regions_group_executable(name.str());
-        group.add_member(region);
-
-        auto parent_group = regions_group_executable(process_names_.at(pid));
-        parent_group.remove_member(region);
-
-        process_names_[pid] = name.str();
+        registry_.get<otf2::definition::system_tree_node>(ByProcess(pid)).name(iname);
+        registry_.get<otf2::definition::location_group>(ByProcess(pid)).name(iname);
+        registry_.get<otf2::definition::comm_group>(ByProcess(pid)).name(iname);
+        registry_.get<otf2::definition::comm>(ByProcess(pid)).name(iname);
     }
     catch (const std::out_of_range&)
     {
@@ -408,32 +296,20 @@ void Trace::update_process_name(pid_t pid, const otf2::definition::string& name)
     }
 }
 
-void Trace::update_process_name(pid_t pid, const std::string& name)
-{
-    update_process_name(pid, intern(name));
-}
-
-void Trace::update_thread_name(pid_t tid, const otf2::definition::string& name)
+void Trace::update_thread_name(pid_t tid, const std::string& name)
 {
     // TODO we call this function in a hot-loop, locking doesn't sound like a good idea
     std::lock_guard<std::recursive_mutex> guard(mutex_);
 
-    auto loc_it = thread_sample_locations_.find(tid);
-
-    if (loc_it != thread_sample_locations_.end())
+    auto& iname = intern((boost::format("%s (tid %d)") % name % tid).str());
+    if (registry_.has<otf2::definition::location>(ByThreadSampleWriter(tid)))
     {
-        loc_it->second.name(name);
+        registry_.get<otf2::definition::location>(ByThreadSampleWriter(tid)).name(iname);
     }
     else
     {
         Log::warn() << "Attempting to update name of unknown thread " << tid << " (" << name << ")";
     }
-}
-
-void Trace::update_thread_name(pid_t tid, const std::string& name)
-{
-    std::string n = (boost::format("%s (tid %d)") % name % tid).str();
-    update_thread_name(tid, intern(n));
 }
 
 void Trace::add_lo2s_property(const std::string& name, const std::string& value)
@@ -447,19 +323,8 @@ void Trace::add_lo2s_property(const std::string& name, const std::string& value)
 
     // Add to machine-specific properties which are stored in the system tree
     // root node.  This is the correct way (TM).
-    system_tree_node_properties_.emplace(system_tree_root_node_, intern(property_name),
-                                         otf2::attribute_value{ intern(value) });
-}
-
-void Trace::add_cpu(int cpuid)
-{
-    auto name = intern((boost::format("cpu %d") % cpuid).str());
-
-    location_groups_cpu_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(cpuid),
-        std::forward_as_tuple(location_group_ref(), name,
-                              otf2::definition::location_group::location_group_type::process,
-                              system_tree_cpu_nodes_.at(cpuid)));
+    registry_.create<otf2::definition::system_tree_node_property>(
+        system_tree_root_node_, intern(property_name), otf2::attribute_value{ intern(value) });
 }
 
 otf2::writer::local& Trace::thread_sample_writer(pid_t pid, pid_t tid)
@@ -470,14 +335,16 @@ otf2::writer::local& Trace::thread_sample_writer(pid_t pid, pid_t tid)
     auto name = (boost::format("thread %d") % tid).str();
 
     // As the tid is unique in this context, create only one writer/location per tid
-    auto location = thread_sample_locations_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(tid),
-        std::forward_as_tuple(location_ref(), intern(name), location_groups_process_.at(pid),
-                              otf2::definition::location::location_type::cpu_thread));
+    const auto& location = registry_.emplace<otf2::definition::location>(
+        ByThreadSampleWriter(tid), intern(name),
+        registry_.get<otf2::definition::location_group>(ByProcess(pid)),
+        otf2::definition::location::location_type::cpu_thread);
 
-    process_comm_groups_.at(pid).add_member(location.first->second);
+    registry_.get<otf2::definition::comm_group>(ByProcess(pid)).add_member(location);
 
-    return archive()(location.first->second);
+    comm_locations_group_.add_member(location);
+
+    return archive_(location);
 }
 
 otf2::writer::local& Trace::cpu_sample_writer(int cpuid)
@@ -489,28 +356,30 @@ otf2::writer::local& Trace::cpu_sample_writer(int cpuid)
 #else
     auto name = (boost::format("sample cpu %d") % cpuid).str();
 
-    // As the cpuid is unique in this context, create only one writer/location per tid
-    auto location = cpu_sample_locations_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(cpuid),
-        std::forward_as_tuple(location_ref(), intern(name), location_groups_cpu_.at(cpuid),
-                              otf2::definition::location::location_type::cpu_thread));
+    // As the cpuid is unique in this context, create only one writer/location per cpuid
+    const auto& location = registry_.emplace<otf2::definition::location>(
+        ByCpuSampleWriter(cpuid), intern(name),
+        registry_.get<otf2::definition::location_group>(ByCpu(cpuid)),
+        otf2::definition::location::location_type::cpu_thread);
 
-    return archive()(location.first->second);
+    comm_locations_group_.add_member(location);
+    return archive_(location);
 #endif
 }
 
 otf2::writer::local& Trace::cpu_switch_writer(int cpuid)
 {
-    // As CPU IDs are unique in this context, create only one writer/location per
-    // CPU ID
+    // As the cpuid is unique in this context, create only one writer/location per
+    // cpuid
     auto name = intern((boost::format("cpu %d") % cpuid).str());
 
-    auto location = cpu_switch_locations_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(cpuid),
-        std::forward_as_tuple(location_ref(), name, location_groups_cpu_.at(cpuid),
-                              otf2::definition::location::location_type::cpu_thread));
+    const auto& location = registry_.emplace<otf2::definition::location>(
+        ByCpuSwitchWriter(cpuid), name,
+        registry_.get<otf2::definition::location_group>(ByCpu(cpuid)),
+        otf2::definition::location::location_type::cpu_thread);
 
-    return archive()(location.first->second);
+    comm_locations_group_.add_member(location);
+    return archive_(location);
 }
 
 otf2::writer::local& Trace::thread_metric_writer(pid_t pid, pid_t tid)
@@ -519,32 +388,32 @@ otf2::writer::local& Trace::thread_metric_writer(pid_t pid, pid_t tid)
 
     // As the tid is unique in this context, create only one
     // writer/location per tid
-    auto location = thread_metric_locations_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(tid),
-        std::forward_as_tuple(location_ref(), intern(name), location_groups_process_.at(pid),
-                              otf2::definition::location::location_type::metric));
+    const auto& location = registry_.emplace<otf2::definition::location>(
+        ByThreadMetricWriter(tid), intern(name),
+        registry_.get<otf2::definition::location_group>(ByProcess(pid)),
+        otf2::definition::location::location_type::metric);
 
-    return archive()(location.first->second);
+    return archive_(location);
 }
 
 otf2::writer::local& Trace::cpu_metric_writer(int cpuid)
 {
     auto name = intern((boost::format("metrics for cpu %d") % cpuid).str());
 
-    auto location = cpu_metric_locations_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(cpuid),
-        std::forward_as_tuple(location_ref(), name, location_groups_cpu_.at(cpuid),
-                              otf2::definition::location::location_type::metric));
-    return archive()(location.first->second);
+    const auto& location = registry_.emplace<otf2::definition::location>(
+        ByCpuMetricWriter(cpuid), name,
+        registry_.get<otf2::definition::location_group>(ByCpu(cpuid)),
+        otf2::definition::location::location_type::metric);
+    return archive_(location);
 }
 
 otf2::writer::local& Trace::named_metric_writer(const std::string& name)
 {
     // As names may not be unique in this context, always generate a new location/writer pair
-    auto location = named_metric_locations_.emplace(
-        location_ref(), intern(name), location_groups_process_.at(METRIC_PID),
+    const auto& location = registry_.create<otf2::definition::location>(
+        intern(name), registry_.get<otf2::definition::location_group>(ByProcess(METRIC_PID)),
         otf2::definition::location::location_type::metric);
-    return archive()(location);
+    return archive_(location);
 }
 
 otf2::definition::metric_member
@@ -552,115 +421,55 @@ Trace::metric_member(const std::string& name, const std::string& description,
                      otf2::common::metric_mode mode, otf2::common::type value_type,
                      const std::string& unit, std::int64_t exponent, otf2::common::base_type base)
 {
-    return metric_members_.emplace(metric_member_ref(), intern(name), intern(description),
-                                   otf2::common::metric_type::other, mode, value_type, base,
-                                   exponent, intern(unit));
+    return registry_.create<otf2::definition::metric_member>(
+        intern(name), intern(description), otf2::common::metric_type::other, mode, value_type, base,
+        exponent, intern(unit));
 }
 
 otf2::definition::metric_instance
-Trace::metric_instance(otf2::definition::metric_class metric_class,
-                       otf2::definition::location recorder, otf2::definition::location scope)
+Trace::metric_instance(const otf2::definition::metric_class& metric_class,
+                       const otf2::definition::location& recorder,
+                       const otf2::definition::location& scope)
 {
-    return metric_instances_.emplace(metric_instance_ref(), metric_class, recorder, scope);
+    return registry_.create<otf2::definition::metric_instance>(metric_class, recorder, scope);
 }
 
 otf2::definition::metric_instance
-Trace::metric_instance(otf2::definition::metric_class metric_class,
-                       otf2::definition::location recorder,
-                       otf2::definition::system_tree_node scope)
+Trace::metric_instance(const otf2::definition::metric_class& metric_class,
+                       const otf2::definition::location& recorder,
+                       const otf2::definition::system_tree_node& scope)
 {
-    return metric_instances_.emplace(metric_instance_ref(), metric_class, recorder, scope);
+    return registry_.create<otf2::definition::metric_instance>(metric_class, recorder, scope);
 }
 
-otf2::definition::metric_class Trace::tracepoint_metric_class(const std::string& event_name)
+otf2::definition::metric_class& Trace::tracepoint_metric_class(const std::string& event_name)
 {
-    auto mc = tracepoint_metric_classes_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(event_name),
-        std::forward_as_tuple(metric_class_ref(), otf2::common::metric_occurence::async,
-                              otf2::common::recorder_kind::abstract));
-
-    if (!mc.second)
-    {
-        return mc.first->second;
-    }
-
+    auto& mc = registry_.emplace<otf2::definition::metric_class>(
+        ByString(event_name), otf2::common::metric_occurence::async,
+        otf2::common::recorder_kind::abstract);
     perf::tracepoint::EventFormat event(event_name);
     for (const auto& field : event.fields())
     {
         if (field.is_integer())
         {
-            mc.first->second.add_member(metric_member(event_name + "::" + field.name(), "?",
-                                                      otf2::common::metric_mode::absolute_next,
-                                                      otf2::common::type::int64, "#"));
+            mc.add_member(metric_member(event_name + "::" + field.name(), "?",
+                                        otf2::common::metric_mode::absolute_next,
+                                        otf2::common::type::int64, "#"));
         }
     }
-    return mc.first->second;
+    return mc;
 }
 
-otf2::definition::metric_class Trace::cpuid_metric_class()
+otf2::definition::metric_class& Trace::metric_class()
 {
-    if (!cpuid_metric_class_)
-    {
-        cpuid_metric_class_ = metric_class();
-
-        cpuid_metric_class_->add_member(metric_member("CPU", "CPU executing the task",
-                                                      otf2::common::metric_mode::absolute_point,
-                                                      otf2::common::type::int64, "cpuid"));
-    }
-
-    return cpuid_metric_class_;
-}
-
-otf2::definition::metric_class Trace::perf_metric_class()
-{
-    if (!perf_metric_class_)
-    {
-        perf_metric_class_ = metric_class();
-
-        const perf::EventCollection& event_collection = perf::requested_events();
-
-        if (!event_collection.events.empty())
-        {
-            perf_metric_class_->add_member(metric_member(
-                event_collection.leader.name, event_collection.leader.name,
-                otf2::common::metric_mode::accumulated_start, otf2::common::type::Double, "#"));
-
-            for (const auto& ev : event_collection.events)
-            {
-                perf_metric_class_->add_member(
-                    metric_member(ev.name, ev.name, otf2::common::metric_mode::accumulated_start,
-                                  otf2::common::type::Double, "#"));
-            }
-
-            perf_metric_class_->add_member(metric_member(
-                "time_enabled", "time event active", otf2::common::metric_mode::accumulated_start,
-                otf2::common::type::uint64, "ns"));
-            perf_metric_class_->add_member(metric_member(
-                "time_running", "time event on CPU", otf2::common::metric_mode::accumulated_start,
-                otf2::common::type::uint64, "ns"));
-        }
-    }
-
-    return perf_metric_class_;
-}
-
-otf2::definition::metric_class Trace::metric_class()
-{
-    return metric_classes_.emplace(metric_class_ref(), otf2::common::metric_occurence::async,
-                                   otf2::common::recorder_kind::abstract);
-}
-
-static LineInfo region_info(LineInfo info)
-{
-    // TODO lookup actual line info
-    info.line = 1;
-    return info;
+    return registry_.create<otf2::definition::metric_class>(otf2::common::metric_occurence::async,
+                                                            otf2::common::recorder_kind::abstract);
 }
 
 void Trace::merge_ips(IpRefMap& new_children, IpCctxMap& children,
                       std::vector<uint32_t>& mapping_table,
-                      otf2::definition::calling_context parent, std::map<pid_t, ProcessInfo>& infos,
-                      pid_t pid)
+                      otf2::definition::calling_context& parent,
+                      std::map<pid_t, ProcessInfo>& infos, pid_t pid)
 {
     for (auto& elem : new_children)
     {
@@ -680,25 +489,21 @@ void Trace::merge_ips(IpRefMap& new_children, IpCctxMap& children,
         auto cctx_it = children.find(ip);
         if (cctx_it == children.end())
         {
-            auto ref = calling_context_ref();
-            auto region = intern_region(region_info(line_info));
-            auto scl = intern_scl(line_info);
-            auto new_cctx = calling_contexts_.emplace(ref, region, scl, parent);
+            auto& new_cctx = registry_.create<otf2::definition::calling_context>(
+                intern_region(line_info), intern_scl(line_info), parent);
             auto r = children.emplace(ip, new_cctx);
-            assert(r.second);
             cctx_it = r.first;
 
             if (config().disassemble && infos.count(pid) == 1)
             {
                 try
                 {
-                    // TODO do not write properties for useless unknown stuff
-                    OTF2_AttributeValue_union value;
                     auto instruction = infos.at(pid).maps().lookup_instruction(ip);
                     Log::trace() << "mapped " << ip << " to " << instruction;
-                    value.stringRef = intern(instruction).ref();
-                    calling_context_properties_.emplace(new_cctx, intern("instruction"),
-                                                        otf2::common::type::string, value);
+
+                    registry_.create<otf2::definition::calling_context_property>(
+                        new_cctx, intern("instruction"),
+                        otf2::attribute_value(intern(instruction)));
                 }
                 catch (std::exception& ex)
                 {
@@ -706,7 +511,7 @@ void Trace::merge_ips(IpRefMap& new_children, IpCctxMap& children,
                 }
             }
         }
-        const auto& cctx = cctx_it->second.cctx;
+        auto& cctx = cctx_it->second.cctx;
         mapping_table.at(local_ref) = cctx.ref();
 
         merge_ips(local_children, cctx_it->second.children, mapping_table, cctx, infos, pid);
@@ -752,6 +557,8 @@ otf2::definition::mapping_table Trace::merge_calling_contexts(ThreadCctxRefMap& 
             }
             global_thread_cctx = calling_context_tree_.find(tid);
         }
+
+        assert(global_thread_cctx != calling_context_tree_.end());
         mappings.at(local_ref) = global_thread_cctx->second.cctx.ref();
 
         merge_ips(local_thread_cctx.second.entry.children, global_thread_cctx->second.children,
@@ -775,26 +582,27 @@ void Trace::add_thread_exclusive(pid_t tid, const std::string& name,
     process_names_.emplace(std::piecewise_construct, std::forward_as_tuple(tid),
                            std::forward_as_tuple(name));
 
-    auto iname = intern((boost::format("%s (%d)") % name % tid).str());
-    auto ret = regions_thread_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(tid),
-        std::forward_as_tuple(region_ref(), iname, iname, iname, otf2::common::role_type::function,
-                              otf2::common::paradigm_type::user, otf2::common::flags_type::none,
-                              iname, 0, 0));
+    auto& iname = intern((boost::format("%s (%d)") % name % tid).str());
 
-    // Check that emplacement succeeded. If not, the thread has already been
-    // registered.
-    if (ret.second)
+    if (!registry_.has<otf2::definition::region>(ByThread(tid)))
     {
-        regions_group_executable(name).add_member(ret.first->second);
+        auto& thread_region = registry_.create<otf2::definition::region>(
+            ByThread(tid), iname, iname, iname, otf2::common::role_type::function,
+            otf2::common::paradigm_type::user, otf2::common::flags_type::none, iname, 0, 0);
+        auto& regions_group = registry_.create<otf2::definition::regions_group>(
+            ByString(name), intern(name), otf2::common::paradigm_type::user,
+            otf2::common::group_flag_type::none);
+        regions_group.add_member(thread_region);
     }
+    auto& thread_region = registry_.get<otf2::definition::region>(ByThread(tid));
     // TODO update iname if not newly inserted
 
     // create calling context
-    calling_context_tree_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(tid),
-        std::forward_as_tuple(otf2::definition::calling_context(
-            calling_context_ref(), ret.first->second, otf2::definition::source_code_location())));
+    auto& thread_cctx = registry_.create<otf2::definition::calling_context>(
+        ByThread(tid), thread_region, otf2::definition::source_code_location());
+
+    calling_context_tree_.emplace(std::piecewise_construct, std::forward_as_tuple(tid),
+                                  std::forward_as_tuple(thread_cctx));
 }
 
 void Trace::add_thread(pid_t tid, const std::string& name)
@@ -811,26 +619,22 @@ void Trace::add_monitoring_thread(pid_t tid, const std::string& name, const std:
     std::lock_guard<std::recursive_mutex> guard(mutex_);
 
     Log::debug() << "Adding monitoring thread " << tid << " (" << name << "): group " << group;
-    auto iname = intern((boost::format("lo2s::%s") % name).str());
+    auto& iname = intern((boost::format("lo2s::%s") % name).str());
 
     // TODO, should be paradigm_type::measurement_system, but that's a bug in Vampir
-    auto ret = regions_thread_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(tid),
-        std::forward_as_tuple(region_ref(), iname, iname, iname, otf2::common::role_type::function,
-                              otf2::common::paradigm_type::user, otf2::common::flags_type::none,
-                              iname, 0, 0));
-    if (ret.second)
+    if (!registry_.has<otf2::definition::region>(ByThread(tid)))
     {
-        (void)group;
-        // Put all lo2s stuff in one single group, ignore the group within lo2s
-        regions_group_monitoring("lo2s").add_member(ret.first->second);
-    }
+        const auto& ret = registry_.create<otf2::definition::region>(
+            ByThread(tid), iname, iname, iname, otf2::common::role_type::function,
+            otf2::common::paradigm_type::user, otf2::common::flags_type::none, iname, 0, 0);
 
-    // create calling context
-    calling_context_tree_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(tid),
-        std::forward_as_tuple(otf2::definition::calling_context(
-            calling_context_ref(), ret.first->second, otf2::definition::source_code_location())));
+        lo2s_regions_group_.add_member(ret);
+
+        auto& lo2s_cctx = registry_.create<otf2::definition::calling_context>(
+            ByThread(tid), ret, otf2::definition::source_code_location());
+        calling_context_tree_.emplace(std::piecewise_construct, std::forward_as_tuple(tid),
+                                      std::forward_as_tuple(lo2s_cctx));
+    }
 }
 
 void Trace::add_threads(const std::unordered_map<pid_t, std::string>& tid_map)
@@ -845,57 +649,29 @@ void Trace::add_threads(const std::unordered_map<pid_t, std::string>& tid_map)
     }
 }
 
-otf2::definition::regions_group Trace::regions_group_executable(const std::string& name)
+const otf2::definition::source_code_location& Trace::intern_scl(const LineInfo& info)
 {
-    auto ret = regions_groups_executable_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(name),
-        std::forward_as_tuple(group_ref(), intern(name), otf2::common::paradigm_type::user,
-                              otf2::common::group_flag_type::none));
-    return ret.first->second;
+    return registry_.emplace<otf2::definition::source_code_location>(ByLineInfo(info),
+                                                                     intern(info.file), info.line);
 }
 
-otf2::definition::regions_group Trace::regions_group_monitoring(const std::string& name)
+const otf2::definition::region& Trace::intern_region(const LineInfo& info)
 {
-    // TODO, should be praradigm_type::measurement_system, but that's a bug in Vampir
-    auto ret = regions_groups_monitoring_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(name),
-        std::forward_as_tuple(group_ref(), intern(name), otf2::common::paradigm_type::user,
-                              otf2::common::group_flag_type::none));
-    return ret.first->second;
+    const auto& name_str = intern(info.function);
+    const auto& region = registry_.emplace<otf2::definition::region>(
+        ByLineInfo(info), name_str, name_str, name_str, otf2::common::role_type::function,
+        otf2::common::paradigm_type::sampling, otf2::common::flags_type::none, intern(info.file),
+        info.line, 0);
+    registry_.emplace<otf2::definition::regions_group>(ByString(info.dso), intern(info.dso),
+                                                       otf2::common::paradigm_type::compiler,
+                                                       otf2::common::group_flag_type::none);
+    return region;
 }
-
-otf2::definition::comm Trace::process_comm(pid_t pid)
-{
-    return process_comms_.at(pid);
-}
-
-otf2::definition::source_code_location Trace::intern_scl(const LineInfo& info)
-{
-    auto ret = source_code_locations_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(info),
-        std::forward_as_tuple(scl_ref(), intern(info.file), info.line));
-    return ret.first->second;
-}
-
-otf2::definition::region Trace::intern_region(const LineInfo& info)
-{
-    auto name_str = intern(info.function);
-    auto ret = regions_line_info_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(info),
-        std::forward_as_tuple(region_ref(), name_str, name_str, name_str,
-                              otf2::common::role_type::function,
-                              otf2::common::paradigm_type::sampling, otf2::common::flags_type::none,
-                              intern(info.file), info.line, 0));
-    return ret.first->second;
-}
-
-otf2::definition::string Trace::intern(const std::string& name)
+const otf2::definition::string& Trace::intern(const std::string& name)
 {
     std::lock_guard<std::recursive_mutex> guard(mutex_);
 
-    auto ret = strings_.emplace(std::piecewise_construct, std::forward_as_tuple(name),
-                                std::forward_as_tuple(string_ref(), name));
-    return ret.first->second;
+    return registry_.emplace<otf2::definition::string>(ByString(name), name);
 }
 } // namespace trace
 } // namespace lo2s


### PR DESCRIPTION
This PR bases the functionality of the trace.cpp on the otf2::definition::registry container instead of
using a zoo of home grown std::map()'s.

This might still contain outstanding issues, due to how long this has been in the works but the test traces i did for system and  process mode look normal to me, so I think this is ready for consideration.

This fixes #124 
