### PR TITLE
Issue 198 cgroups

### DIFF
--- a/include/lo2s/config.hpp
+++ b/include/lo2s/config.hpp
@@ -59,6 +59,7 @@ struct Config
 #ifdef HAVE_X86_ADAPT
     std::vector<std::string> x86_adapt_knobs;
 #endif
+    int cgroup_fd = -1;
     // OTF2
     std::string trace_path;
     // perf

--- a/include/lo2s/perf/sample/reader.hpp
+++ b/include/lo2s/perf/sample/reader.hpp
@@ -146,7 +146,7 @@ protected:
          * and the value of it is greater than the initial value */
         do
         {
-            fd_ = perf_event_open(&perf_attr, scope, -1, 0);
+            fd_ = perf_event_open(&perf_attr, scope, -1, 0, config().cgroup_fd);
 
             if (errno == EACCES && !perf_attr.exclude_kernel && perf_event_paranoid() > 1)
             {

--- a/include/lo2s/perf/tracepoint/reader.hpp
+++ b/include/lo2s/perf/tracepoint/reader.hpp
@@ -120,7 +120,7 @@ public:
         attr.sample_period = 1;
         attr.sample_type = PERF_SAMPLE_RAW | PERF_SAMPLE_TIME;
 
-        fd_ = perf_event_open(&attr, cpu.as_scope(), -1, 0);
+        fd_ = perf_event_open(&attr, cpu.as_scope(), -1, 0, config().cgroup_fd);
         if (fd_ < 0)
         {
             Log::error() << "perf_event_open for raw tracepoint failed.";

--- a/include/lo2s/perf/util.hpp
+++ b/include/lo2s/perf/util.hpp
@@ -14,14 +14,14 @@ namespace perf
 
 int perf_event_paranoid();
 int perf_event_open(struct perf_event_attr* perf_attr, ExecutionScope scope, int group_fd,
-                    unsigned long flags);
+                    unsigned long flags, int cgroup_fd = -1);
 struct perf_event_attr common_perf_event_attrs();
 void perf_warn_paranoid();
 void perf_check_disabled();
 
 int perf_event_description_open(ExecutionScope scope, const EventDescription& desc, int group_fd);
 int perf_try_event_open(struct perf_event_attr* perf_attr, ExecutionScope scope, int group_fd,
-                        unsigned long flags);
+                        unsigned long flags, int cgroup_fd = -1);
 
 } // namespace perf
 } // namespace lo2s

--- a/include/lo2s/util.hpp
+++ b/include/lo2s/util.hpp
@@ -98,6 +98,8 @@ std::unordered_map<Thread, std::string> get_comms_for_running_threads();
 
 void try_pin_to_scope(ExecutionScope scope);
 
+int get_cgroup_mountpoint_fd(std::string cgroup);
+
 Thread gettid();
 
 std::vector<BlockDevice> get_block_devices();

--- a/man/lo2s.1.pod
+++ b/man/lo2s.1.pod
@@ -184,6 +184,10 @@ Beyond standard clocks lo2s also supports a special "pebs" clock, which will
 give the same timestamps as "monotonic-raw", but is set up in a slightly different
 way to support the large PEBS feature of newer (Skylake+) Intel processors
 
+=item B<--cgroup> I<NAME>
+
+If set, only perf events for processes in the I<NAME> cgroup are recorded.
+
 =item B<--list-clockids>
 
 List the names of clocks that can be used as I<CLOCKID> argument.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -452,36 +452,7 @@ void parse_program_options(int argc, const char** argv)
 
         if (arguments.provided("cgroup"))
         {
-            std::ifstream mtab("/proc/mounts");
-
-            // This regex does not work when cgroupfs is mounted on a path containing whitespaces
-            // But i think people that mount important Linux filesystems on paths containing
-            // whitespaces should not be let anywhere near lo2s anyways
-            // /proc/mounts format:
-            // device mountpoint fs_type options freq passno
-            std::regex cgroup_regex(R"((\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+)\s+(\S+))");
-            std::smatch cgroup_match;
-            std::string line;
-            while (std::getline(mtab, line))
-            {
-                if (std::regex_match(line, cgroup_match, cgroup_regex))
-                {
-                    // For the ancient cgroupfs mount point we have to use the one with perf_event
-                    // in the options
-                    if (cgroup_match[3].str() != "cgroup" ||
-                        cgroup_match[4].str().find("perf_event"))
-                    {
-                        std::filesystem::path cgroup_path =
-                            std::filesystem::path(cgroup_match[2].str()) / arguments.get("cgroup");
-                        config.cgroup_fd = open(cgroup_path.c_str(), O_RDONLY);
-
-                        if (config.cgroup_fd != -1)
-                        {
-                            break;
-                        }
-                    }
-                }
-            }
+            config.cgroup_fd = get_cgroup_mountpoint_fd(arguments.get("cgroup"));
 
             if (config.cgroup_fd == -1)
             {

--- a/src/perf/counter/group/reader.cpp
+++ b/src/perf/counter/group/reader.cpp
@@ -79,7 +79,7 @@ Reader<T>::Reader(ExecutionScope scope, bool enable_on_exec)
         PERF_FORMAT_TOTAL_TIME_ENABLED | PERF_FORMAT_TOTAL_TIME_RUNNING | PERF_FORMAT_GROUP;
     leader_attr.enable_on_exec = enable_on_exec;
 
-    group_leader_fd_ = perf_try_event_open(&leader_attr, scope, -1, 0);
+    group_leader_fd_ = perf_try_event_open(&leader_attr, scope, -1, 0, config().cgroup_fd);
     if (group_leader_fd_ < 0)
     {
         Log::error() << "perf_event_open for counter group leader failed";

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -358,7 +358,8 @@ int get_cgroup_mountpoint_fd(std::string cgroup)
         {
             // For the ancient cgroupfs mount point we have to use the one with perf_event
             // in the options
-            if (cgroup_match[3].str() != "cgroup" || cgroup_match[4].str().find("perf_event"))
+            if (cgroup_match[3].str() == "cgroup2" ||
+                (cgroup_match[3].str() == "cgroup" && cgroup_match[4].str().find("perf_event")))
             {
                 std::filesystem::path cgroup_path =
                     std::filesystem::path(cgroup_match[2].str()) / cgroup;


### PR DESCRIPTION
This adds an option to filter perf events by cgroup

@rschoene could you confirm that this does what you want it to do?

Caveats:

* This assumes that cgroupfs is mounted at /sys/fs/cgroup, where it is mounted on 99,9% of Linux systems. However there is nothing stopping you from mounting it wherever you like. Do we:
    1. Live with that
    2. Reguire full paths, which practically no other tool requires
    3. Port perfs rather ugly cgroupfs-mountpoint searching code.
* This only covers perf events, which makes sense for now (why filter x86_energy by cgroup) but we must keep that in mind for some place in the future where not everything in lo2s comes from perf (BPF for example)

This closes #198 .