### PR TITLE
feat(tracepoints): Print Help Message if no tracepoints are available

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ In both modes, system-level metrics (e.g. tracepoints), are always grouped by th
 
 # Runtime Requirements
 
- * `kernel.perf_event_paranoid` should be less than or equal to `1` for process monitoring mode and less than or equal to `0` in system monitoring mode. A value of `-1` will give the most features for non-root performance recording, at the cost of some security. Modify as follows:
+ * `kernel.perf_event_paranoid` should be less than or equal to `1` for process monitoring mode and less than or equal to `0` in system monitoring mode. A value of `-1` will give the most features for non-root performance recording, such as tracepoints and block I/O, at the cost of some security. Modify as follows:
 
    `sudo sysctl kernel.perf_event_paranoid=1`
 

--- a/man/lo2s.1.pod
+++ b/man/lo2s.1.pod
@@ -439,10 +439,21 @@ B<lo2s>:
 
 =over 6
 
-=item B<NOTE:>
+=item B<PERMISSIONS:>
+
 
 Recording tracepoint events usually requires both read and execute permissions
 on F</sys/kernel/debug>.
+
+To mount the debugfs execute:
+
+    # mount -t debugfs none /sys/kernel/debug
+
+Non-root access requires you to change the ownership of the debugfs and execute with kernel.perf_event_paranoid set to -1:
+
+    # chown -R myusername /sys/kernel/debug
+    # sysctl kernel.perf_event_paranoid=-1
+
 
 =back
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -437,9 +437,22 @@ void parse_program_options(int argc, const char** argv)
 
         if (arguments.given("list-tracepoints"))
         {
-            list_arguments_sorted(std::cout, "Kernel tracepoint events",
-                                  perf::tracepoint::EventFormat::get_tracepoint_event_names());
-            std::exit(EXIT_SUCCESS);
+            auto tracepoints = perf::tracepoint::EventFormat::get_tracepoint_event_names();
+
+            if (tracepoints.empty())
+            {
+                std::cout << "No tracepoints found!\n";
+                std::cout << "Make sure that the debugfs is mounted and that you have read-execute "
+                             "access to it.\n";
+                std::cout << "\n";
+                std::cout << "For more information, see the section TRACEPOINT in the man-page\n";
+                std::exit(EXIT_FAILURE);
+            }
+            else
+            {
+                list_arguments_sorted(std::cout, "Kernel tracepoint events", tracepoints);
+                std::exit(EXIT_SUCCESS);
+            }
         }
 
         if (arguments.given("list-knobs"))


### PR DESCRIPTION
I think this is the recommended way to get tracepoints access in lo2s.

This fixes #238