### PR TITLE
Remove the only union from lo2s

### DIFF
--- a/include/lo2s/config.hpp
+++ b/include/lo2s/config.hpp
@@ -73,10 +73,10 @@ struct Config
     std::chrono::nanoseconds perf_read_interval;
     // Metrics
     bool metric_use_frequency;
-    union {
-        std::uint64_t metric_count;
-        std::uint64_t metric_frequency;
-    };
+
+    std::uint64_t metric_count;
+    std::uint64_t metric_frequency;
+
     std::string metric_leader;
     bool standard_metrics;
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -533,6 +533,13 @@ void parse_program_options(int argc, const char** argv)
     // Use time interval based metric recording as a default
     if (!vm.count("metric-leader"))
     {
+        if (metric_frequency == 0)
+        {
+            Log::fatal()
+                << "--metric-frequency should not be zero when using the default metric leader";
+            std::exit(EXIT_FAILURE);
+        }
+
         Log::debug() << "checking if cpu-clock is available...";
         try
         {
@@ -556,6 +563,12 @@ void parse_program_options(int argc, const char** argv)
     }
     else
     {
+        if (metric_count == 0)
+        {
+            Log::fatal() << "--metric-count should not be zero when using a custom metric leader";
+            std::exit(EXIT_FAILURE);
+        }
+
         config.metric_use_frequency = false;
         config.metric_count = metric_count;
     }


### PR DESCRIPTION
I think we can live with using 8 byte more memory every time we run lo2s for the sake of more consistent formatting.

This fixes #151 (At least a little)