### PR TITLE
Issue 147 Part 2: boost::filesystem -> std::filesystem (and C++17)

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -53,4 +53,6 @@ SpacesInCStyleCastParentheses: false
 SpaceAfterControlStatementKeyword: true
 SpaceBeforeAssignmentOperators: true
 ContinuationIndentWidth: 4
+BraceWrapping:
+    AfterUnion: true
 ...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,47 +1,10 @@
 language: generic
 
 sudo: required
-dist: trusty
+dist: bionic
 
 matrix:
   include:
-    - os: linux
-      env: CXX="g++-7" CC="gcc-7"
-      compiler: gcc
-      addons:
-        apt:
-          packages:
-            - gcc-7
-            - g++-7
-            - cmake
-            - cmake-data
-            - binutils-dev
-            - zlib1g-dev
-            - libc6-dev
-            - libboost-system-dev
-            - libboost-program-options-dev
-            - libboost-filesystem-dev
-            - linux-libc-dev
-          sources: &sources
-            - ubuntu-toolchain-r-test
-    - os: linux
-      env: CXX="g++-6" CC="gcc-6"
-      compiler: gcc
-      addons:
-        apt:
-          packages:
-            - gcc-6
-            - g++-6
-            - cmake
-            - cmake-data
-            - binutils-dev
-            - zlib1g-dev
-            - libc6-dev
-            - libboost-system-dev
-            - libboost-program-options-dev
-            - libboost-filesystem-dev
-            - linux-libc-dev
-          sources: *sources
     - os: linux
       env: CXX="g++-8" CC="gcc-8"
       compiler: gcc
@@ -55,51 +18,39 @@ matrix:
             - binutils-dev
             - zlib1g-dev
             - libc6-dev
-            - libboost-system-dev
             - libboost-program-options-dev
-            - libboost-filesystem-dev
             - linux-libc-dev
           sources: *sources
     - os: linux
-      env: CXX="clang++-5.0" CC="clang-5.0"
+      env: CXX="clang++-6.0" CC="clang-6.0"
       compiler: clang
       addons:
         apt:
           packages:
-            - clang-5.0
-            - g++-5
+            - clang-6.0
+            - g++-8
             - cmake
             - cmake-data
             - binutils-dev
             - zlib1g-dev
             - libc6-dev
-            - libboost-system-dev
             - libboost-program-options-dev
-            - libboost-filesystem-dev
             - linux-libc-dev
-          sources:
-            - llvm-toolchain-trusty-5.0
-            - ubuntu-toolchain-r-test
     - os: linux
-      env: CXX="clang++-4.0" CC="clang-4.0"
+      env: CXX="clang++-8.0" CC="clang-8.0"
       compiler: clang
       addons:
         apt:
           packages:
-            - clang-4.0
-            - g++-5
+            - clang-8.0
+            - g++-8
             - cmake
             - cmake-data
             - binutils-dev
             - zlib1g-dev
             - libc6-dev
-            - libboost-system-dev
             - libboost-program-options-dev
-            - libboost-filesystem-dev
             - linux-libc-dev
-          sources:
-            - llvm-toolchain-trusty-4.0
-            - ubuntu-toolchain-r-test
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,21 @@ dist: bionic
 matrix:
   include:
     - os: linux
+      env: CXX="g++-7" CC="gcc-7"
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - gcc-7
+            - g++-7
+            - cmake
+            - cmake-data
+            - binutils-dev
+            - zlib1g-dev
+            - libc6-dev
+            - libboost-program-options-dev
+            - linux-libc-dev
+    - os: linux
       env: CXX="g++-8" CC="gcc-8"
       compiler: gcc
       addons:
@@ -20,7 +35,6 @@ matrix:
             - libc6-dev
             - libboost-program-options-dev
             - linux-libc-dev
-          sources: *sources
     - os: linux
       env: CXX="clang++-6.0" CC="clang-6.0"
       compiler: clang
@@ -37,12 +51,12 @@ matrix:
             - libboost-program-options-dev
             - linux-libc-dev
     - os: linux
-      env: CXX="clang++-8.0" CC="clang-8.0"
+      env: CXX="clang++-8" CC="clang-8"
       compiler: clang
       addons:
         apt:
           packages:
-            - clang-8.0
+            - clang-8
             - g++-8
             - cmake
             - cmake-data

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,7 @@ set(THREADS_PREFER_PTHREAD_FLAG true)
 find_package(Threads REQUIRED)
 find_package(Doxygen COMPONENTS dot)
 find_package(x86_energy 2.0 CONFIG)
