### PR TITLE
Issue 147 Part 3 boost::algorithm removal

### DIFF
--- a/include/lo2s/io.hpp
+++ b/include/lo2s/io.hpp
@@ -36,8 +36,8 @@
 #include <map>
 #include <string>
 
-#include <boost/algorithm/string.hpp>
 #include <lo2s/time/time.hpp>
+#include <nitro/lang/string.hpp>
 
 namespace lo2s
 {
@@ -128,8 +128,7 @@ operator<<(std::ostream& os, const ArgumentList<std::map<std::string, std::strin
         }
         for (auto it = list.first_; it != list.last_; ++it)
         {
-            std::vector<std::string> lines;
-            boost::split(lines, it->second, [](char c) { return c == '\n'; });
+            std::vector<std::string> lines = nitro::lang::split(it->second, "\n");
             os << "  " << std::left << std::setw(max_string_length + 2) << it->first << lines[0]
                << '\n';
             lines.erase(lines.begin());

--- a/src/bfd_resolve.cpp
+++ b/src/bfd_resolve.cpp
@@ -21,8 +21,8 @@
 #include <lo2s/address.hpp>
 #include <lo2s/bfd_resolve.hpp>
 
-#include <boost/algorithm/string/predicate.hpp>
 #include <filesystem>
+
 #include <system_error>
 
 #include <cstdlib>

--- a/src/mmap.cpp
+++ b/src/mmap.cpp
@@ -23,7 +23,7 @@
 #include <lo2s/mmap.hpp>
 #include <lo2s/util.hpp>
 
-#include <boost/algorithm/string/predicate.hpp>
+#include <nitro/lang/string.hpp>
 
 #include <fmt/core.h>
 
@@ -83,7 +83,7 @@ void MemoryMap::mmap(const RawMemoryMapEntry& entry)
     if (entry.filename.empty() || std::string("//anon") == entry.filename ||
         std::string("/dev/zero") == entry.filename ||
         std::string("/anon_hugepage") == entry.filename ||
-        boost::starts_with(entry.filename, "/SYSV"))
+        nitro::lang::starts_with(entry.filename, "/SYSV"))
     {
         Log::debug() << "mmap: skipping dso: " << entry.filename << " (known non-library)";
         return;

--- a/src/perf/tracepoint/format.cpp
+++ b/src/perf/tracepoint/format.cpp
@@ -28,7 +28,7 @@
 #include <regex>
 #include <string>
 
-#include <boost/algorithm/string/predicate.hpp>
+#include <nitro/lang/string.hpp>
 
 #include <cerrno>
 
@@ -111,7 +111,7 @@ void EventFormat::parse_format_line(const std::string& line)
     std::string name = type_name_match[2];
     EventField field(name, offset, size);
 
-    if (boost::starts_with(name, "common_"))
+    if (nitro::lang::starts_with(name, "common_"))
     {
         common_fields_.emplace_back(field);
     }

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -36,8 +36,8 @@
 
 #include <nitro/env/get.hpp>
 #include <nitro/env/hostname.hpp>
+#include <nitro/lang/string.hpp>
 
-#include <boost/algorithm/string/replace.hpp>
 #include <filesystem>
 
 #include <fmt/core.h>
@@ -67,8 +67,8 @@ std::string get_trace_name(std::string prefix = "")
         prefix = "lo2s_trace_{DATE}";
     }
 
-    boost::replace_all(prefix, "{DATE}", get_datetime());
-    boost::replace_all(prefix, "{HOSTNAME}", nitro::env::hostname());
+    nitro::lang::replace_all(prefix, "{DATE}", get_datetime());
+    nitro::lang::replace_all(prefix, "{HOSTNAME}", nitro::env::hostname());
 
     auto result = prefix;
 
@@ -78,7 +78,7 @@ std::string get_trace_name(std::string prefix = "")
 
     for (std::sregex_iterator it = env_begin; it != env_end; ++it)
     {
-        boost::replace_all(result, it->str(), nitro::env::get((*it)[1]));
+        nitro::lang::replace_all(result, it->str(), nitro::env::get((*it)[1]));
     }
 
     return result;


### PR DESCRIPTION
This PR replaces the boost::algorithm string function used by lo2s with our own homegrown nitro variants

This depends on https://github.com/tud-zih-energy/lo2s/pull/154 so have a look at that first