### PR TITLE
trace registry setup: fix lifetime of variables

### DIFF
--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -124,7 +124,7 @@ Trace::Trace()
         Core core = sys.core_of(cpu);
         Package package = sys.package_of(cpu);
 
-        auto& package_node = registry_.find<otf2::definition::system_tree_node>(ByPackage(package));
+        auto package_node = registry_.find<otf2::definition::system_tree_node>(ByPackage(package));
 
         if (!package_node)
         {
@@ -136,7 +136,7 @@ Trace::Trace()
                 package_node, otf2::common::system_tree_node_domain::socket);
         }
 
-        auto& core_node = registry_.find<otf2::definition::system_tree_node>(ByCore(core));
+        const auto& core_node = registry_.find<otf2::definition::system_tree_node>(ByCore(core));
 
         if (!core_node)
         {


### PR DESCRIPTION
The old version used `auto&` as type for function results, and did not handle the underlying lifetime of the objects correctly resulting in undefined behavior. This is replaced by a copy (`auto`) where modification of the variable is required, and `const auto&` where it is not.

This resulted in the map of system_tree_node by package to not be initialized fully (second package was missing), from where later lookups to this map failed. This commit fixes this initialization and eliminates the previously occuring lookup error from `map::at()`.