### PR TITLE
Issue 117 improve list events

### DIFF
--- a/include/lo2s/perf/counter_description.hpp
+++ b/include/lo2s/perf/counter_description.hpp
@@ -34,6 +34,7 @@ namespace perf
 {
 enum class Availability
 {
+    UNAVAILABLE,
     SYSTEM_MODE,
     PROCESS_MODE,
     UNIVERSAL
@@ -44,7 +45,7 @@ struct CounterDescription
     CounterDescription(const std::string& name, perf_type_id type, std::uint64_t config,
                        std::uint64_t config1 = 0)
     : name(name), type(type), config(config), config1(config1),
-      availability(Availability::UNIVERSAL)
+      availability(Availability::UNAVAILABLE)
     {
     }
 

--- a/include/lo2s/perf/counter_description.hpp
+++ b/include/lo2s/perf/counter_description.hpp
@@ -32,11 +32,19 @@ namespace lo2s
 {
 namespace perf
 {
+enum class Availability
+{
+    SYSTEM_MODE,
+    PROCESS_MODE,
+    UNIVERSAL
+};
+
 struct CounterDescription
 {
     CounterDescription(const std::string& name, perf_type_id type, std::uint64_t config,
                        std::uint64_t config1 = 0)
-    : name(name), type(type), config(config), config1(config1)
+    : name(name), type(type), config(config), config1(config1),
+      availability(Availability::UNIVERSAL)
     {
     }
 
@@ -44,6 +52,7 @@ struct CounterDescription
     perf_type_id type;
     std::uint64_t config;
     std::uint64_t config1;
+    Availability availability;
 };
 } // namespace perf
 } // namespace lo2s

--- a/include/lo2s/perf/event_provider.hpp
+++ b/include/lo2s/perf/event_provider.hpp
@@ -86,8 +86,8 @@ public:
 
     static bool has_event(const std::string& name);
 
-    static std::vector<std::string> get_predefined_event_names();
-    static std::vector<std::string> get_pmu_event_names();
+    static std::vector<CounterDescription> get_predefined_events();
+    static std::vector<CounterDescription> get_pmu_events();
 
     static const CounterDescription& get_default_metric_leader_event();
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -86,6 +86,28 @@ static inline void list_arguments_sorted(std::ostream& os, const std::string& de
     os << io::make_argument_list(description, items.begin(), items.end());
 }
 
+static inline void print_availability(std::ostream& os, const std::string& description,
+                                      std::vector<perf::CounterDescription> events)
+{
+    std::vector<std::string> event_names;
+    for (auto& ev : events)
+    {
+        if (ev.availability == perf::Availability::PROCESS_MODE)
+        {
+            event_names.push_back(ev.name + " *");
+        }
+        else if (ev.availability == perf::Availability::SYSTEM_MODE)
+        {
+            event_names.push_back(ev.name + " #");
+        }
+        else
+        {
+            event_names.push_back(ev.name);
+        }
+    }
+    list_arguments_sorted(os, description, event_names);
+}
+
 static inline void print_version(std::ostream& os)
 {
     // clang-format off
@@ -382,10 +404,14 @@ void parse_program_options(int argc, const char** argv)
 
         if (list_events)
         {
-            list_arguments_sorted(std::cout, "predefined events",
-                                  perf::EventProvider::get_predefined_event_names());
-            list_arguments_sorted(std::cout, "Kernel PMU events",
-                                  perf::EventProvider::get_pmu_event_names());
+            print_availability(std::cout, "predefined events",
+                               perf::EventProvider::get_predefined_events());
+            print_availability(std::cout, "Kernel PMU events",
+                               perf::EventProvider::get_pmu_events());
+
+            std::cout << "(* Only available in process-monitoring mode" << std::endl;
+            std::cout << "(# Only available in system-monitoring mode" << std::endl;
+
             std::exit(EXIT_SUCCESS);
         }
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -92,7 +92,11 @@ static inline void print_availability(std::ostream& os, const std::string& descr
     std::vector<std::string> event_names;
     for (auto& ev : events)
     {
-        if (ev.availability == perf::Availability::PROCESS_MODE)
+        if (ev.availability == perf::Availability::UNAVAILABLE)
+        {
+            continue;
+        }
+        else if (ev.availability == perf::Availability::PROCESS_MODE)
         {
             event_names.push_back(ev.name + " *");
         }

--- a/src/perf/event_provider.cpp
+++ b/src/perf/event_provider.cpp
@@ -192,6 +192,7 @@ static bool event_is_openable(CounterDescription& ev)
     }
     else
     {
+        ev.availability = Availability::UNIVERSAL;
         close(sys_fd);
         close(proc_fd);
     }


### PR DESCRIPTION
This PR adds an indicator to the list-events switch, which shows if an event is only available in process monitoring or system mode.

I haven't tackled the "maybe also check it root privileges are needed part" but that should be easy to implement as well, as we most probably only have to check for EACCES

This PR resolves #117 

This is Also based on #144, so that should probably be merged first.