### PR TITLE
Require C++17 as a whole instead of the individual language features

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,9 +306,7 @@ add_subdirectory(man)
 
 message(STATUS "Linux kernel version: ${LINUX_VERSION}")
 
-set_property(TARGET lo2s PROPERTY CXX_STANDARD 17)
-set_property(TARGET lo2s PROPERTY CXX_STANDARD_REQUIRED ON)
-
+target_compile_features(lo2s PRIVATE cxx_std_17)
 
 # define feature test macro
 target_compile_definitions(lo2s PRIVATE _GNU_SOURCE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,33 +306,9 @@ add_subdirectory(man)
 
 message(STATUS "Linux kernel version: ${LINUX_VERSION}")
 
-# define list of C++ features needed for compilation
-target_compile_features(lo2s
-    PRIVATE
-        cxx_auto_type
-        cxx_constexpr
-        cxx_decltype
-        cxx_decltype_auto
-        cxx_defaulted_functions
-        cxx_defaulted_move_initializers
-        cxx_delegating_constructors
-        cxx_deleted_functions
-        cxx_explicit_conversions
-        cxx_generalized_initializers
-        cxx_generic_lambdas
-        cxx_lambdas
-        cxx_lambda_init_captures
-        cxx_noexcept
-        cxx_nullptr
-        cxx_override
-        cxx_range_for
-        cxx_return_type_deduction
-        cxx_rvalue_references
-        cxx_trailing_return_types
-        cxx_user_literals
-        cxx_variadic_templates
-        cxx_template_template_parameters
-)
+set_property(TARGET lo2s PROPERTY CXX_STANDARD 17)
+set_property(TARGET lo2s PROPERTY CXX_STANDARD_REQUIRED ON)
+
 
 # define feature test macro
 target_compile_definitions(lo2s PRIVATE _GNU_SOURCE)


### PR DESCRIPTION
As the title says.

In the meeting last friday, @tilsche and  I decided to just require C++17 as a whole instead of the different individual language features.

@bmario should probably take a look at this, because he understands CMake probably as much as a human mind is able to.

