### PR TITLE
Issue 151 - Protect the only union in lo2s from being formatted differently by different versions of clang-format

### DIFF
--- a/include/lo2s/config.hpp
+++ b/include/lo2s/config.hpp
@@ -73,10 +73,15 @@ struct Config
     std::chrono::nanoseconds perf_read_interval;
     // Metrics
     bool metric_use_frequency;
+
+    // Newer versions format this differently, so protect this for now
+    // clang-format off
     union {
         std::uint64_t metric_count;
         std::uint64_t metric_frequency;
     };
+    // clang-format on
+
     std::string metric_leader;
     bool standard_metrics;
 


### PR DESCRIPTION
This fixes #151 