### PR TITLE
fix: move calling context merge until the very end,

### DIFF
--- a/include/lo2s/perf/calling_context_manager.hpp
+++ b/include/lo2s/perf/calling_context_manager.hpp
@@ -1,0 +1,165 @@
+/*
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2016,
+ *    Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#pragma once
+
+#include <lo2s/config.hpp>
+#include <lo2s/trace/trace.hpp>
+
+#include <otf2xx/otf2.hpp>
+
+namespace lo2s
+{
+namespace perf
+{
+
+class CallingContextManager
+{
+public:
+    CallingContextManager(trace::Trace& trace, otf2::writer::local& writer)
+    : trace_(trace), otf2_writer_(writer), local_cctx_refs_(trace.create_cctx_refs())
+    {
+    }
+
+    void update(otf2::chrono::time_point tp, Process process, Thread thread)
+    {
+        if (current_thread_cctx_refs_ && current_thread_cctx_refs_->first == thread)
+        {
+            return;
+        }
+        else if (current_thread_cctx_refs_)
+        {
+            leave(tp, thread);
+        }
+
+        // thread has changed
+        auto ret =
+            local_cctx_refs_.map.emplace(std::piecewise_construct, std::forward_as_tuple(thread),
+                                         std::forward_as_tuple(process, next_cctx_ref_));
+        if (ret.second)
+        {
+            next_cctx_ref_++;
+        }
+        otf2_writer_.write_calling_context_enter(tp, ret.first->second.entry.ref, 2);
+        current_thread_cctx_refs_ = &(*ret.first);
+    }
+
+    void leave(otf2::chrono::time_point tp, Thread thread)
+    {
+        if (current_thread_cctx_refs_ == nullptr)
+        {
+            // Already not in a thread
+            return;
+        }
+
+        if (current_thread_cctx_refs_->first != thread)
+        {
+            Log::debug() << "inconsistent leave thread"; // will probably set to trace sooner or
+                                                         // later
+        }
+        otf2_writer_.write_calling_context_leave(tp, current_thread_cctx_refs_->second.entry.ref);
+        current_thread_cctx_refs_ = nullptr;
+    }
+
+    void finalize(otf2::chrono::time_point tp)
+    {
+        if (current_thread_cctx_refs_)
+        {
+            otf2_writer_.write_calling_context_leave(tp,
+                                                     current_thread_cctx_refs_->second.entry.ref);
+        }
+        local_cctx_refs_.ref_count = next_cctx_ref_;
+        // set writer last, because it is used as sentry to confirm that the cctx refs are properly
+        // finalized.
+        local_cctx_refs_.writer = &otf2_writer_;
+    }
+
+    void write_sample(otf2::chrono::time_point tp, uint64_t num_ips, const uint64_t ips[])
+    {
+        // For unwind distance definiton, see:
+        // http://scorepci.pages.jsc.fz-juelich.de/otf2-pipelines/docs/otf2-2.2/html/group__records__definition.
+        // html#CallingContext
+
+        // We always have a fake CallingContext for the process, which is scheduled.
+        // So if we don't record the calling context tree, all nodes in the calling context tree
+        // are: The fake node for the process and a second node for the current context of the
+        // sample. Therefore, we always have an unwind distance of 2. (Technically, it could also be
+        // 1, but we lack the information to distinguish those cases. Hence, we stick with 2.)
+        //
+        // However, in the case that we actually record the complete call stack, we get the number
+        // of nodes in the calling context tree from the number of elements in the call stack
+        // recorded from perf. Tough, we still have the fake calling context for the process, which
+        // adds 1 to that number. But we also remove the lowest entry from the call stack, because
+        // that is ALWAYS in the kernel, which can't be resolved and thus doesn't provide any useful
+        // information.
+        //
+        // Having these things in mind, look at this line and tell me, why it is still wrong:
+        auto children = &current_thread_cctx_refs_->second.entry.children;
+        for (uint64_t i = num_ips - 1;; i--)
+        {
+            auto it = find_ip_child(ips[i], *children);
+            // We intentionally discard the last sample as it is somewhere in the kernel
+            if (i == 1)
+            {
+                otf2_writer_.write_calling_context_sample(tp, it->second.ref, num_ips,
+                                                          trace_.interrupt_generator().ref());
+                return;
+            }
+
+            children = &it->second.children;
+        }
+    }
+
+    void write_sample(otf2::chrono::time_point tp, uint64_t ip)
+    {
+        auto it = find_ip_child(ip, current_thread_cctx_refs_->second.entry.children);
+
+        otf2_writer_.write_calling_context_sample(tp, it->second.ref, 2,
+                                                  trace_.interrupt_generator().ref());
+    }
+
+private:
+    trace::IpRefMap::iterator find_ip_child(Address addr, trace::IpRefMap& children)
+    {
+        // -1 can't be inserted into the ip map, as it imples a 1-byte region from -1 to 0.
+        if (addr == -1)
+        {
+            Log::debug() << "Got invalid ip (-1) from call stack. Replacing with -2.";
+            addr = -2;
+        }
+        auto ret = children.emplace(std::piecewise_construct, std::forward_as_tuple(addr),
+                                    std::forward_as_tuple(next_cctx_ref_));
+        if (ret.second)
+        {
+            next_cctx_ref_++;
+        }
+        return ret.first;
+    }
+
+private:
+    trace::Trace& trace_;
+    otf2::writer::local& otf2_writer_;
+    trace::ThreadCctxRefMap& local_cctx_refs_;
+    trace::ThreadCctxRefMap::value_type* current_thread_cctx_refs_ = nullptr;
+
+    size_t next_cctx_ref_ = 0;
+};
+} // namespace perf
+} // namespace lo2s

--- a/include/lo2s/perf/sample/writer.hpp
+++ b/include/lo2s/perf/sample/writer.hpp
@@ -23,6 +23,7 @@
 
 #include <lo2s/address.hpp>
 #include <lo2s/mmap.hpp>
+#include <lo2s/perf/calling_context_manager.hpp>
 
 #include <lo2s/perf/sample/reader.hpp>
 #include <lo2s/perf/time/converter.hpp>
@@ -73,12 +74,7 @@ public:
     void end();
 
 private:
-    otf2::definition::calling_context::reference_type
-    cctx_ref(const Reader::RecordSampleType* sample);
-    trace::IpRefMap::iterator find_ip_child(Address addr, trace::IpRefMap& children);
-
     void update_current_thread(Process process, Thread thread, otf2::chrono::time_point tp);
-    void leave_current_thread(Thread thread, otf2::chrono::time_point tp);
     void update_calling_context(Process process, Thread thread, otf2::chrono::time_point tp,
                                 bool switch_out);
 
@@ -94,11 +90,7 @@ private:
     otf2::definition::metric_instance cpuid_metric_instance_;
     otf2::event::metric cpuid_metric_event_;
 
-    trace::ThreadCctxRefMap& local_cctx_refs_;
-    size_t next_cctx_ref_ = 0;
-
-    trace::ThreadCctxRefMap::value_type* current_thread_cctx_refs_ = nullptr;
-
+    CallingContextManager cctx_manager_;
     RawMemoryMapCache cached_mmap_events_;
     std::unordered_map<Thread, std::string> comms_;
 

--- a/include/lo2s/perf/sample/writer.hpp
+++ b/include/lo2s/perf/sample/writer.hpp
@@ -94,7 +94,7 @@ private:
     otf2::definition::metric_instance cpuid_metric_instance_;
     otf2::event::metric cpuid_metric_event_;
 
-    trace::ThreadCctxRefMap local_cctx_refs_;
+    trace::ThreadCctxRefMap& local_cctx_refs_;
     size_t next_cctx_ref_ = 0;
 
     trace::ThreadCctxRefMap::value_type* current_thread_cctx_refs_ = nullptr;

--- a/include/lo2s/perf/sample/writer.hpp
+++ b/include/lo2s/perf/sample/writer.hpp
@@ -78,6 +78,7 @@ private:
     void update_calling_context(Process process, Thread thread, otf2::chrono::time_point tp,
                                 bool switch_out);
 
+    void leave_current_thread(Thread thread, otf2::chrono::time_point tp);
     otf2::chrono::time_point adjust_timepoints(otf2::chrono::time_point tp);
 
     ExecutionScope scope_;

--- a/include/lo2s/perf/tracepoint/switch_writer.hpp
+++ b/include/lo2s/perf/tracepoint/switch_writer.hpp
@@ -62,6 +62,7 @@ private:
 
     CallingContextManager cctx_manager_;
 
+    EventField prev_pid_field_;
     EventField next_pid_field_;
     EventField prev_state_field_;
 

--- a/include/lo2s/perf/tracepoint/switch_writer.hpp
+++ b/include/lo2s/perf/tracepoint/switch_writer.hpp
@@ -25,8 +25,8 @@
 
 #include <lo2s/perf/tracepoint/format.hpp>
 
+#include <lo2s/perf/calling_context_manager.hpp>
 #include <lo2s/perf/time/converter.hpp>
-
 #include <lo2s/trace/fwd.hpp>
 #include <lo2s/trace/trace.hpp>
 
@@ -57,19 +57,12 @@ public:
     bool handle(const Reader::RecordSampleType* sample);
 
 private:
-    otf2::definition::calling_context::reference_type thread_calling_context_ref(Thread thread);
-
-private:
     otf2::writer::local& otf2_writer_;
     trace::Trace& trace_;
     const time::Converter time_converter_;
 
-    using calling_context_ref = otf2::definition::calling_context::reference_type;
-    trace::ThreadCctxRefMap thread_calling_context_refs_;
-    Process current_process_;
-    calling_context_ref current_calling_context_ = calling_context_ref::undefined();
+    CallingContextManager cctx_manager_;
 
-    EventField prev_pid_field_;
     EventField next_pid_field_;
     EventField prev_state_field_;
 

--- a/include/lo2s/perf/tracepoint/switch_writer.hpp
+++ b/include/lo2s/perf/tracepoint/switch_writer.hpp
@@ -58,7 +58,6 @@ public:
 
 private:
     otf2::writer::local& otf2_writer_;
-    trace::Trace& trace_;
     const time::Converter time_converter_;
 
     CallingContextManager cctx_manager_;

--- a/include/lo2s/process_info.hpp
+++ b/include/lo2s/process_info.hpp
@@ -48,7 +48,7 @@ public:
         maps_.mmap(entry);
     }
 
-    MemoryMap maps()
+    MemoryMap maps() const
     {
         std::lock_guard<std::mutex> lock(mutex_);
         // Yes, this is correct as per 6.6.3 The Return Statement
@@ -57,7 +57,7 @@ public:
 
 private:
     const Process process_;
-    std::mutex mutex_;
+    mutable std::mutex mutex_;
     MemoryMap maps_;
 };
 } // namespace lo2s

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -121,9 +121,9 @@ public:
     void update_thread_name(Thread t, const std::string& name);
 
     ThreadCctxRefMap& create_cctx_refs();
-    otf2::definition::mapping_table merge_calling_contexts(const std::map<Thread, ThreadCctxRefs>& new_ips,
-                                                           size_t num_ip_refs,
-                                                           const std::map<Process, ProcessInfo>& infos);
+    otf2::definition::mapping_table
+    merge_calling_contexts(const std::map<Thread, ThreadCctxRefs>& new_ips, size_t num_ip_refs,
+                           const std::map<Process, ProcessInfo>& infos);
     void merge_calling_contexts(const std::map<Process, ProcessInfo>& process_infos);
 
     otf2::definition::mapping_table merge_syscall_contexts(const std::set<int64_t>& used_syscalls);
@@ -349,6 +349,8 @@ private:
     ExecutionScopeGroup& groups_;
 
     std::deque<ThreadCctxRefMap> cctx_refs_;
+    // Mutex is only used for accessing the cctx_refs_
+    std::mutex cctx_refs_mutex_;
     // I wanted to use atomic_flag, but I need test and that's a C++20 exclusive.
     std::atomic_bool cctx_refs_finalized_ = false;
 };

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -349,6 +349,8 @@ private:
     ExecutionScopeGroup& groups_;
 
     std::deque<ThreadCctxRefMap> cctx_refs_;
+    // I wanted to use atomic_flag, but I need test and that's a C++20 exclusive.
+    std::atomic_bool cctx_refs_finalized_ = false;
 };
 } // namespace trace
 } // namespace lo2s

--- a/src/monitor/cpu_set_monitor.cpp
+++ b/src/monitor/cpu_set_monitor.cpp
@@ -72,8 +72,9 @@ CpuSetMonitor::CpuSetMonitor() : MainMonitor()
         {
             Log::debug() << "Create cstate recorder for cpu #" << cpu.as_int();
 
-            auto inserted = monitors_.emplace(std::piecewise_construct, std::forward_as_tuple(cpu),
-                                            std::forward_as_tuple(ExecutionScope(cpu), *this, false));
+            auto inserted =
+                monitors_.emplace(std::piecewise_construct, std::forward_as_tuple(cpu),
+                                  std::forward_as_tuple(ExecutionScope(cpu), *this, false));
             assert(inserted.second);
             // directly start the measurement thread
             inserted.first->second.start();
@@ -81,12 +82,13 @@ CpuSetMonitor::CpuSetMonitor() : MainMonitor()
     }
     catch (...)
     {
-        Log::error() << "Failed to create/start all CPU monitors ("
-                     << monitors_.size() << " out of "
-                     << Topology::instance().cpus().size() << " suceeded): remove already existing monitors";
+        Log::error() << "Failed to create/start all CPU monitors (" << monitors_.size()
+                     << " out of " << Topology::instance().cpus().size()
+                     << " suceeded): remove already existing monitors";
 
         // clean up existing thread
-        for (auto& monitor_map_it : monitors_) {
+        for (auto& monitor_map_it : monitors_)
+        {
             monitor_map_it.second.stop();
         }
 

--- a/src/monitor/main_monitor.cpp
+++ b/src/monitor/main_monitor.cpp
@@ -193,6 +193,8 @@ MainMonitor::~MainMonitor()
     trace_.end_record();
 
     metrics_.stop();
+
+    trace_.merge_calling_contexts(get_process_infos());
 }
 } // namespace monitor
 } // namespace lo2s

--- a/src/monitor/process_monitor.cpp
+++ b/src/monitor/process_monitor.cpp
@@ -47,8 +47,7 @@ void ProcessMonitor::insert_thread(Process process, Thread thread, std::string n
 
     if (config().sampling)
     {
-        process_infos_.emplace(std::piecewise_construct, std::forward_as_tuple(process),
-                               std::forward_as_tuple(process, spawn));
+        process_infos_.try_emplace(process, process, spawn);
     }
 
     if (config().sampling ||

--- a/src/monitor/process_monitor.cpp
+++ b/src/monitor/process_monitor.cpp
@@ -54,8 +54,9 @@ void ProcessMonitor::insert_thread(Process process, Thread thread, std::string n
         perf::counter::CounterProvider::instance().has_group_counters(ExecutionScope(thread)) ||
         perf::counter::CounterProvider::instance().has_userspace_counters(ExecutionScope(thread)))
     {
-        auto inserted = threads_.emplace(std::piecewise_construct, std::forward_as_tuple(thread),
-                                         std::forward_as_tuple(ExecutionScope(thread), *this, spawn));
+        auto inserted =
+            threads_.emplace(std::piecewise_construct, std::forward_as_tuple(thread),
+                             std::forward_as_tuple(ExecutionScope(thread), *this, spawn));
         assert(inserted.second);
         // actually start thread
         inserted.first->second.start();

--- a/src/perf/sample/writer.cpp
+++ b/src/perf/sample/writer.cpp
@@ -59,63 +59,14 @@ Writer::Writer(ExecutionScope scope, monitor::MainMonitor& Monitor, trace::Trace
   cpuid_metric_instance_(trace.metric_instance(trace.cpuid_metric_class(), otf2_writer_.location(),
                                                otf2_writer_.location())),
   cpuid_metric_event_(otf2::chrono::genesis(), cpuid_metric_instance_),
-  local_cctx_refs_(trace.create_cctx_refs()),
-  time_converter_(perf::time::Converter::instance()), first_time_point_(lo2s::time::now()),
-  last_time_point_(first_time_point_)
+  cctx_manager_(trace, otf2_writer_), time_converter_(perf::time::Converter::instance()),
+  first_time_point_(lo2s::time::now()), last_time_point_(first_time_point_)
 {
 }
 
 Writer::~Writer()
 {
-    if (current_thread_cctx_refs_)
-    {
-        otf2_writer_.write_calling_context_leave(adjust_timepoints(lo2s::time::now()),
-                                                 current_thread_cctx_refs_->second.entry.ref);
-    }
-    local_cctx_refs_.ref_count = next_cctx_ref_;
-    // set writer last, because it is used as sentry to confirm that the cctx refs are properly finalized.
-    local_cctx_refs_.writer = &otf2_writer_;
-}
-
-trace::IpRefMap::iterator Writer::find_ip_child(Address addr, trace::IpRefMap& children)
-{
-    // -1 can't be inserted into the ip map, as it imples a 1-byte region from -1 to 0.
-    if (addr == -1)
-    {
-        Log::debug() << "Got invalid ip (-1) from call stack. Replacing with -2.";
-        addr = -2;
-    }
-    auto ret = children.emplace(std::piecewise_construct, std::forward_as_tuple(addr),
-                                std::forward_as_tuple(next_cctx_ref_));
-    if (ret.second)
-    {
-        next_cctx_ref_++;
-    }
-    return ret.first;
-}
-otf2::definition::calling_context::reference_type
-Writer::cctx_ref(const Reader::RecordSampleType* sample)
-{
-    if (!has_cct_)
-    {
-        auto it = find_ip_child(sample->ip, current_thread_cctx_refs_->second.entry.children);
-        return it->second.ref;
-    }
-    else
-    {
-        auto children = &current_thread_cctx_refs_->second.entry.children;
-        for (uint64_t i = sample->nr - 1;; i--)
-        {
-            auto it = find_ip_child(sample->ips[i], *children);
-            // We intentionally discard the last sample as it is somewhere in the kernel
-            if (i == 1)
-            {
-                return it->second.ref;
-            }
-
-            children = &it->second.children;
-        }
-    }
+    cctx_manager_.finalize(adjust_timepoints(lo2s::time::now()));
 }
 
 bool Writer::handle(const Reader::RecordSampleType* sample)
@@ -129,28 +80,14 @@ bool Writer::handle(const Reader::RecordSampleType* sample)
     cpuid_metric_event_.raw_values()[0] = sample->cpu;
     otf2_writer_ << cpuid_metric_event_;
 
-    // For unwind distance definiton, see:
-    // http://scorepci.pages.jsc.fz-juelich.de/otf2-pipelines/docs/otf2-2.2/html/group__records__definition.html#CallingContext
-
-    // We always have a fake CallingContext for the process, which is scheduled.
-    // So if we don't record the calling context tree, all nodes in the calling context tree are:
-    // The fake node for the process and a second node for the current context of the sample.
-    // Therefore, we always have an unwind distance of 2. (Technically, it could also be 1, but we
-    // lack the information to distinguish those cases. Hence, we stick with 2.)
-    //
-    // However, in the case that we actually record the complete call stack, we get the number of
-    // nodes in the calling context tree from the number of elements in the call stack recorded from
-    // perf. Tough, we still have the fake calling context for the process, which adds 1 to that
-    // number. But we also remove the lowest entry from the call stack, because that is ALWAYS in
-    // the kernel, which can't be resolved and thus doesn't provide any useful information.
-    //
-    // Having these things in mind, look at this line and tell me, why it is still wrong:
-    auto unwind_distance = has_cct_ ? sample->nr /* + 1 - 1 */ : 2;
-
-    // we write the ugly raw ref-only events here due to performance reasons
-    otf2_writer_.write_calling_context_sample(tp, cctx_ref(sample), unwind_distance,
-                                              trace_.interrupt_generator().ref());
-
+    if (!has_cct_)
+    {
+        cctx_manager_.write_sample(tp, sample->ip);
+    }
+    else
+    {
+        cctx_manager_.write_sample(tp, sample->nr, sample->ips);
+    }
     return false;
 }
 
