### PR TITLE
Don't use exceptions for control flow

### DIFF
--- a/include/lo2s/process_controller.hpp
+++ b/include/lo2s/process_controller.hpp
@@ -37,6 +37,12 @@ namespace lo2s
 
 class ProcessController
 {
+    enum class SignalHandlingState
+    {
+        KeepRunning,
+        Stop
+    };
+
 public:
     ProcessController(Process child, const std::string& name, bool spawn,
                       monitor::AbstractProcessMonitor& monitor);
@@ -48,7 +54,7 @@ public:
 private:
     void handle_ptrace_event(Thread thread, int event);
 
-    void handle_signal(Thread thread, int status);
+    SignalHandlingState handle_signal(Thread thread, int status);
 
     const Thread first_child_;
     sighandler_t default_signal_handler;


### PR DESCRIPTION
It hurts to exit the main loop by exception, when during the stack unwinding another exception gets thrown. We're then directly in std::terminate land and the error message is "Success".