### PR TITLE
Receive all process names

### DIFF
--- a/include/lo2s/monitor/abstract_process_monitor.hpp
+++ b/include/lo2s/monitor/abstract_process_monitor.hpp
@@ -42,6 +42,8 @@ public:
 
     virtual void exit_process(pid_t pid) = 0;
     virtual void exit_thread(pid_t tid) = 0;
+
+    virtual void update_process_name(pid_t pid, const std::string& name) = 0;
 };
 } // namespace monitor
 } // namespace lo2s

--- a/include/lo2s/monitor/dummy_monitor.hpp
+++ b/include/lo2s/monitor/dummy_monitor.hpp
@@ -61,6 +61,11 @@ public:
     {
         (void)tid;
     }
+
+    virtual void update_process_name([[maybe_unused]] pid_t pid,
+                                     [[maybe_unused]] const std::string& name) override
+    {
+    }
 };
 } // namespace monitor
 } // namespace lo2s

--- a/include/lo2s/monitor/process_monitor.hpp
+++ b/include/lo2s/monitor/process_monitor.hpp
@@ -49,6 +49,8 @@ public:
     void exit_process(pid_t pid) override;
     void exit_thread(pid_t tid) override;
 
+    void update_process_name(pid_t pid, const std::string& name) override;
+
 private:
     std::map<pid_t, ThreadMonitor> threads_;
 };

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -207,7 +207,7 @@ private:
 
     // TODO add location groups (processes), read path from /proc/self/exe symlink
 
-    std::map<pid_t, std::string> process_names_;
+    std::map<pid_t, std::string> thread_names_;
     std::map<pid_t, IpCctxEntry> calling_context_tree_;
 
     otf2::definition::comm_locations_group& comm_locations_group_;

--- a/src/monitor/process_monitor.cpp
+++ b/src/monitor/process_monitor.cpp
@@ -58,6 +58,11 @@ void ProcessMonitor::insert_thread(pid_t pid, pid_t tid, std::string name, bool 
     trace_.update_thread_name(tid, name);
 }
 
+void ProcessMonitor::update_process_name(pid_t pid, const std::string& name)
+{
+    trace_.update_process_name(pid, name);
+}
+
 void ProcessMonitor::exit_process(pid_t pid)
 {
     exit_thread(pid);


### PR DESCRIPTION
This looks more like it:
![image](https://user-images.githubusercontent.com/17126443/87574183-50d63680-c6ce-11ea-86af-d47d09c66b3a.png)


- check for the ptrace EVENT_EXEC event as the name is already updated there
- fix update_process_name (the region.add_member thingy did not work at  all)
- also change the name of the otf2::definition::location

This fixes #143