### PR TITLE
 fix(trace): Set regions_group name to name of process

### DIFF
--- a/include/lo2s/trace/reg_keys.hpp
+++ b/include/lo2s/trace/reg_keys.hpp
@@ -122,7 +122,8 @@ struct Holder<otf2::definition::system_tree_node>
 template <>
 struct Holder<otf2::definition::regions_group>
 {
-    using type = otf2::lookup_definition_holder<otf2::definition::regions_group, ByString>;
+    using type =
+        otf2::lookup_definition_holder<otf2::definition::regions_group, ByString, ByExecutionScope>;
 };
 template <>
 struct Holder<otf2::definition::metric_class>


### PR DESCRIPTION
Previously every thread became it's own regions_group with the name of the thread as the name of the regions_group

Now we have one regions_group per process with the process' name.

Changing the behaviour to one regions group per executable name (=All processes with name "FIRESTARTER" share the same group)  would be trivial to implement if we would want that instead.

* Add thread->process relations to ExecutionScopeGroup in merge_ips
  and get_comms_for_running_processes() too
* in ~Trace(): use ExecutionScopeGroup to get the process of threads and
  then use the process' name instead of the thread name for the
  regions_group

This fixes #180