### PR TITLE
fix(build): Set lo2s_USE_STATIC_LIBS to OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ include(cmake/GitSubmoduleUpdate.cmake)
 git_submodule_update()
 
 # Set of variables to enforce static or dynamic linking
-set(lo2s_USE_STATIC_LIBS "MOSTLY" CACHE STRING "Link lo2s statically.")
+set(lo2s_USE_STATIC_LIBS "OFF" CACHE STRING "Link lo2s statically.")
 set_property(CACHE lo2s_USE_STATIC_LIBS PROPERTY STRINGS "MOSTLY" "OFF" "ALL")
 
 IfUpdatedUnsetAll(lo2s_USE_STATIC_LIBS


### PR DESCRIPTION
Some distributions (e.g. Arch Linux) do not guarantee to ship static libraries.

So change the default for lo2s_USE_STATIC_LIBS to OFF.