@@ -177,43 +114,7 @@ void Writer::update_current_thread(Process process, Thread thread, otf2::chrono:
         otf2_writer_ << otf2::event::thread_begin(tp, trace_.process_comm(scope_.as_thread()), -1);
         first_event_ = false;
     }
-
-    if (current_thread_cctx_refs_ && current_thread_cctx_refs_->first == thread)
-    {
-        // current thread is unchanged
-        return;
-    }
-    else if (current_thread_cctx_refs_)
-    {
-
-        // need to leave
-        otf2_writer_.write_calling_context_leave(tp, current_thread_cctx_refs_->second.entry.ref);
-    }
-    // thread has changed
-    auto ret = local_cctx_refs_.map.emplace(std::piecewise_construct, std::forward_as_tuple(thread),
-                                        std::forward_as_tuple(process, next_cctx_ref_));
-    if (ret.second)
-    {
-        next_cctx_ref_++;
-    }
-    otf2_writer_.write_calling_context_enter(tp, ret.first->second.entry.ref, 2);
-    current_thread_cctx_refs_ = &(*ret.first);
-}
-
-void Writer::leave_current_thread(Thread thread, otf2::chrono::time_point tp)
-{
-    if (current_thread_cctx_refs_ == nullptr)
-    {
-        // Already not in a thread
-        return;
-    }
-
-    if (current_thread_cctx_refs_->first != thread)
-    {
-        Log::debug() << "inconsistent leave thread"; // will probably set to trace sooner or later
-    }
-    otf2_writer_.write_calling_context_leave(tp, current_thread_cctx_refs_->second.entry.ref);
-    current_thread_cctx_refs_ = nullptr;
+    cctx_manager_.update(tp, process, thread);
 }
 
 otf2::chrono::time_point Writer::adjust_timepoints(otf2::chrono::time_point tp)
