### PR TITLE
feat(block I/O): Implement Block I/O tracing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,6 +133,7 @@ set(SOURCE_FILES
     src/monitor/scope_monitor.cpp
     src/monitor/threaded_monitor.cpp
     src/monitor/tracepoint_monitor.cpp
+    src/monitor/bio_monitor.cpp
     src/process_controller.cpp
 
     src/perf/event_provider.cpp
@@ -148,6 +149,7 @@ set(SOURCE_FILES
     src/perf/time/converter.cpp src/perf/time/reader.cpp
     src/perf/tracepoint/format.cpp
     src/perf/tracepoint/writer.cpp
+    src/perf/bio/event_cacher.cpp
 
     src/time/time.cpp
 

--- a/include/lo2s/config.hpp
+++ b/include/lo2s/config.hpp
@@ -90,6 +90,9 @@ struct Config
     clockid_t clockid;
     // x86_energy
     bool use_x86_energy;
+    // block I/O
+    bool use_block_io;
+    size_t block_io_cache_size;
 };
 
 const Config& config();

--- a/include/lo2s/measurement_scope.hpp
+++ b/include/lo2s/measurement_scope.hpp
@@ -30,6 +30,7 @@ enum class MeasurementScopeType
     GROUP_METRIC,
     USERSPACE_METRIC,
     SWITCH,
+    BIO,
     UNKNOWN
 };
 
@@ -66,6 +67,11 @@ struct MeasurementScope
         return { MeasurementScopeType::SWITCH, s };
     }
 
+    static MeasurementScope bio(ExecutionScope s)
+    {
+        return { MeasurementScopeType::BIO, s };
+    }
+
     friend bool operator==(const MeasurementScope& lhs, const MeasurementScope& rhs)
     {
         return (lhs.scope == rhs.scope) && lhs.type == rhs.type;
@@ -94,6 +100,8 @@ struct MeasurementScope
             return fmt::format("samples for {}", scope.name());
         case MeasurementScopeType::SWITCH:
             return fmt::format("context switches for {}", scope.name());
+        case MeasurementScopeType::BIO:
+            return fmt::format("block layer I/O events for {}", scope.name());
         default:
             throw new std::runtime_error("Unknown ExecutionScopeType!");
         }

--- a/include/lo2s/monitor/bio_monitor.hpp
+++ b/include/lo2s/monitor/bio_monitor.hpp
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2017,
+ *    Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <lo2s/perf/bio/event_cacher.hpp>
+#include <lo2s/perf/bio/writer.hpp>
+
+#include <lo2s/monitor/poll_monitor.hpp>
+#include <lo2s/trace/trace.hpp>
+
+#include <map>
+#include <memory>
+
+namespace lo2s
+{
+namespace monitor
+{
+
+class BioMonitor : public PollMonitor
+{
+public:
+    BioMonitor(trace::Trace& trace, Cpu cpu,
+               std::map<dev_t, std::unique_ptr<perf::bio::Writer>>& writers_);
+
+private:
+    void monitor(int fd) override;
+    void initialize_thread() override;
+    void finalize_thread() override;
+
+    std::string group() const override
+    {
+        return "lo2s::BioMonitor";
+    }
+
+private:
+    Cpu cpu_;
+    perf::bio::EventCacher bio_insert_cacher_;
+    perf::bio::EventCacher bio_issue_cacher_;
+    perf::bio::EventCacher bio_complete_cacher_;
+};
+} // namespace monitor
+} // namespace lo2s

--- a/include/lo2s/monitor/main_monitor.hpp
+++ b/include/lo2s/monitor/main_monitor.hpp
@@ -29,6 +29,7 @@
 #include <lo2s/metric/x86_energy/metrics.hpp>
 #endif
 #include <lo2s/mmap.hpp>
+#include <lo2s/monitor/bio_monitor.hpp>
 #include <lo2s/monitor/tracepoint_monitor.hpp>
 #include <lo2s/process_info.hpp>
 #include <lo2s/trace/trace.hpp>
