### PR TITLE
fix(metrics): Use .scale and .unit for PMU events

### DIFF
--- a/include/lo2s/perf/counter/counter_collection.hpp
+++ b/include/lo2s/perf/counter/counter_collection.hpp
@@ -35,6 +35,18 @@ struct CounterCollection
 {
     EventDescription leader;
     std::vector<EventDescription> counters;
+
+    double get_scale(int index) const
+    {
+        if (index == 0)
+        {
+            return leader.scale;
+        }
+        else
+        {
+            return counters[index - 1].scale;
+        }
+    }
 };
 
 const CounterCollection& requested_userspace_counters();

--- a/include/lo2s/perf/counter/group/writer.hpp
+++ b/include/lo2s/perf/counter/group/writer.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <lo2s/perf/counter/counter_collection.hpp>
 #include <lo2s/perf/counter/group/reader.hpp>
 #include <lo2s/perf/counter/metric_writer.hpp>
 #include <lo2s/perf/time/converter.hpp>
@@ -41,6 +42,9 @@ public:
 
     using Reader<Writer>::handle;
     bool handle(const RecordSampleType* sample);
+
+private:
+    const CounterCollection& counters_;
 };
 } // namespace group
 } // namespace counter

--- a/include/lo2s/perf/counter/userspace/writer.hpp
+++ b/include/lo2s/perf/counter/userspace/writer.hpp
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <lo2s/perf/counter/counter_collection.hpp>
 #include <lo2s/perf/counter/metric_writer.hpp>
 #include <lo2s/perf/counter/userspace/reader.hpp>
 #include <lo2s/perf/time/converter.hpp>
@@ -41,6 +42,9 @@ public:
     Writer(ExecutionScope scope, trace::Trace& trace);
 
     bool handle(std::vector<UserspaceReadFormat>& data);
+
+private:
+    const CounterCollection& counters_;
 };
 } // namespace userspace
 } // namespace counter

--- a/include/lo2s/perf/event_description.hpp
+++ b/include/lo2s/perf/event_description.hpp
@@ -43,14 +43,14 @@ enum class Availability
 struct EventDescription
 {
     EventDescription(const std::string& name, perf_type_id type, std::uint64_t config,
-                     std::uint64_t config1 = 0)
-    : name(name), type(type), config(config), config1(config1),
+                     std::uint64_t config1 = 0, double scale = 1, std::string unit = "#")
+    : name(name), type(type), config(config), config1(config1), scale(scale), unit(unit),
       availability(Availability::UNAVAILABLE)
     {
     }
 
     EventDescription()
-    : name(""), type(static_cast<perf_type_id>(-1)), config(0), config1(0),
+    : name(""), type(static_cast<perf_type_id>(-1)), config(0), config1(0), scale(1), unit("#"),
       availability(Availability::UNAVAILABLE)
     {
     }
@@ -59,6 +59,8 @@ struct EventDescription
     perf_type_id type;
     std::uint64_t config;
     std::uint64_t config1;
+    double scale;
+    std::string unit;
     Availability availability;
 };
 } // namespace perf

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -243,15 +243,16 @@ private:
             otf2::common::metric_occurence::async, otf2::common::recorder_kind::abstract);
         if (!counter_collection_.counters.empty())
         {
-            perf_group_metric_class_->add_member(metric_member(
-                counter_collection_.leader.name, counter_collection_.leader.name,
-                otf2::common::metric_mode::accumulated_start, otf2::common::type::Double, "#"));
+            perf_group_metric_class_->add_member(
+                metric_member(counter_collection_.leader.name, counter_collection_.leader.name,
+                              otf2::common::metric_mode::accumulated_start,
+                              otf2::common::type::Double, counter_collection_.leader.unit));
 
             for (const auto& counter : counter_collection_.counters)
             {
                 perf_group_metric_class_->add_member(metric_member(
                     counter.name, counter.name, otf2::common::metric_mode::accumulated_start,
-                    otf2::common::type::Double, "#"));
+                    otf2::common::type::Double, counter.unit));
             }
 
             perf_group_metric_class_->add_member(metric_member(

--- a/src/perf/counter/group/writer.cpp
+++ b/src/perf/counter/group/writer.cpp
@@ -32,7 +32,8 @@ namespace counter
 namespace group
 {
 Writer::Writer(ExecutionScope scope, trace::Trace& trace, bool enable_on_exec)
-: Reader(scope, enable_on_exec), MetricWriter(MeasurementScope::group_metric(scope), trace)
+: Reader(scope, enable_on_exec), MetricWriter(MeasurementScope::group_metric(scope), trace),
+  counters_(requested_group_counters())
 {
 }
 
@@ -50,7 +51,7 @@ bool Writer::handle(const Reader::RecordSampleType* sample)
     // read counter values into metric event
     for (std::size_t i = 0; i < counter_buffer_.size(); i++)
     {
-        values[i] = counter_buffer_[i];
+        values[i] = counter_buffer_[i] * counters_.get_scale(i);
     }
 
     auto index = counter_buffer_.size();

--- a/src/perf/counter/userspace/writer.cpp
+++ b/src/perf/counter/userspace/writer.cpp
@@ -33,7 +33,8 @@ namespace counter
 namespace userspace
 {
 Writer::Writer(ExecutionScope scope, trace::Trace& trace)
-: Reader(scope), MetricWriter(MeasurementScope::userspace_metric(scope), trace)
+: Reader(scope), MetricWriter(MeasurementScope::userspace_metric(scope), trace),
+  counters_(requested_userspace_counters())
 {
 }
 
@@ -49,9 +50,10 @@ bool Writer::handle(std::vector<UserspaceReadFormat>& data)
     assert(counter_buffer_.size() <= values.size());
 
     // read counter values into metric event
+
     for (std::size_t i = 0; i < counter_buffer_.size(); i++)
     {
-        values[i] = counter_buffer_[i];
+        values[i] = counter_buffer_[i] * counters_.get_scale(i);
     }
 
     writer_.write(metric_event_);

--- a/src/perf/event_provider.cpp
+++ b/src/perf/event_provider.cpp
@@ -473,7 +473,8 @@ const EventDescription sysfs_read_event(const std::string& ev_desc)
 
     // read event configuration
     std::string ev_cfg;
-    std::ifstream event_stream(pmu_path / "events" / event_name);
+    std::filesystem::path event_path = pmu_path / "events" / event_name;
+    std::ifstream event_stream(event_path);
     event_stream >> ev_cfg;
     if (!event_stream)
     {
@@ -535,6 +536,20 @@ const EventDescription sysfs_read_event(const std::string& ev_desc)
     Log::debug() << std::hex << std::showbase << "parsed event description: " << pmu_name << "/"
                  << event_name << "/type=" << event.type << ",config=" << event.config
                  << ",config1=" << event.config1 << std::dec << std::noshowbase << "/";
+
+    std::ifstream scale_stream(event_path.string() + ".scale");
+    scale_stream >> event.scale;
+    if (scale_stream.fail())
+    {
+        event.scale = 1;
+    }
+
+    std::ifstream unit_stream(event_path.string() + ".unit");
+    unit_stream >> event.unit;
+    if (scale_stream.fail())
+    {
+        event.unit = "#";
+    }
 
     if (!event_is_openable(event))
     {


### PR DESCRIPTION
This fixes #208

PMU events may come with a separate scaling factor, which needs to be
multiplied with the event read-out. This is located in [event_path].scale.

As I was touching the PMU event read code anyways I also added support
for parsing the [event_path].unit, which tells us the unit of the PMU event.

Traces look fine by me, can you further test this @s9105947 ?