@@ -272,7 +173,7 @@ void Writer::update_calling_context(Process process, Thread thread, otf2::chrono
 {
     if (switch_out)
     {
-        leave_current_thread(thread, tp);
+        cctx_manager_.leave(tp, thread);
     }
     else
     {

--- a/src/perf/time/reader.cpp
+++ b/src/perf/time/reader.cpp
@@ -92,9 +92,11 @@ Reader::Reader()
     catch (...)
     {
 #ifndef USE_HW_BREAKPOINT_COMPAT
-        Log::error() << "time synchronization with hardware breakpoints failed, try rebuilding lo2s with -DUSE_HW_BREAKPOINT_COMPAT=ON";
+        Log::error() << "time synchronization with hardware breakpoints failed, try rebuilding "
+                        "lo2s with -DUSE_HW_BREAKPOINT_COMPAT=ON";
 #else
-        Log::error() << "opening the perf event for HW_BREAKPOINT_COMPAT time synchronization failed";
+        Log::error()
+            << "opening the perf event for HW_BREAKPOINT_COMPAT time synchronization failed";
 #endif
         close(fd_);
         throw;

--- a/src/perf/tracepoint/switch_writer.cpp
+++ b/src/perf/tracepoint/switch_writer.cpp
@@ -48,8 +48,7 @@ static const EventFormat& get_sched_switch_event()
 
 SwitchWriter::SwitchWriter(Cpu cpu, trace::Trace& trace)
 try : Reader(cpu, get_sched_switch_event().id()), otf2_writer_(trace.switch_writer(cpu.as_scope())),
-    trace_(trace), time_converter_(time::Converter::instance()),
-    prev_pid_field_(get_sched_switch_event().field("prev_pid")),
+    trace_(trace), time_converter_(time::Converter::instance()), cctx_manager_(trace, otf2_writer_),
     next_pid_field_(get_sched_switch_event().field("next_pid")),
     prev_state_field_(get_sched_switch_event().field("prev_state"))
 {
@@ -65,43 +64,15 @@ catch (const EventFormat::ParseError& e)
 
 SwitchWriter::~SwitchWriter()
 {
-    // Always close the last event
-    if (!current_calling_context_.is_undefined())
-    {
-        // time::now() can apparently lie in the past sometimes
-        otf2_writer_.write_calling_context_leave(std::max(last_time_point_, lo2s::time::now()),
-                                                 current_calling_context_);
-    }
-
-    if (!thread_calling_context_refs_.empty())
-    {
-        std::map<Process, ProcessInfo> m;
-        const auto& mapping = trace_.merge_calling_contexts(thread_calling_context_refs_,
-                                                            thread_calling_context_refs_.size(), m);
-        otf2_writer_ << mapping;
-    }
+    cctx_manager_.finalize(std::max(last_time_point_, lo2s::time::now()));
 }
 
 bool SwitchWriter::handle(const Reader::RecordSampleType* sample)
 {
     auto tp = time_converter_(sample->time);
-    Process prev_process = Process(sample->raw_data.get(prev_pid_field_));
     Process next_process = Process(sample->raw_data.get(next_pid_field_));
-    if (!current_calling_context_.is_undefined())
-    {
-        if (prev_process != current_process_)
-        {
-            Log::warn() << "Conflicting processes: previous: " << prev_process
-                        << " != current: " << current_process_
-                        << " current_region: " << current_calling_context_;
-        }
-        otf2_writer_.write_calling_context_leave(tp, current_calling_context_);
-    }
-    current_process_ = next_process;
 
-    current_calling_context_ = thread_calling_context_ref(current_process_.as_thread());
-    otf2_writer_.write_calling_context_enter(tp, current_calling_context_, 2);
-
+    cctx_manager_.update(tp, Process::invalid(), next_process.as_thread());
     last_time_point_ = tp;
 
     if (next_process != Process::idle())
@@ -111,14 +82,6 @@ bool SwitchWriter::handle(const Reader::RecordSampleType* sample)
     return false;
 }
 
-otf2::definition::calling_context::reference_type
-SwitchWriter::thread_calling_context_ref(Thread thread)
-{
-    auto ret = thread_calling_context_refs_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(thread),
-        std::forward_as_tuple(Process::invalid(), thread_calling_context_refs_.size()));
-    return ret.first->second.entry.ref;
-}
 } // namespace tracepoint
 } // namespace perf
 } // namespace lo2s

--- a/src/perf/tracepoint/switch_writer.cpp
+++ b/src/perf/tracepoint/switch_writer.cpp
@@ -48,7 +48,7 @@ static const EventFormat& get_sched_switch_event()
 
 SwitchWriter::SwitchWriter(Cpu cpu, trace::Trace& trace)
 try : Reader(cpu, get_sched_switch_event().id()), otf2_writer_(trace.switch_writer(cpu.as_scope())),
-    trace_(trace), time_converter_(time::Converter::instance()), cctx_manager_(trace, otf2_writer_),
+    time_converter_(time::Converter::instance()), cctx_manager_(trace, otf2_writer_),
     next_pid_field_(get_sched_switch_event().field("next_pid")),
     prev_state_field_(get_sched_switch_event().field("prev_state"))
 {

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -26,6 +26,7 @@
 #include <lo2s/config.hpp>
 #include <lo2s/line_info.hpp>
 #include <lo2s/mmap.hpp>
+#include <lo2s/monitor/main_monitor.hpp>
 #include <lo2s/perf/bio/block_device.hpp>
 #include <lo2s/perf/tracepoint/format.hpp>
 #include <lo2s/summary.hpp>
@@ -34,15 +35,15 @@
 #include <lo2s/topology.hpp>
 #include <lo2s/util.hpp>
 #include <lo2s/version.hpp>
+
 #include <nitro/env/get.hpp>
 #include <nitro/env/hostname.hpp>
 #include <nitro/lang/string.hpp>
 
-#include <filesystem>
-
 #include <fmt/chrono.h>
 #include <fmt/core.h>
 
+#include <filesystem>
 #include <map>
 #include <mutex>
 #include <regex>
@@ -563,12 +564,12 @@ otf2::definition::metric_class& Trace::metric_class()
                                                             otf2::common::recorder_kind::abstract);
 }
 