@@ -63,10 +64,12 @@ public:
 
 protected:
     trace::Trace trace_;
-
     std::map<Process, ProcessInfo> process_infos_;
     metric::plugin::Metrics metrics_;
     std::vector<std::unique_ptr<TracepointMonitor>> tracepoint_monitors_;
+
+    std::map<dev_t, std::unique_ptr<perf::bio::Writer>> writers_;
+    std::vector<std::unique_ptr<BioMonitor>> bio_monitors_;
 #ifdef HAVE_X86_ADAPT
     std::unique_ptr<metric::x86_adapt::Metrics> x86_adapt_metrics_;
 #endif

--- a/include/lo2s/perf/bio/block_device.hpp
+++ b/include/lo2s/perf/bio/block_device.hpp
@@ -1,0 +1,66 @@
+/*
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2022,
+ *    Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <string>
+
+extern "C"
+{
+#include <sys/types.h>
+}
+
+namespace lo2s
+{
+
+enum class BlockDeviceType
+{
+    PARTITION,
+    DISK
+};
+
+struct BlockDevice
+{
+    BlockDevice() : id(0), name(), type(BlockDeviceType::PARTITION), parent(0)
+    {
+    }
+
+    BlockDevice(dev_t id, const std::string& name, BlockDeviceType type, dev_t parent)
+    : id(id), name(name), type(type), parent(parent)
+    {
+    }
+
+    static BlockDevice partition(dev_t id, const std::string& name, dev_t parent)
+    {
+        return BlockDevice(id, name, BlockDeviceType::PARTITION, parent);
+    }
+
+    static BlockDevice disk(dev_t id, const std::string& name)
+    {
+        return BlockDevice(id, name, BlockDeviceType::DISK, 0);
+    }
+
+    dev_t id;
+    std::string name;
+    BlockDeviceType type;
+    dev_t parent;
+};
+} // namespace lo2s

--- a/include/lo2s/perf/bio/event_cacher.hpp
+++ b/include/lo2s/perf/bio/event_cacher.hpp
@@ -1,0 +1,91 @@
+/*
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2017,
+ *    Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <lo2s/perf/bio/reader.hpp>
+#include <lo2s/perf/bio/writer.hpp>
+#include <lo2s/perf/time/converter.hpp>
+
+#include <lo2s/trace/trace.hpp>
+
+#include <otf2xx/definition/metric_instance.hpp>
+#include <otf2xx/event/metric.hpp>
+#include <otf2xx/writer/local.hpp>
+
+#include <unordered_map>
+#include <vector>
+
+namespace lo2s
+{
+namespace perf
+{
+namespace bio
+{
+// Note, this cannot be protected for CRTP reasons...
+
+class EventCacher : public Reader<EventCacher>
+{
+public:
+    struct __attribute((__packed__)) RecordBlock
+    {
+        uint16_t common_type;         // 2
+        uint8_t common_flag;          // 3
+        uint8_t common_preempt_count; // 4
+        int32_t common_pid;           // 8
+
+        uint32_t dev; // 12
+        char padding[4];
+        uint64_t sector; // 24
+
+        uint32_t nr_sector; // 28
+        int32_t error_or_bytes;
+
+        char rwbs[8]; // 40
+    };
+
+    EventCacher(Cpu cpu, std::map<dev_t, std::unique_ptr<Writer>>& writers, BioEventType type);
+
+    EventCacher(const EventCacher& other) = delete;
+
+    EventCacher(EventCacher&& other) = default;
+
+public:
+    using Reader<EventCacher>::handle;
+
+    bool handle(const Reader::RecordSampleType* sample);
+
+    void end()
+    {
+        for (auto& events : events_)
+        {
+            writers_[events.first]->submit_events(events.second);
+        }
+    }
+
+private:
+    std::map<dev_t, std::unique_ptr<Writer>>& writers_;
+    std::unordered_map<dev_t, std::vector<BioEvent>> events_;
+};
+
+} // namespace bio
+} // namespace perf
+} // namespace lo2s

--- a/include/lo2s/perf/bio/event_cacher.hpp
+++ b/include/lo2s/perf/bio/event_cacher.hpp
@@ -52,12 +52,12 @@ public:
         uint8_t common_preempt_count; // 4
         int32_t common_pid;           // 8
 
-        uint32_t dev; // 12
-        char padding[4];
+        uint32_t dev;    // 12
+        char padding[4]; // 16
         uint64_t sector; // 24
 
-        uint32_t nr_sector; // 28
-        int32_t error_or_bytes;
+        uint32_t nr_sector;     // 28
+        int32_t error_or_bytes; // 32
 
         char rwbs[8]; // 40
     };
@@ -73,7 +73,7 @@ public:
 
     bool handle(const Reader::RecordSampleType* sample);
 
-    void end()
+    void finalize()
     {
         for (auto& events : events_)
         {

--- a/include/lo2s/perf/bio/reader.hpp
+++ b/include/lo2s/perf/bio/reader.hpp
@@ -1,0 +1,157 @@
+/*
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2017,
+ *    Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <lo2s/measurement_scope.hpp>
+#include <lo2s/perf/bio/writer.hpp>
+#include <lo2s/perf/event_reader.hpp>
+#include <lo2s/perf/tracepoint/format.hpp>
+#include <lo2s/perf/util.hpp>
+
+#include <lo2s/config.hpp>
+#include <lo2s/log.hpp>
+#include <lo2s/util.hpp>
+
+#include <filesystem>
+
+#include <ios>
+
+#include <cstddef>
+
+extern "C"
+{
+#include <fcntl.h>
+#include <linux/perf_event.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+}
+
+namespace lo2s
+{
+namespace perf
+{
+namespace bio
+{
+
+template <class T>
+class Reader : public EventReader<T>
+{
+public:
+    struct RecordSampleType
+    {
+        struct perf_event_header header;
+        uint64_t time;
+        uint32_t tp_data_size;
+        char tp_data[1];
+    };
+    Reader(Cpu cpu, BioEventType type) : type_(type), cpu_(cpu)
+    {
+        struct perf_event_attr attr = common_perf_event_attrs();
+        attr.type = PERF_TYPE_TRACEPOINT;
+        if (type == BioEventType::INSERT)
+        {
+            attr.config = tracepoint::EventFormat("block:block_rq_insert").id();
+        }
+        else if (type == BioEventType::ISSUE)
+        {
+            attr.config = tracepoint::EventFormat("block:block_rq_issue").id();
+        }
+        else
+        {
+            attr.config = tracepoint::EventFormat("block:block_rq_complete").id();
+        }
+
+        attr.sample_period = 1;
+        attr.sample_type = PERF_SAMPLE_RAW | PERF_SAMPLE_TIME;
+
+        fd_ = perf_event_open(&attr, cpu_.as_scope(), -1, 0);
+        if (fd_ < 0)
+        {
+            Log::error() << "perf_event_open for raw tracepoint failed.";
+            throw_errno();
+        }
+        Log::debug() << "Opened block_rq_insert_tracing";
+
+        try
+        {
+            // asynchronous delivery
+            // if (fcntl(fd, F_SETFL, O_ASYNC | O_NONBLOCK))
+            if (fcntl(fd_, F_SETFL, O_NONBLOCK))
+            {
+                throw_errno();
+            }
+
+            init_mmap(fd_);
+            Log::debug() << "perf_tracepoint_reader mmap initialized";
+
+            auto ret = ioctl(fd_, PERF_EVENT_IOC_ENABLE);
+            Log::debug() << "perf_tracepoint_reader ioctl(fd, PERF_EVENT_IOC_ENABLE) = " << ret;
+            if (ret == -1)
+            {
+                throw_errno();
+            }
+        }
+        catch (...)
+        {
+            Log::error() << "Couldn't initialize block:rq_insert reading";
+            close(fd_);
+            throw;
+        }
+    }
+
+    Reader(Reader&& other)
+    : EventReader<T>(std::forward<perf::EventReader<T>>(other)), cpu_(other.cpu_)
+    {
+        std::swap(fd_, other.fd_);
+    }
+
+    ~Reader()
+    {
+        if (fd_ != -1)
+        {
+            close(fd_);
+        }
+    }
+
+    void stop()
+    {
+        auto ret = ioctl(fd_, PERF_EVENT_IOC_DISABLE);
+        Log::debug() << "perf_tracepoint_reader ioctl(fd, PERF_EVENT_IOC_DISABLE) = " << ret;
+        if (ret == -1)
+        {
+            throw_errno();
+        }
+        this->read();
+    }
+
+protected:
+    using EventReader<T>::init_mmap;
+    BioEventType type_;
+
+private:
+    Cpu cpu_;
+    int fd_ = -1;
+};
+} // namespace bio
+} // namespace perf
+} // namespace lo2s

--- a/include/lo2s/perf/bio/reader.hpp
+++ b/include/lo2s/perf/bio/reader.hpp
@@ -64,6 +64,7 @@ public:
         uint32_t tp_data_size;
         char tp_data[1];
     };
+
     Reader(Cpu cpu, BioEventType type) : type_(type), cpu_(cpu)
     {
         struct perf_event_attr attr = common_perf_event_attrs();
@@ -90,12 +91,11 @@ public:
             Log::error() << "perf_event_open for raw tracepoint failed.";
             throw_errno();
         }
+
         Log::debug() << "Opened block_rq_insert_tracing";
 
         try
         {
-            // asynchronous delivery
-            // if (fcntl(fd, F_SETFL, O_ASYNC | O_NONBLOCK))
             if (fcntl(fd_, F_SETFL, O_NONBLOCK))
             {
                 throw_errno();

--- a/include/lo2s/perf/bio/writer.hpp
+++ b/include/lo2s/perf/bio/writer.hpp
@@ -1,0 +1,134 @@
+/*
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2017,
+ *    Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <lo2s/perf/time/converter.hpp>
+#include <lo2s/trace/trace.hpp>
+#include <lo2s/types.hpp>
+#include <lo2s/util.hpp>
+
+#include <otf2xx/otf2.hpp>
+
+#include <cstdint>
+#include <map>
+#include <mutex>
+#include <queue>
+#include <vector>
+
+namespace lo2s
+{
+namespace perf
+{
+namespace bio
+{
+
+enum class BioEventType
+{
+    INSERT,
+    ISSUE,
+    COMPLETE
+};
+
+struct BioEvent
+{
+    BioEvent(dev_t device, uint64_t sector, uint64_t time, BioEventType type,
+             otf2::common::io_operation_mode_type mode, uint32_t nr_sector)
+    : device(device), sector(sector), time(time), type(type), mode(mode), nr_sector(nr_sector)
+    {
+    }
+    dev_t device;
+    uint64_t sector;
+    uint64_t time;
+    BioEventType type;
+    otf2::common::io_operation_mode_type mode;
+    uint32_t nr_sector;
+};
+
+class BioComperator
+{
+public:
+    bool operator()(const BioEvent& t1, const BioEvent& t2)
+    {
+        return t1.time > t2.time;
+    }
+};
+
+class Writer
+{
+public:
+    Writer(trace::Trace& trace, BlockDevice& device)
+    : trace_(trace), time_converter_(time::Converter::instance()), device_(device)
+    {
+    }
+
+    void submit_events(const std::vector<BioEvent>& new_events_)
+    {
+        std::lock_guard<std::mutex> guard(lock_);
+        for (auto& event : new_events_)
+        {
+            events_.emplace(event);
+        }
+    }
+
+    void write_events()
+    {
+        if (events_.empty())
+        {
+            return;
+        }
+        otf2::writer::local& writer = trace_.bio_writer(device_);
+        otf2::definition::io_handle& handle = trace_.block_io_handle(device_);
+        while (!events_.empty())
+        {
+            const BioEvent& event = events_.top();
+            if (event.type == BioEventType::INSERT)
+            {
+                writer << otf2::event::io_operation_begin(
+                    time_converter_(event.time), handle, event.mode,
+                    otf2::common::io_operation_flag_type::non_blocking, event.nr_sector,
+                    event.sector);
+            }
+            else if (event.type == BioEventType::ISSUE)
+            {
+                writer << otf2::event::io_operation_issued(time_converter_(event.time), handle,
+                                                           event.sector);
+            }
+            else
+            {
+                writer << otf2::event::io_operation_complete(time_converter_(event.time), handle,
+                                                             event.nr_sector, event.sector);
+            }
+            events_.pop();
+        }
+    }
+
+private:
+    trace::Trace& trace_;
+    const time::Converter& time_converter_;
+    BlockDevice device_;
+    std::priority_queue<BioEvent, std::vector<BioEvent>, BioComperator> events_;
+    std::mutex lock_;
+};
+
+} // namespace bio
+} // namespace perf
+} // namespace lo2s

--- a/include/lo2s/trace/reg_keys.hpp
+++ b/include/lo2s/trace/reg_keys.hpp
@@ -82,6 +82,11 @@ struct ByProcessTag
 };
 using ByProcess = SimpleKeyType<Process, ByProcessTag>;
 
+struct ByDevTag
+{
+};
+using ByDev = SimpleKeyType<dev_t, ByDevTag>;
+
 struct ByStringTag
 {
 };
@@ -112,12 +117,11 @@ struct Holder
 {
     using type = typename otf2::get_default_holder<Definition>::type;
 };
-
 template <>
 struct Holder<otf2::definition::system_tree_node>
 {
     using type = otf2::lookup_definition_holder<otf2::definition::system_tree_node, ByCore,
-                                                ByProcess, ByCpu, ByPackage>;
+                                                ByProcess, ByDev, ByCpu, ByPackage>;
 };
 template <>
 struct Holder<otf2::definition::regions_group>
@@ -131,6 +135,16 @@ struct Holder<otf2::definition::metric_class>
     using type = otf2::lookup_definition_holder<otf2::definition::metric_class, ByString>;
 };
 template <>
+struct Holder<otf2::definition::io_handle>
+{
+    using type = otf2::lookup_definition_holder<otf2::definition::io_handle, ByDev>;
+};
+template <>
+struct Holder<otf2::definition::io_regular_file>
+{
+    using type = otf2::lookup_definition_holder<otf2::definition::io_regular_file, ByDev>;
+};
+template <>
 struct Holder<otf2::definition::string>
 {
     using type = otf2::lookup_definition_holder<otf2::definition::string, ByString>;
@@ -138,13 +152,14 @@ struct Holder<otf2::definition::string>
 template <>
 struct Holder<otf2::definition::location_group>
 {
-    using type = otf2::lookup_definition_holder<otf2::definition::location_group, ByExecutionScope>;
+    using type =
+        otf2::lookup_definition_holder<otf2::definition::location_group, ByExecutionScope, ByDev>;
 };
 template <>
 struct Holder<otf2::definition::location>
 {
     using type = otf2::lookup_definition_holder<otf2::definition::location, ByExecutionScope,
-                                                ByMeasurementScope>;
+                                                ByMeasurementScope, ByDev>;
 };
 template <>
 struct Holder<otf2::definition::region>
@@ -164,7 +179,7 @@ struct Holder<otf2::definition::source_code_location>
 template <>
 struct Holder<otf2::definition::comm>
 {
-    using type = otf2::lookup_definition_holder<otf2::definition::comm, ByProcess>;
+    using type = otf2::lookup_definition_holder<otf2::definition::comm, ByProcess, ByDev>;
 };
 template <>
 struct Holder<otf2::definition::comm_group>

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -107,7 +107,10 @@ public:
     otf2::writer::local& sample_writer(const ExecutionScope& scope);
     otf2::writer::local& switch_writer(const ExecutionScope& scope);
     otf2::writer::local& metric_writer(const MeasurementScope& scope);
+    otf2::writer::local& bio_writer(BlockDevice& device);
     otf2::writer::local& create_metric_writer(const std::string& name);
+
+    otf2::definition::io_handle& block_io_handle(BlockDevice& device);
 
     otf2::definition::metric_member
     metric_member(const std::string& name, const std::string& description,
@@ -256,6 +259,18 @@ private:
         }
     }
 
+    const otf2::definition::system_tree_node bio_parent_node(BlockDevice& device)
+    {
+        if (device.type == BlockDeviceType::PARTITION)
+        {
+            if (registry_.has<otf2::definition::system_tree_node>(ByDev(device.parent)))
+            {
+                return registry_.get<otf2::definition::system_tree_node>(ByDev(device.parent));
+            }
+        }
+        return bio_system_tree_node_;
+    }
+
     void create_userspace_metric_class()
     {
         const auto& counter_collection_ = perf::counter::requested_userspace_counters();
@@ -303,11 +318,16 @@ private:
     std::map<Thread, IpCctxEntry> calling_context_tree_;
 
     otf2::definition::comm_locations_group& comm_locations_group_;
+    otf2::definition::comm_locations_group& hardware_comm_locations_group_;
     otf2::definition::regions_group& lo2s_regions_group_;
 
     otf2::definition::detail::weak_ref<otf2::definition::metric_class> cpuid_metric_class_;
     otf2::definition::detail::weak_ref<otf2::definition::metric_class> perf_group_metric_class_;
     otf2::definition::detail::weak_ref<otf2::definition::metric_class> perf_userspace_metric_class_;
+
+    otf2::definition::detail::weak_ref<otf2::definition::system_tree_node> bio_system_tree_node_;
+    otf2::definition::detail::weak_ref<otf2::definition::io_paradigm> bio_paradigm_;
+    otf2::definition::detail::weak_ref<otf2::definition::comm_group> bio_comm_group_;
 
     const otf2::definition::system_tree_node& system_tree_root_node_;
 

--- a/include/lo2s/util.hpp
+++ b/include/lo2s/util.hpp
@@ -32,6 +32,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include <cstdint>
 #include <ctime>
@@ -72,6 +73,38 @@ private:
     std::mutex mutex_;
 };
 
+enum class BlockDeviceType
+{
+    PARTITION,
+    DISK
+};
+struct BlockDevice
+{
+    BlockDevice() : id(0), name(), type(BlockDeviceType::PARTITION), parent(0)
+    {
+    }
+
+    BlockDevice(dev_t id, const std::string& name, BlockDeviceType type, dev_t parent)
+    : id(id), name(name), type(type), parent(parent)
+    {
+    }
+
+    static BlockDevice partition(dev_t id, const std::string& name, dev_t parent)
+    {
+        return BlockDevice(id, name, BlockDeviceType::PARTITION, parent);
+    }
+
+    static BlockDevice disk(dev_t id, std::string name)
+    {
+        return BlockDevice(id, name, BlockDeviceType::DISK, 0);
+    }
+
+    dev_t id;
+    std::string name;
+    BlockDeviceType type;
+    dev_t parent;
+};
+
 std::size_t get_page_size();
 std::string get_process_exe(Process process);
 std::string get_process_comm(Process process);
@@ -102,4 +135,5 @@ std::unordered_map<Thread, std::string> get_comms_for_running_threads();
 void try_pin_to_scope(ExecutionScope scope);
 
 Thread gettid();
+std::vector<BlockDevice> get_block_devices();
 } // namespace lo2s

--- a/man/lo2s.1.pod
+++ b/man/lo2s.1.pod
@@ -335,6 +335,20 @@ Record L<x86_energy.h(3)> values.
 
 =back
 
+=head2 B<Block I/O> options
+
+=over
+
+=item B<--block-io>
+
+Record block I/O events using the block:block_rq_insert tracepoint for begin events and block:block_rq_complete tracepoint for end events specifically.
+
+=item B<--block-io-cache-size> I<NUM>
+
+Size of the per-CPU cache in number-of-events. A larger cache size might increase performance but comes at the cost of a higher memory footprint.
+
+=back
+
 =head2 Arguments to options
 
 =over

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -120,6 +120,7 @@ void parse_program_options(int argc, const char** argv)
     auto& kernel_tracepoint_options = parser.group("Kernel tracepoint options");
     auto& x86_adapt_options = parser.group("x86_adapt options");
     auto& x86_energy_options = parser.group("x86_energy options");
+    auto& io_options = parser.group("I/O recording options");
 
     lo2s::Config config;
 
@@ -274,6 +275,12 @@ void parse_program_options(int argc, const char** argv)
 
     x86_energy_options.toggle("x86-energy", "Add x86_energy recordings.").short_name("X");
 
+    io_options.toggle("block-io",
+                      "Enable recording of block I/O events (requires access to debugfs)");
+    io_options.option("block-io-cache-size", "Size (in events) of the block I/O event cache")
+        .optional()
+        .metavar("NUM")
+        .default_value("1000");
     nitro::options::arguments arguments;
     try
     {
@@ -300,6 +307,8 @@ void parse_program_options(int argc, const char** argv)
     config.perf_userspace_events = arguments.get_all("userspace-metric-event");
     config.standard_metrics = arguments.given("standard-metrics");
     config.use_x86_energy = arguments.given("x86-energy");
+    config.use_block_io = arguments.given("block-io");
+    config.block_io_cache_size = arguments.as<std::size_t>("block-io-cache-size");
     config.command = arguments.positionals();
 
     if (arguments.given("help"))

--- a/src/monitor/bio_monitor.cpp
+++ b/src/monitor/bio_monitor.cpp
@@ -41,6 +41,7 @@ BioMonitor::BioMonitor(trace::Trace& trace, Cpu cpu,
     add_fd(bio_issue_cacher_.fd());
     add_fd(bio_complete_cacher_.fd());
 }
+
 void BioMonitor::initialize_thread()
 {
     try_pin_to_scope(cpu_.as_scope());
@@ -48,10 +49,11 @@ void BioMonitor::initialize_thread()
 
 void BioMonitor::finalize_thread()
 {
-    bio_insert_cacher_.end();
-    bio_issue_cacher_.end();
-    bio_complete_cacher_.end();
+    bio_insert_cacher_.finalize();
+    bio_issue_cacher_.finalize();
+    bio_complete_cacher_.finalize();
 }
+
 void BioMonitor::monitor(int fd)
 {
     if (fd == timer_pfd().fd)

--- a/src/monitor/bio_monitor.cpp
+++ b/src/monitor/bio_monitor.cpp
@@ -1,0 +1,81 @@
+/*
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2017,
+ *    Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <lo2s/monitor/bio_monitor.hpp>
+
+#include <lo2s/config.hpp>
+#include <lo2s/log.hpp>
+#include <lo2s/util.hpp>
+
+namespace lo2s
+{
+namespace monitor
+{
+
+BioMonitor::BioMonitor(trace::Trace& trace, Cpu cpu,
+                       std::map<dev_t, std::unique_ptr<perf::bio::Writer>>& writers)
+: monitor::PollMonitor(trace, "", config().perf_read_interval), cpu_(cpu),
+  bio_insert_cacher_(cpu, writers, perf::bio::BioEventType::INSERT),
+  bio_issue_cacher_(cpu, writers, perf::bio::BioEventType::ISSUE),
+  bio_complete_cacher_(cpu, writers, perf::bio::BioEventType::COMPLETE)
+{
+    add_fd(bio_insert_cacher_.fd());
+    add_fd(bio_issue_cacher_.fd());
+    add_fd(bio_complete_cacher_.fd());
+}
+void BioMonitor::initialize_thread()
+{
+    try_pin_to_scope(cpu_.as_scope());
+}
+
+void BioMonitor::finalize_thread()
+{
+    bio_insert_cacher_.end();
+    bio_issue_cacher_.end();
+    bio_complete_cacher_.end();
+}
+void BioMonitor::monitor(int fd)
+{
+    if (fd == timer_pfd().fd)
+    {
+        return;
+    }
+    else if (fd == bio_insert_cacher_.fd())
+    {
+        bio_insert_cacher_.read();
+    }
+    else if (fd == bio_issue_cacher_.fd())
+    {
+        bio_issue_cacher_.read();
+    }
+    else if (fd == bio_complete_cacher_.fd())
+    {
+        bio_complete_cacher_.read();
+    }
+    else
+    {
+        bio_insert_cacher_.read();
+        bio_issue_cacher_.read();
+        bio_complete_cacher_.read();
+    }
+}
+} // namespace monitor
+} // namespace lo2s

--- a/src/perf/bio/event_cacher.cpp
+++ b/src/perf/bio/event_cacher.cpp
@@ -1,0 +1,69 @@
+#include <lo2s/config.hpp>
+#include <lo2s/perf/bio/event_cacher.hpp>
+#include <lo2s/perf/time/converter.hpp>
+#include <lo2s/trace/trace.hpp>
+
+#include <fmt/core.h>
+
+#include <string>
+
+extern "C"
+{
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+}
+
+namespace lo2s
+{
+namespace perf
+{
+namespace bio
+{
+
+EventCacher::EventCacher(Cpu cpu, std::map<dev_t, std::unique_ptr<Writer>>& writers,
+                         BioEventType type)
+: Reader(cpu, type), writers_(writers)
+{
+    for (auto& entry : get_block_devices())
+    {
+        events_.emplace(std::piecewise_construct, std::forward_as_tuple(entry.id), std::tuple());
+
+        events_[entry.id].reserve(config().block_io_cache_size);
+    }
+}
+
+bool EventCacher::handle(const Reader::RecordSampleType* sample)
+{
+    struct RecordBlock* record = (struct RecordBlock*)&sample->tp_data;
+    otf2::common::io_operation_mode_type mode = otf2::common::io_operation_mode_type::flush;
+    // TODO: Handle the few io operations that arent either reads or write
+    if (record->rwbs[0] == 'R')
+    {
+        mode = otf2::common::io_operation_mode_type::read;
+    }
+    else if (record->rwbs[0] == 'W')
+    {
+        mode = otf2::common::io_operation_mode_type::write;
+    }
+    else
+    {
+        return false;
+    }
+
+    dev_t dev = makedev(record->dev >> 20, record->dev & ((1U << 20) - 1));
+    // Linux reports the size of  I/O operations in number of sectors, which are always 512 byte
+    // lare, regardless of what the real sector size of the block device is
+    events_[dev].push_back(
+        BioEvent(dev, record->sector, sample->time, type_, mode, record->nr_sector * 512));
+
+    if (events_[dev].size() == config().block_io_cache_size)
+    {
+        writers_[dev]->submit_events(events_[dev]);
+        events_[dev].clear();
+    }
+    return false;
+}
+
+} // namespace bio
+} // namespace perf
+} // namespace lo2s

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -26,6 +26,7 @@
 #include <lo2s/config.hpp>
 #include <lo2s/line_info.hpp>
 #include <lo2s/mmap.hpp>
+#include <lo2s/perf/bio/block_device.hpp>
 #include <lo2s/perf/tracepoint/format.hpp>
 #include <lo2s/summary.hpp>
 #include <lo2s/time/time.hpp>


### PR DESCRIPTION
Introduces the --block-io switch to record block I/O events

The implementation is discussed in detail in #196 

This closes #196 