+find_package(StdFilesystem REQUIRED)
 
 CHECK_STRUCT_HAS_BITFIELD("struct perf_event_attr" context_switch linux/perf_event.h HAVE_PERF_RECORD_SWITCH)
 
@@ -186,7 +187,7 @@ target_link_libraries(lo2s
         Boost::program_options
         Binutils::Binutils
         fmt::fmt
-        stdc++fs
+        std::filesystem
 )
 
 # old glibc versions require -lrt for clock_gettime()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,7 @@ target_link_libraries(lo2s
         Boost::program_options
         Binutils::Binutils
         fmt::fmt
+        stdc++fs
 )
 
 # old glibc versions require -lrt for clock_gettime()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ include(cmake/CheckStructHasBitField.cmake)
 include(cmake/GitSubmoduleUpdate.cmake)
 git_submodule_update()
 
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # Set of variables to enforce static or dynamic linking
 set(lo2s_USE_STATIC_LIBS "MOSTLY" CACHE STRING "Link lo2s statically.")
 set_property(CACHE lo2s_USE_STATIC_LIBS PROPERTY STRINGS "MOSTLY" "OFF" "ALL")
@@ -98,7 +101,7 @@ include(lib/x86_adapt/x86_adapt.cmake)
 
 # find external dependencies
 find_package(Git)
-find_package(Boost REQUIRED COMPONENTS system program_options filesystem)
+find_package(Boost REQUIRED COMPONENTS program_options)
 find_package(Binutils REQUIRED)
 find_package(Radare)
 set(THREADS_PREFER_PTHREAD_FLAG true)
@@ -181,7 +184,6 @@ target_link_libraries(lo2s
         Nitro::dl
         Threads::Threads
         Boost::program_options
-        Boost::filesystem
         Binutils::Binutils
         fmt::fmt
 )

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ In both modes, system-level metrics (e.g. tracepoints), are always grouped by th
  * libiberty
  * boost (>= 1.62)
  * CMake (>= 3.5)
+ * A C++ Compiler with C++17 support and the std::filesystem library (GCC > 7, Clang > 5)
 
 <sup>1</sup>: Use Linux >= 4.1 for best results. Older versions, even the ancient 2.6.32, will work, but with degraded time synchronization.
 

