### PR TITLE
fix monitor cleanup and potential race condition

### DIFF
--- a/src/monitor/cpu_set_monitor.cpp
+++ b/src/monitor/cpu_set_monitor.cpp
@@ -66,15 +66,31 @@ CpuSetMonitor::CpuSetMonitor() : MainMonitor()
 
     trace_.add_threads(get_comms_for_running_threads());
 
-    for (const auto& cpu : Topology::instance().cpus())
+    try
     {
-        Log::debug() << "Create cstate recorder for cpu #" << cpu.as_int();
+        for (const auto& cpu : Topology::instance().cpus())
+        {
+            Log::debug() << "Create cstate recorder for cpu #" << cpu.as_int();
 
-        auto inserted = monitors_.emplace(std::piecewise_construct, std::forward_as_tuple(cpu),
-                                          std::forward_as_tuple(ExecutionScope(cpu), *this, false));
-        assert(inserted.second);
-        // directly start the measurement thread
-        inserted.first->second.start();
+            auto inserted = monitors_.emplace(std::piecewise_construct, std::forward_as_tuple(cpu),
+                                            std::forward_as_tuple(ExecutionScope(cpu), *this, false));
+            assert(inserted.second);
+            // directly start the measurement thread
+            inserted.first->second.start();
+        }
+    }
+    catch (...)
+    {
+        Log::error() << "Failed to create/start all CPU monitors ("
+                     << monitors_.size() << " out of "
+                     << Topology::instance().cpus().size() << " suceeded): remove already existing monitors";
+
+        // clean up existing thread
+        for (auto& monitor_map_it : monitors_) {
+            monitor_map_it.second.stop();
+        }
+
+        throw;
     }
 }
 

--- a/src/monitor/cpu_set_monitor.cpp
+++ b/src/monitor/cpu_set_monitor.cpp
@@ -70,8 +70,11 @@ CpuSetMonitor::CpuSetMonitor() : MainMonitor()
     {
         Log::debug() << "Create cstate recorder for cpu #" << cpu.as_int();
 
-        monitors_.emplace(std::piecewise_construct, std::forward_as_tuple(cpu),
-                          std::forward_as_tuple(ExecutionScope(cpu), *this, false));
+        auto inserted = monitors_.emplace(std::piecewise_construct, std::forward_as_tuple(cpu),
+                                          std::forward_as_tuple(ExecutionScope(cpu), *this, false));
+        assert(inserted.second);
+        // directly start the measurement thread
+        inserted.first->second.start();
     }
 }
 

--- a/src/monitor/process_monitor.cpp
+++ b/src/monitor/process_monitor.cpp
@@ -55,8 +55,11 @@ void ProcessMonitor::insert_thread(Process process, Thread thread, std::string n
         perf::counter::CounterProvider::instance().has_group_counters(ExecutionScope(thread)) ||
         perf::counter::CounterProvider::instance().has_userspace_counters(ExecutionScope(thread)))
     {
-        threads_.emplace(std::piecewise_construct, std::forward_as_tuple(thread),
-                         std::forward_as_tuple(ExecutionScope(thread), *this, spawn));
+        auto inserted = threads_.emplace(std::piecewise_construct, std::forward_as_tuple(thread),
+                                         std::forward_as_tuple(ExecutionScope(thread), *this, spawn));
+        assert(inserted.second);
+        // actually start thread
+        inserted.first->second.start();
     }
 
     trace_.update_thread_name(thread, name);

--- a/src/monitor/scope_monitor.cpp
+++ b/src/monitor/scope_monitor.cpp
@@ -84,8 +84,7 @@ ScopeMonitor::ScopeMonitor(ExecutionScope scope, MainMonitor& parent, bool enabl
     }
 #endif
 
-    /* setup the sampling counter(s) and start a monitoring thread */
-    start();
+    // note: start() can now be called
 }
 
 void ScopeMonitor::initialize_thread()


### PR DESCRIPTION
Fixes race condition and cleanup for CPU ScopedMonitors, closes #226.
See commit messages for detailed description.

Produces errors like this:

```
[108994189964536][pid: 129226][tid: 129226][ERROR]: Failed to create/start all CPU monitors (104 out of 128 suceeded): remove already existing monitors
[108994577353307][pid: 129226][tid: 129226][FATAL]: Aborting: Too many open files
```