### PR TITLE
Removes gcc and clang older than 9.x

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,15 +11,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04]
-        compiler: [g++-8, g++-9, g++-10, clang++-8, clang++-9, clang++-10]
+        compiler: [g++-9, g++-10, clang++-9, clang++-10, clang++-11]
         include:
-          - os: ubuntu-16.04
-            compiler: g++-8
           - os: ubuntu-16.04
             compiler: g++-9
           - os: ubuntu-16.04
-            compiler: clang++-8
-          - os: ubuntu-16.04
+            compiler: clang++-9
+          - os: ubuntu-18.04
+            compiler: g++-9
+          - os: ubuntu-18.04
+            compiler: g++-10
+          - os: ubuntu-18.04
             compiler: clang++-9
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Support was dropped: https://github.com/actions/virtual-environments/issues/2950