--- a/cmake/FindStdFilesystem.cmake
+++ b/cmake/FindStdFilesystem.cmake
@@ -1,0 +1,136 @@
+# Copyright (c) 2019, ZIH, Technische Universitaet Dresden, Federal Republic of Germany
+#
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#     * Redistributions of source code must retain the above copyright notice,
+#       this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above copyright notice,
+#       this list of conditions and the following disclaimer in the documentation
+#       and/or other materials provided with the distribution.
+#     * Neither the name of metricq nor the names of its contributors
+#       may be used to endorse or promote products derived from this software
+#       without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+# LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+include(FindPackageHandleStandardArgs)
+include(CheckCXXSymbolExists)
+include(CheckCXXSourceCompiles)
+
+if (StdFilesystem_LIBRARY)
+    set(StdFilesystem_FIND_QUIETLY TRUE)
+endif()
+
+# detect the stdlib we are using
+CHECK_CXX_SYMBOL_EXISTS(_LIBCPP_VERSION ciso646 HAS_LIBCXX)
+CHECK_CXX_SYMBOL_EXISTS(__GLIBCXX__ ciso646 HAS_LIBSTDCXX)
+
+if(HAS_LIBSTDCXX)
+    set(StdFSLibName "stdc++fs")
+elseif(HAS_LIBCXX)
+    set(StdFSLibName "c++fs")
+endif()
+
+# detect if the headers are present
+set(CMAKE_REQUIRED_FLAGS "-std=c++17")
+CHECK_CXX_SYMBOL_EXISTS(std::filesystem::status_known filesystem HAS_STD_FILESYSTEM)
+CHECK_CXX_SYMBOL_EXISTS(std::experimental::filesystem::status_known experimental/filesystem HAS_EXPERIMENTAL_STD_FILESYSTEM)
+unset(CMAKE_REQUIRED_LIBRARIES)
+
+# source code for further checks
+if(HAS_EXPERIMENTAL_STD_FILESYSTEM)
+    set(_CHECK_FILESYSTEM_CODE_PREFIX "
+#include <experimental/filesystem>
+namespace std
+{
+using namespace experimental;
+}")
+else()
+    set(_CHECK_FILESYSTEM_CODE_PREFIX "
+#include <filesystem>
+")
+endif()
+set(_CHECK_FILESYSTEM_CODE "
+${_CHECK_FILESYSTEM_CODE_PREFIX}
+int main(void)
+{
+    return std::filesystem::exists(std::filesystem::path(\"\"));
+}
+")
+
+# check if we need to link an additional library
+check_cxx_source_compiles("${_CHECK_FILESYSTEM_CODE}" _HAS_INTEGRATED_STD_FILESYSTEM)
+
+# check if the compiler can find the filesystem library of its stdlib by itself
+if(NOT _HAS_INTEGRATED_STD_FILESYSTEM)
+    set(CMAKE_REQUIRED_LIBRARIES ${StdFSLibName})
+    check_cxx_source_compiles("${_CHECK_FILESYSTEM_CODE}" _HAS_BUNDLED_FILESYSTEM_LIBRARY)
+    unset(CMAKE_REQUIRED_LIBRARIES)
+endif()
+unset(CMAKE_REQUIRED_FLAGS)
+
+# if we only have it in experimental, we still have it
+if(HAS_EXPERIMENTAL_STD_FILESYSTEM)
+    set(HAS_STD_FILESYSTEM TRUE)
+endif()
+
+if(NOT _HAS_INTEGRATED_STD_FILESYSTEM AND NOT _HAS_BUNDLED_FILESYSTEM_LIBRARY)
+    if(HAS_LIBSTDCXX)
+        find_library(StdFilesystem_LIBRARY NAMES ${StdFSLibName} HINTS ENV LD_LIBRARY_PATH ENV LIBRARY_PATH ENV DYLD_LIBRARY_PATH)
+    elseif(HAS_LIBCXX)
+        find_library(StdFilesystem_LIBRARY NAMES ${StdFSLibName} HINTS ENV LD_LIBRARY_PATH ENV LIBRARY_PATH ENV DYLD_LIBRARY_PATH)
+    else()
+        message(WARNING "Couldn't detect your C++ standard library, but also couldn't link without an additional library. This is bad.")
+    endif()
+
+    find_package_handle_standard_args(StdFilesystem
+        "Coudln't determine a proper setup for std::filesystem. Please use a fully C++17 compliant compiler and standard library."
+        StdFilesystem_LIBRARY
+        HAS_STD_FILESYSTEM
+    )
+else()
+    if(_HAS_INTEGRATED_STD_FILESYSTEM)
+        set(OUTPUT_MESSAGE "Compiler integrated")
+    else()
+        set(OUTPUT_MESSAGE "Using -l${StdFSLibName}")
+    endif()
+    find_package_handle_standard_args(StdFilesystem
+        "Coudln't determine a proper setup for std::filesystem. Please use a fully C++17 compliant compiler and standard library."
+        OUTPUT_MESSAGE
+        HAS_STD_FILESYSTEM
+    )
+endif()
+
+# if we have found it, let's define the std::filesystem target
+if(StdFilesystem_FOUND)
+    add_library(std::filesystem INTERFACE IMPORTED)
+    target_compile_features(std::filesystem INTERFACE cxx_std_17)
+
+    if(NOT _HAS_INTEGRATED_STD_FILESYSTEM AND NOT _HAS_BUNDLED_FILESYSTEM_LIBRARY)
+        target_link_libraries(std::filesystem INTERFACE ${StdFilesystem_LIBRARY})
+    elseif(_HAS_BUNDLED_FILESYSTEM_LIBRARY)
+        target_link_libraries(std::filesystem INTERFACE ${StdFSLibName})
+        set(StdFilesystem_LIBRARY ${StdFSLibName})
+    endif()
+
+    if(HAS_EXPERIMENTAL_STD_FILESYSTEM)
+        set_target_properties(std::filesystem PROPERTIES INTERFACE_COMPILE_DEFINITIONS HAS_EXPERIMENTAL_STD_FILESYSTEM)
+    else()
+        set_target_properties(std::filesystem PROPERTIES INTERFACE_COMPILE_DEFINITIONS HAS_STD_FILESYSTEM)
+    endif()
+
+    mark_as_advanced(StdFilesystem_LIBRARY)
+endif()

--- a/include/lo2s/bfd_resolve.hpp
+++ b/include/lo2s/bfd_resolve.hpp
@@ -32,8 +32,6 @@
 #include <unordered_map>
 #include <vector>
 
-#include <boost/filesystem.hpp>
-
 using std::hex;
 
 #include <cassert>

--- a/include/lo2s/config.hpp
+++ b/include/lo2s/config.hpp
@@ -73,6 +73,7 @@ struct Config
     std::chrono::nanoseconds perf_read_interval;
     // Metrics
     bool metric_use_frequency;
+
     union
     {
         std::uint64_t metric_count;

--- a/include/lo2s/config.hpp
+++ b/include/lo2s/config.hpp
@@ -73,7 +73,8 @@ struct Config
     std::chrono::nanoseconds perf_read_interval;
     // Metrics
     bool metric_use_frequency;
-    union {
+    union
+    {
         std::uint64_t metric_count;
         std::uint64_t metric_frequency;
     };

--- a/include/lo2s/config.hpp
+++ b/include/lo2s/config.hpp
@@ -73,7 +73,6 @@ struct Config
     std::chrono::nanoseconds perf_read_interval;
     // Metrics
     bool metric_use_frequency;
-
     union
     {
         std::uint64_t metric_count;

--- a/include/lo2s/filesystem.hpp
+++ b/include/lo2s/filesystem.hpp
@@ -20,11 +20,10 @@
  */
 
 #pragma once
-#include <version>
 
-#ifdef __cpp_lib_filesystem
+#if __has_include(<filesystem>)
 #include <filesystem>
-#elif __cpp_lib_experimental_filesystem
+#elif __has_include(<experimental/filesystem>)
 #include <experimental/filesystem>
 namespace std
 {

--- a/include/lo2s/filesystem.hpp
+++ b/include/lo2s/filesystem.hpp
@@ -1,0 +1,35 @@
+/*
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2016,
+ *    Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <version>
+
+#ifdef __cpp_lib_filesystem
+#include <filesystem>
+#elif __cpp_lib_experimental_filesystem
+#include <experimental/filesystem>
+namespace std
+{
+using namespace experimental;
+}
+#else
+#error "No support for std::filesystem found"
+#endif

--- a/include/lo2s/line_info.hpp
+++ b/include/lo2s/line_info.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 namespace lo2s
 {
@@ -50,7 +50,7 @@ public:
     {
         return LineInfo((file != nullptr) ? file : "<unknown file>",
                         (function != nullptr) ? function : "<unknown function>", line,
-                        boost::filesystem::path(dso).filename().string());
+                        std::filesystem::path(dso).filename().string());
     }
 
     static LineInfo for_unknown_function()
@@ -61,7 +61,7 @@ public:
     static LineInfo for_unknown_function_in_dso(const std::string& dso)
     {
         return LineInfo("<unknown file>", "<unknown function>", UNKNOWN_LINE,
-                        boost::filesystem::path(dso).filename().string());
+                        std::filesystem::path(dso).filename().string());
     }
 
     static LineInfo for_binary(const std::string& binary)

--- a/include/lo2s/line_info.hpp
+++ b/include/lo2s/line_info.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <filesystem>
+#include <lo2s/filesystem.hpp>
 
 namespace lo2s
 {

--- a/include/lo2s/perf/tracepoint/format.hpp
+++ b/include/lo2s/perf/tracepoint/format.hpp
@@ -26,7 +26,7 @@
 
 #include <cstddef>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 namespace lo2s
 {
@@ -141,7 +141,7 @@ private:
     std::vector<EventField> common_fields_;
     std::vector<EventField> fields_;
 
-    const static boost::filesystem::path base_path_;
+    const static std::filesystem::path base_path_;
 };
 } // namespace tracepoint
 } // namespace perf

--- a/include/lo2s/perf/tracepoint/format.hpp
+++ b/include/lo2s/perf/tracepoint/format.hpp
@@ -26,7 +26,7 @@
 
 #include <cstddef>
 
-#include <filesystem>
+#include <lo2s/filesystem.hpp>
 
 namespace lo2s
 {

--- a/include/lo2s/perf/tracepoint/reader.hpp
+++ b/include/lo2s/perf/tracepoint/reader.hpp
@@ -30,7 +30,7 @@
 #include <lo2s/log.hpp>
 #include <lo2s/util.hpp>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include <ios>
 
@@ -41,8 +41,6 @@ extern "C"
 #include <sys/ioctl.h>
 #include <sys/mman.h>
 }
-
-namespace fs = boost::filesystem;
 
 namespace lo2s
 {
@@ -186,11 +184,12 @@ protected:
 private:
     int cpu_;
     int fd_ = -1;
-    const static fs::path base_path;
+    const static std::filesystem::path base_path;
 };
 
 template <typename T>
-const fs::path Reader<T>::base_path = fs::path("/sys/kernel/debug/tracing/events");
+const std::filesystem::path
+    Reader<T>::base_path = std::filesystem::path("/sys/kernel/debug/tracing/events");
 } // namespace tracepoint
 } // namespace perf
 } // namespace lo2s

--- a/include/lo2s/perf/tracepoint/reader.hpp
+++ b/include/lo2s/perf/tracepoint/reader.hpp
@@ -30,7 +30,7 @@
 #include <lo2s/log.hpp>
 #include <lo2s/util.hpp>
 
-#include <filesystem>
+#include <lo2s/filesystem.hpp>
 
 #include <ios>
 

--- a/include/lo2s/topology.hpp
+++ b/include/lo2s/topology.hpp
@@ -35,10 +35,8 @@
 
 #include <cstdint>
 
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
+#include <filesystem>
 
-namespace fs = boost::filesystem;
 using namespace std::literals::string_literals;
 
 namespace lo2s
@@ -143,6 +141,6 @@ private:
 
     bool hypervised_ = false;
 
-    const static fs::path base_path;
+    const static std::filesystem::path base_path;
 };
 } // namespace lo2s

--- a/include/lo2s/topology.hpp
+++ b/include/lo2s/topology.hpp
@@ -35,7 +35,7 @@
 
 #include <cstdint>
 
-#include <filesystem>
+#include <lo2s/filesystem.hpp>
 
 using namespace std::literals::string_literals;
 

--- a/include/lo2s/util.hpp
+++ b/include/lo2s/util.hpp
@@ -21,10 +21,10 @@
 
 #pragma once
 
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
+#include <filesystem>
 
 #include <chrono>
+#include <fstream>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -81,8 +81,8 @@ const struct ::utsname& get_uname();
 template <typename T>
 T get_sysctl(const std::string& group, const std::string& name)
 {
-    auto sysctl_path = boost::filesystem::path("/proc/sys") / group / name;
-    boost::filesystem::ifstream sysctl_stream;
+    auto sysctl_path = std::filesystem::path("/proc/sys") / group / name;
+    std::ifstream sysctl_stream;
     sysctl_stream.exceptions(std::ifstream::failbit | std::ifstream::badbit);
     sysctl_stream.open(sysctl_path);
 

--- a/include/lo2s/util.hpp
+++ b/include/lo2s/util.hpp
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include <filesystem>
+#include <lo2s/filesystem.hpp>
 
 #include <chrono>
 #include <fstream>

--- a/src/bfd_resolve.cpp
+++ b/src/bfd_resolve.cpp
@@ -22,7 +22,8 @@
 #include <lo2s/bfd_resolve.hpp>
 
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
+#include <system_error>
 
 #include <cstdlib>
 
@@ -31,22 +32,22 @@ namespace lo2s
 namespace bfdr
 {
 
-static boost::filesystem::path check_path(const std::string& name)
+static std::filesystem::path check_path(const std::string& name)
 {
-    boost::system::error_code ec;
-    auto path = boost::filesystem::canonical(name, ec);
+    std::error_code ec;
+    auto path = std::filesystem::canonical(name, ec);
     if (ec)
     {
         throw InvalidFileError("could not resolve to canonical path", name);
     }
 
-    auto status = boost::filesystem::status(path, ec);
+    auto status = std::filesystem::status(path, ec);
     if (ec)
     {
         throw InvalidFileError("could not read status", name);
     }
 
-    if (!boost::filesystem::is_regular_file(status))
+    if (!std::filesystem::is_regular_file(status))
     {
         throw InvalidFileError("not a regular file", name);
     }

--- a/src/bfd_resolve.cpp
+++ b/src/bfd_resolve.cpp
@@ -22,7 +22,7 @@
 #include <lo2s/bfd_resolve.hpp>
 
 #include <boost/algorithm/string/predicate.hpp>
-#include <filesystem>
+#include <lo2s/filesystem.hpp>
 #include <system_error>
 
 #include <cstdlib>

--- a/src/mmap.cpp
+++ b/src/mmap.cpp
@@ -24,7 +24,6 @@
 #include <lo2s/util.hpp>
 
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/filesystem.hpp>
 
 #include <fmt/core.h>
 

--- a/src/monitor/cpu_set_monitor.cpp
+++ b/src/monitor/cpu_set_monitor.cpp
@@ -8,8 +8,7 @@
 #include <lo2s/monitor/process_monitor_main.hpp>
 #include <lo2s/perf/event_collection.hpp>
 
-#include <boost/filesystem.hpp>
-#include <boost/range/iterator_range.hpp>
+#include <filesystem>
 
 #include <regex>
 
@@ -28,13 +27,13 @@ CpuSetMonitor::CpuSetMonitor() : MainMonitor()
     std::smatch pid_match;
     pid_t pid;
 
-    const boost::filesystem::path proc_path("/proc");
+    const std::filesystem::path proc_path("/proc");
     if (config().sampling)
     {
-        for (const auto& p :
-             boost::make_iterator_range(boost::filesystem::directory_iterator{ proc_path }, {}))
+        for (const auto& p : std::filesystem::directory_iterator(proc_path))
         {
-            if (std::regex_match(p.path().string(), pid_match, proc_regex))
+            std::string path = p.path().string();
+            if (std::regex_match(path, pid_match, proc_regex))
             {
                 pid = std::stol(pid_match[1]);
 

--- a/src/monitor/cpu_set_monitor.cpp
+++ b/src/monitor/cpu_set_monitor.cpp
@@ -8,7 +8,7 @@
 #include <lo2s/monitor/process_monitor_main.hpp>
 #include <lo2s/perf/event_collection.hpp>
 
-#include <filesystem>
+#include <lo2s/filesystem.hpp>
 
 #include <regex>
 

--- a/src/perf/event_provider.cpp
+++ b/src/perf/event_provider.cpp
@@ -26,11 +26,8 @@
 #include <lo2s/perf/event_provider.hpp>
 #include <lo2s/perf/util.hpp>
 
-#define BOOST_FILESYSTEM_NO_DEPRECATED
-
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
-#include <boost/range/iterator_range.hpp>
+#include <filesystem>
+#include <fstream>
 #include <ios>
 #include <limits>
 #include <regex>
@@ -222,11 +219,11 @@ std::vector<std::string> EventProvider::get_pmu_event_names()
 {
     std::vector<std::string> names;
 
-    namespace fs = boost::filesystem;
+    namespace fs = std::filesystem;
 
     const fs::path pmu_devices("/sys/bus/event_source/devices");
 
-    for (const auto& pmu : boost::make_iterator_range(fs::directory_iterator{ pmu_devices }, {}))
+    for (const auto& pmu : fs::directory_iterator(pmu_devices))
     {
         const auto pmu_path = pmu.path();
 
@@ -238,8 +235,7 @@ std::vector<std::string> EventProvider::get_pmu_event_names()
             continue;
         }
 
-        for (const auto& event :
-             boost::make_iterator_range(fs::directory_iterator{ event_dir }, {}))
+        for (const auto& event : fs::directory_iterator(event_dir))
         {
             std::stringstream event_name;
 
@@ -389,7 +385,7 @@ const CounterDescription raw_read_event(const std::string& ev_desc)
 
 const CounterDescription sysfs_read_event(const std::string& ev_desc)
 {
-    namespace fs = boost::filesystem;
+    namespace fs = std::filesystem;
 
     // Parse event description //
 
@@ -433,7 +429,7 @@ const CounterDescription sysfs_read_event(const std::string& ev_desc)
 
     // read PMU type id
     std::underlying_type<perf_type_id>::type type;
-    if ((fs::ifstream(pmu_path / "type") >> type).fail())
+    if ((std::ifstream(pmu_path / "type") >> type).fail())
     {
         using namespace std::string_literals;
         throw EventProvider::InvalidEvent("unknown PMU '"s + pmu_name + "'");
@@ -444,7 +440,7 @@ const CounterDescription sysfs_read_event(const std::string& ev_desc)
 
     // read event configuration
     std::string ev_cfg;
-    if ((fs::ifstream(pmu_path / "events" / event_name) >> ev_cfg).fail())
+    if ((std::ifstream(pmu_path / "events" / event_name) >> ev_cfg).fail())
     {
         using namespace std::string_literals;
         throw EventProvider::InvalidEvent("unknown event '"s + event_name + "' for PMU '"s +
@@ -483,7 +479,7 @@ const CounterDescription sysfs_read_event(const std::string& ev_desc)
             (kv_match[EC_VALUE].length() != 0) ? kv_match[EC_VALUE] : default_value;
 
         std::string format;
-        if (!(fs::ifstream(pmu_path / "format" / term) >> format))
+        if (!(std::ifstream(pmu_path / "format" / term) >> format))
         {
             throw EventProvider::InvalidEvent("cannot read event format");
         }

--- a/src/perf/event_provider.cpp
+++ b/src/perf/event_provider.cpp
@@ -26,10 +26,10 @@
 #include <lo2s/perf/event_provider.hpp>
 #include <lo2s/perf/util.hpp>
 
-#include <filesystem>
 #include <fstream>
 #include <ios>
 #include <limits>
+#include <lo2s/filesystem.hpp>
 #include <regex>
 #include <sstream>
 

--- a/src/perf/tracepoint/format.cpp
+++ b/src/perf/tracepoint/format.cpp
@@ -23,12 +23,11 @@
 
 #include <lo2s/log.hpp>
 
+#include <fstream>
 #include <regex>
 #include <string>
 
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
 
 #include <cerrno>
 
@@ -50,8 +49,8 @@ EventFormat::EventFormat(const std::string& name) : name_(name)
     // allow perf-like name format which uses ':' as a separator
     std::replace(name_.begin(), name_.end(), ':', '/');
 
-    boost::filesystem::path path_event = base_path_ / name_;
-    boost::filesystem::ifstream ifs_id, ifs_format;
+    std::filesystem::path path_event = base_path_ / name_;
+    std::ifstream ifs_id, ifs_format;
 
     auto id_path = path_event / "id";
     auto format_path = path_event / "format";
@@ -125,7 +124,7 @@ std::vector<std::string> EventFormat::get_tracepoint_event_names()
 {
     try
     {
-        boost::filesystem::ifstream ifs_available_events;
+        std::ifstream ifs_available_events;
         ifs_available_events.exceptions(std::ios::failbit | std::ios::badbit);
 
         ifs_available_events.open("/sys/kernel/debug/tracing/available_events");
@@ -146,7 +145,7 @@ std::vector<std::string> EventFormat::get_tracepoint_event_names()
         return {};
     }
 }
-const boost::filesystem::path EventFormat::base_path_ = "/sys/kernel/debug/tracing/events";
+const std::filesystem::path EventFormat::base_path_ = "/sys/kernel/debug/tracing/events";
 } // namespace tracepoint
 } // namespace perf
 } // namespace lo2s

--- a/src/summary.cpp
+++ b/src/summary.cpp
@@ -2,7 +2,7 @@
 #include <lo2s/summary.hpp>
 #include <lo2s/util.hpp>
 
-#include <filesystem>
+#include <lo2s/filesystem.hpp>
 
 #include <array>
 #include <fstream>

--- a/src/summary.cpp
+++ b/src/summary.cpp
@@ -2,7 +2,7 @@
 #include <lo2s/summary.hpp>
 #include <lo2s/util.hpp>
 
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include <array>
 #include <fstream>
@@ -95,16 +95,17 @@ void Summary::show()
 
     std::chrono::duration<double> cpu_time = get_cpu_time();
 
-    boost::filesystem::recursive_directory_iterator it(trace_dir_), end;
+    std::filesystem::recursive_directory_iterator it(trace_dir_), end;
 
-    trace_size = std::accumulate(it, end, static_cast<size_t>(0),
-                                 [](std::size_t sum, boost::filesystem::directory_entry& entry) {
-                                     if (!boost::filesystem::is_directory(entry))
-                                     {
-                                         return sum + boost::filesystem::file_size(entry);
-                                     }
-                                     return sum;
-                                 });
+    trace_size =
+        std::accumulate(it, end, static_cast<size_t>(0),
+                        [](std::size_t sum, const std::filesystem::directory_entry& entry) {
+                            if (!std::filesystem::is_directory(entry))
+                            {
+                                return sum + std::filesystem::file_size(entry);
+                            }
+                            return sum;
+                        });
 
     if (config().monitor_type == lo2s::MonitorType::PROCESS)
     {

--- a/src/topology.cpp
+++ b/src/topology.cpp
@@ -2,7 +2,7 @@
 
 namespace lo2s
 {
-const fs::path Topology::base_path = "/sys/devices/system/cpu";
+const std::filesystem::path Topology::base_path = "/sys/devices/system/cpu";
 
 namespace detail
 {
@@ -43,10 +43,10 @@ void Topology::read_proc()
     std::string present_list;
 
     {
-        fs::ifstream cpu_online(base_path / "/online");
+        std::ifstream cpu_online(base_path / "/online");
         std::getline(cpu_online, online_list);
 
-        fs::ifstream cpu_present(base_path / "/present");
+        std::ifstream cpu_present(base_path / "/present");
         std::getline(cpu_present, present_list);
     }
 
@@ -57,9 +57,9 @@ void Topology::read_proc()
     {
         std::stringstream filename_stream;
 
-        fs::path topology = base_path / ("cpu"s + std::to_string(cpu_id)) / "topology";
-        fs::ifstream package_stream(topology / "physical_package_id");
-        fs::ifstream core_stream(topology / "core_id");
+        std::filesystem::path topology = base_path / ("cpu"s + std::to_string(cpu_id)) / "topology";
+        std::ifstream package_stream(topology / "physical_package_id");
+        std::ifstream core_stream(topology / "core_id");
 
         uint32_t package_id, core_id;
         package_stream >> package_id;
@@ -98,7 +98,7 @@ void Topology::read_proc()
 
     {
         std::string line;
-        fs::ifstream cpuinfo("/proc/cpuinfo");
+        std::ifstream cpuinfo("/proc/cpuinfo");
 
         while (std::getline(cpuinfo, line))
         {

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -38,7 +38,7 @@
 #include <nitro/env/hostname.hpp>
 
 #include <boost/algorithm/string/replace.hpp>
-#include <filesystem>
+#include <lo2s/filesystem.hpp>
 
 #include <fmt/core.h>
 

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -38,7 +38,7 @@
 #include <nitro/env/hostname.hpp>
 
 #include <boost/algorithm/string/replace.hpp>
-#include <boost/filesystem.hpp>
+#include <filesystem>
 
 #include <fmt/core.h>
 
@@ -216,24 +216,24 @@ Trace::~Trace()
 
     archive_ << otf2::definition::clock_properties(starting_time_, stopping_time_);
 
-    boost::filesystem::path symlink_path = nitro::env::get("LO2S_OUTPUT_LINK");
+    std::filesystem::path symlink_path = nitro::env::get("LO2S_OUTPUT_LINK");
 
     if (symlink_path.empty())
     {
         return;
     }
 
-    if (boost::filesystem::is_symlink(symlink_path))
+    if (std::filesystem::is_symlink(symlink_path))
     {
-        boost::filesystem::remove(symlink_path);
+        std::filesystem::remove(symlink_path);
     }
-    else if (boost::filesystem::exists(symlink_path))
+    else if (std::filesystem::exists(symlink_path))
     {
         Log::warn() << "The path " << symlink_path
                     << " exists and isn't a symlink, refusing to create link to latest trace";
         return;
     }
-    boost::filesystem::create_symlink(trace_name_, symlink_path);
+    std::filesystem::create_symlink(trace_name_, symlink_path);
 }
 
 const otf2::definition::system_tree_node& Trace::intern_process_node(pid_t pid)

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -2,7 +2,7 @@
 #include <lo2s/log.hpp>
 #include <lo2s/util.hpp>
 
-#include <filesystem>
+#include <lo2s/filesystem.hpp>
 
 #include <fmt/core.h>
 

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -2,8 +2,7 @@
 #include <lo2s/log.hpp>
 #include <lo2s/util.hpp>
 
-#include <boost/filesystem.hpp>
-#include <boost/range/iterator_range.hpp>
+#include <filesystem>
 
 #include <fmt/core.h>
 
@@ -76,9 +75,9 @@ std::string get_process_exe(pid_t pid)
     return exe_cstr;
 }
 
-static std::string read_file(const boost::filesystem::path& path)
+static std::string read_file(const std::filesystem::path& path)
 {
-    boost::filesystem::ifstream s;
+    std::ifstream s;
     s.exceptions(std::ifstream::failbit | std::ifstream::badbit);
     s.open(path);
 
@@ -97,7 +96,7 @@ static std::string read_file(const boost::filesystem::path& path)
 
 std::string get_process_comm(pid_t pid)
 {
-    auto proc_comm = boost::filesystem::path{ "/proc" } / std::to_string(pid) / "comm";
+    auto proc_comm = std::filesystem::path{ "/proc" } / std::to_string(pid) / "comm";
     try
     {
         return read_file(proc_comm);
@@ -111,7 +110,7 @@ std::string get_process_comm(pid_t pid)
 
 std::string get_task_comm(pid_t pid, pid_t task)
 {
-    auto task_comm = boost::filesystem::path{ "/proc" } / std::to_string(pid) / "task" /
+    auto task_comm = std::filesystem::path{ "/proc" } / std::to_string(pid) / "task" /
                      std::to_string(task) / "comm";
     try
     {
@@ -167,8 +166,8 @@ const struct ::utsname& get_uname()
 std::unordered_map<pid_t, std::string> get_comms_for_running_processes()
 {
     std::unordered_map<pid_t, std::string> ret;
-    boost::filesystem::path proc("/proc");
-    for (auto& entry : boost::make_iterator_range(boost::filesystem::directory_iterator(proc), {}))
+    std::filesystem::path proc("/proc");
+    for (auto& entry : std::filesystem::directory_iterator(proc))
     {
         pid_t pid;
         try
@@ -184,9 +183,8 @@ std::unordered_map<pid_t, std::string> get_comms_for_running_processes()
         ret.emplace(pid, name);
         try
         {
-            boost::filesystem::path task(fmt::format("/proc/{}/task", pid));
-            for (auto& entry_task :
-                 boost::make_iterator_range(boost::filesystem::directory_iterator(task), {}))
+            std::filesystem::path task(fmt::format("/proc/{}/task", pid));
+            for (auto& entry_task : std::filesystem::directory_iterator(task))
             {
                 pid_t tid;
                 try


### PR DESCRIPTION
This PR get lo2s to C++17 and so replaces boost::filesystem with the all new and shiny std::filesystem

With this I could also remove stuff such as make_iterator_range and boost::fs::ifstream
