### PR TITLE
fix man page install

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ In both modes, system-level metrics (e.g. tracepoints), are always grouped by th
  * [x86_energy](https://github.com/tud-zih-energy/x86_energy) for CPU power metrics
  * libradare for disassembled instruction strings
  * libsensors for sensor readings
+ * [pod2man](https://www.eyrie.org/~eagle/software/podlators/) to generate the man pages (typically distributed as part of `perl`)
+ * `gzip` to compress the man pages
 
 # Runtime Requirements
 

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -1,32 +1,65 @@
-option(INSTALL_MANPAGE "Build and install man pages" ON)
+# desired installation behavior
+# option  | pod2man NOT found | pod2man found
+# --------|-------------------|----------------
+# OFF     | no man page       | no man page
+# default | no man page       | build man page
+# ON      | error             | build man page
+#
+# This is realised through a "smart" default for the INSTALL_MANPAGE cmake option.
 
-if(INSTALL_MANPAGE)
-    find_program(POD2MAN_EXECUTABLE pod2man)
-    mark_as_advanced(POD2MAN_EXECUTABLE)
+# step 1: investigate if man page can even be built
+find_program(POD2MAN_EXECUTABLE pod2man)
+mark_as_advanced(POD2MAN_EXECUTABLE)
 
-    if (POD2MAN_EXECUTABLE)
-        add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lo2s.1
-            COMMAND ${POD2MAN_EXECUTABLE}
-            ARGS --name="lo2s"
-                 --center="lo2s User Manual"
-                 --release="${LO2S_VERSION_STRING}"
-                 --utf8
-                 lo2s.1.pod
-                 ${CMAKE_CURRENT_BINARY_DIR}/lo2s.1
-            MAIN_DEPENDENCY lo2s.1.pod
-            COMMENT "Generating man pages"
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        )
-        add_custom_target(man-page ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/lo2s.1)
-    else()
-        message(WARNING
-            "pod2man not found. Man pages will not be available")
-    endif()
+# *Technically* gzip is not required for man pages,
+# but (1) exists on most systems,
+# and (2) all other man pages are gzipped.
+find_program(GZIP_EXECUTABLE gzip)
+mark_as_advanced(GZIP_EXECUTABLE)
+
+if (POD2MAN_EXECUTABLE AND GZIP_EXECUTABLE)
+    set(INSTALL_MANPAGE_DEFAULT ON)
+else()
+    set(INSTALL_MANPAGE_DEFAULT OFF)
 endif()
 
-include(GNUInstallDirs)
-install(
-    FILES ${CMAKE_CURRENT_BINARY_DIR}/lo2s.1
-    DESTINATION "${CMAKE_INSTALL_MANDIR}/man1"
-    OPTIONAL
-)
+# step 2: set default option accordingly (idea: don't get in the way of user)
+option(INSTALL_MANPAGE "Build and install man pages" ${INSTALL_MANPAGE_DEFAULT})
+add_feature_info(INSTALL_MANPAGE INSTALL_MANPAGE "Build and install man pages.")
+
+# step 3: if requested (either through default or explicitly), build man page
+if(INSTALL_MANPAGE)
+    if (NOT POD2MAN_EXECUTABLE)
+        message(FATAL_ERROR "pod2man not found: can not install man page")
+    endif()
+    if (NOT GZIP_EXECUTABLE)
+        message(FATAL_ERROR "gzip not found: can not install man page")
+    endif()
+
+    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lo2s.1
+        COMMAND ${POD2MAN_EXECUTABLE}
+        ARGS --name="lo2s"
+                --center="lo2s User Manual"
+                --release="${LO2S_VERSION_STRING}"
+                --utf8
+                lo2s.1.pod
+                ${CMAKE_CURRENT_BINARY_DIR}/lo2s.1
+        MAIN_DEPENDENCY lo2s.1.pod
+        COMMENT "Generating man pages"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    )
+    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lo2s.1.gz
+        COMMAND ${GZIP_EXECUTABLE}
+        ARGS -9 --force --keep ${CMAKE_CURRENT_BINARY_DIR}/lo2s.1
+        MAIN_DEPENDENCY ${CMAKE_CURRENT_BINARY_DIR}/lo2s.1
+        COMMENT "Compressing man pages"
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    add_custom_target(man-page ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/lo2s.1.gz)
+
+    include(GNUInstallDirs)
+    install(
+        FILES ${CMAKE_CURRENT_BINARY_DIR}/lo2s.1.gz
+        DESTINATION "${CMAKE_INSTALL_MANDIR}/man1"
+    )
+endif()


### PR DESCRIPTION
The man page build and install process now follows more sane defaults: If the requirements for building the man pages (pod2man, gzip) are available, it is built by default. Otherwise, man pages are disabled. This man page support is reported to the user as an enabled or disabled feature as part of the feature summary.

If the man page is enabled explicitly (`-DINSTALL_MANPAGE=ON`), but the dependencies are not found the configuration is aborted. This breaks previous behavior, which skipped man page generation with a warning and carried on -- even with man pages explicitly enabled.

Additionally, the man page is now compressed with gzip before being installed. This follows the requirement of the debian package maintainer manual. In order to avoid potential conflict on multiple invocations, gzip is invoked with --keep --force to *always* produce output and *never* destroy the input.

The man page dependencies (pod2man, gzip) are explicitly mentioned in the README.