-void Trace::merge_ips(IpRefMap& new_children, IpCctxMap& children,
+void Trace::merge_ips(const IpRefMap& new_children, IpCctxMap& children,
                       std::vector<uint32_t>& mapping_table,
                       otf2::definition::calling_context& parent,
-                      std::map<Process, ProcessInfo>& infos, Process process)
+                      const std::map<Process, ProcessInfo>& infos, Process process)
 {
-    for (auto& elem : new_children)
+    for (const auto& elem : new_children)
     {
         auto& ip = elem.first;
         auto& local_ref = elem.second.ref;
@@ -615,9 +616,9 @@ void Trace::merge_ips(IpRefMap& new_children, IpCctxMap& children,
     }
 }
 
-otf2::definition::mapping_table Trace::merge_calling_contexts(ThreadCctxRefMap& new_ips,
+otf2::definition::mapping_table Trace::merge_calling_contexts(const std::map<Thread, ThreadCctxRefs>& new_ips,
                                                               size_t num_ip_refs,
-                                                              std::map<Process, ProcessInfo>& infos)
+                                                              const std::map<Process, ProcessInfo>& infos)
 {
     std::lock_guard<std::recursive_mutex> guard(mutex_);
 #ifndef NDEBUG
@@ -828,6 +829,27 @@ const otf2::definition::string& Trace::intern(const std::string& name)
     std::lock_guard<std::recursive_mutex> guard(mutex_);
 
     return registry_.emplace<otf2::definition::string>(ByString(name), name);
+}
+
+ThreadCctxRefMap& Trace::create_cctx_refs()
+{
+    // TODO use better mutex
+    std::lock_guard<std::recursive_mutex> guard(mutex_);
+
+    return cctx_refs_.emplace_back();
+}
+
+void Trace::merge_calling_contexts(const std::map<Process, ProcessInfo>& process_infos)
+{
+    for (auto& cctx : cctx_refs_)
+    {
+        assert(cctx.writer != nullptr);
+        if (cctx.ref_count > 0)
+        {
+            const auto& mapping = merge_calling_contexts(cctx.map, cctx.ref_count, process_infos);
+            (*cctx.writer) << mapping;
+        }
+    }
 }
 } // namespace trace
 } // namespace lo2s

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -840,12 +840,9 @@ ThreadCctxRefMap& Trace::create_cctx_refs()
 {
     std::lock_guard<std::mutex> guard(cctx_refs_mutex_);
 
+    assert(!cctx_refs_finalized_);
+
     return cctx_refs_.emplace_back();
-    if (cctx_refs_finalized_)
-    {
-        Log::error() << "create_cctx_refs called after finalized."
-                        "Please report this bug to the developers";
-    }
 }
 
 void Trace::merge_calling_contexts(const std::map<Process, ProcessInfo>& process_infos)

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -838,8 +838,7 @@ const otf2::definition::string& Trace::intern(const std::string& name)
 
 ThreadCctxRefMap& Trace::create_cctx_refs()
 {
-    // TODO use better mutex
-    std::lock_guard<std::recursive_mutex> guard(mutex_);
+    std::lock_guard<std::mutex> guard(cctx_refs_mutex_);
 
     return cctx_refs_.emplace_back();
     if (cctx_refs_finalized_)


### PR DESCRIPTION
while still destructing the monitoring threads early.

This fixes an issue with unknown functions due to missing mmap entries when deconstructing monitors of threads early.

Fixes #240 