### PR TITLE
Replace boost::format with fmtlib

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/nitro"]
 	path = lib/nitro
 	url = https://github.com/tud-zih-energy/nitro.git
+[submodule "lib/fmt"]
+	path = lib/fmt
+	url = https://github.com/fmtlib/fmt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,9 @@ set(OTF2XX_CHRONO_DURATION_TYPE nanoseconds CACHE INTERNAL "")
 add_subdirectory(lib/otf2xx)
 mark_as_advanced(OTF2XX_WITH_MPI OTF2_CONFIG OTF2_PRINT)
 
+# configure fmtlib submodule
+add_subdirectory(lib/fmt)
+
 # configure Nitro submodule
 add_subdirectory(lib/nitro)
 
@@ -177,10 +180,10 @@ target_link_libraries(lo2s
         Nitro::env
         Nitro::dl
         Threads::Threads
-        Boost::system
         Boost::program_options
         Boost::filesystem
         Binutils::Binutils
+        fmt::fmt
 )
 
 # old glibc versions require -lrt for clock_gettime()

--- a/include/lo2s/bfd_resolve.hpp
+++ b/include/lo2s/bfd_resolve.hpp
@@ -33,9 +33,7 @@
 #include <vector>
 
 #include <boost/filesystem.hpp>
-#include <boost/format.hpp>
-using fmt = boost::format;
-using boost::str;
+
 using std::hex;
 
 #include <cassert>

--- a/include/lo2s/monitor/threaded_monitor.hpp
+++ b/include/lo2s/monitor/threaded_monitor.hpp
@@ -23,8 +23,6 @@
 
 #include <lo2s/trace/fwd.hpp>
 
-#include <boost/format.hpp>
-
 #include <string>
 #include <thread>
 

--- a/include/lo2s/perf/tracepoint/reader.hpp
+++ b/include/lo2s/perf/tracepoint/reader.hpp
@@ -31,7 +31,6 @@
 #include <lo2s/util.hpp>
 
 #include <boost/filesystem.hpp>
-#include <boost/format.hpp>
 
 #include <ios>
 

--- a/include/lo2s/topology.hpp
+++ b/include/lo2s/topology.hpp
@@ -37,9 +37,7 @@
 
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
-#include <boost/format.hpp>
 
-using fmt = boost::format;
 namespace fs = boost::filesystem;
 using namespace std::literals::string_literals;
 

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -29,8 +29,6 @@
 
 #include <otf2xx/otf2.hpp>
 
-#include <boost/format.hpp>
-
 #include <map>
 #include <mutex>
 #include <unordered_map>

--- a/src/mmap.cpp
+++ b/src/mmap.cpp
@@ -25,7 +25,8 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem.hpp>
-#include <boost/system/error_code.hpp>
+
+#include <fmt/core.h>
 
 #include <mutex>
 #include <regex>
@@ -45,7 +46,7 @@ MemoryMap::MemoryMap(pid_t pid, bool read_initial)
         return;
     }
     // Supposedly this one is faster than /proc/%d/maps for processes with many threads
-    auto filename = str(fmt("/proc/%d/task/%d/maps") % pid % pid);
+    auto filename = fmt::format("/proc/{}/task/{}/maps", pid, pid);
 
     std::ifstream mapstream(filename);
     if (mapstream.fail())

--- a/src/monitor/threaded_monitor.cpp
+++ b/src/monitor/threaded_monitor.cpp
@@ -25,6 +25,8 @@
 #include <lo2s/trace/trace.hpp>
 #include <lo2s/util.hpp>
 
+#include <fmt/core.h>
+
 namespace lo2s
 {
 namespace monitor
@@ -52,7 +54,7 @@ std::string ThreadedMonitor::name() const
     {
         return group();
     }
-    return (boost::format("%s (%s)") % group() % name_).str();
+    return fmt::format("{} ({})", group(), name_);
 }
 
 void ThreadedMonitor::thread_main()

--- a/src/perf/tracepoint/writer.cpp
+++ b/src/perf/tracepoint/writer.cpp
@@ -5,6 +5,8 @@
 
 #include <lo2s/trace/trace.hpp>
 
+#include <fmt/core.h>
+
 namespace lo2s
 {
 namespace perf
@@ -15,7 +17,7 @@ namespace tracepoint
 Writer::Writer(int cpu, const EventFormat& event, trace::Trace& trace_,
                const otf2::definition::metric_class& metric_class)
 : Reader(cpu, event.id()), event_(event),
-  writer_(trace_.named_metric_writer((boost::format("tracepoint metrics for CPU %d") % cpu).str())),
+  writer_(trace_.named_metric_writer(fmt::format("tracepoint metrics for CPU {}", cpu))),
   metric_instance_(
       trace_.metric_instance(metric_class, writer_.location(), trace_.system_tree_cpu_node(cpu))),
   time_converter_(perf::time::Converter::instance()),

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -3,8 +3,9 @@
 #include <lo2s/util.hpp>
 
 #include <boost/filesystem.hpp>
-#include <boost/format.hpp>
 #include <boost/range/iterator_range.hpp>
+
+#include <fmt/core.h>
 
 #include <fstream>
 #include <iomanip>
@@ -61,7 +62,7 @@ std::chrono::duration<double> get_cpu_time()
 
 std::string get_process_exe(pid_t pid)
 {
-    auto proc_exe_filename = (boost::format("/proc/%d/exe") % pid).str();
+    auto proc_exe_filename = fmt::format("/proc/{}/exe", pid);
     char exe_cstr[PATH_MAX + 1];
     auto ret = readlink(proc_exe_filename.c_str(), exe_cstr, PATH_MAX);
 
@@ -104,7 +105,7 @@ std::string get_process_comm(pid_t pid)
     catch (const std::ios::failure&)
     {
         Log::warn() << "Failed to get name for process " << pid;
-        return (boost::format{ "[process %d]" } % pid).str();
+        return fmt::format("[process {}]", pid);
     }
 }
 
@@ -119,7 +120,7 @@ std::string get_task_comm(pid_t pid, pid_t task)
     catch (const std::ios::failure&)
     {
         Log::warn() << "Failed to get name for task " << task << " in process " << pid;
-        return (boost::format{ "[thread %d]" } % task).str();
+        return fmt::format("[thread {}]", task);
     }
 }
 
@@ -183,7 +184,7 @@ std::unordered_map<pid_t, std::string> get_comms_for_running_processes()
         ret.emplace(pid, name);
         try
         {
-            boost::filesystem::path task((boost::format("/proc/%d/task") % pid).str());
+            boost::filesystem::path task(fmt::format("/proc/{}/task", pid));
             for (auto& entry_task :
                  boost::make_iterator_range(boost::filesystem::directory_iterator(task), {}))
             {


### PR DESCRIPTION
Part 1 of the effort to remove boost from lo2s

This PR replaces boost::format with the venerable fmtlib, as well as removing some boost dependencies that weren't used at all.