### PR TITLE
fix(sensors): Clear names for sensors with multiple scopes

### DIFF
--- a/src/metric/sensors/recorder.cpp
+++ b/src/metric/sensors/recorder.cpp
@@ -87,7 +87,7 @@ Recorder::Recorder(trace::Trace& trace)
 
         std::string chip_name;
         chip_name.resize(chip_name_size);
-        int res = sensors_snprintf_chip_name(chip_name.data(), chip_name.size(), chip);
+        int res = sensors_snprintf_chip_name(chip_name.data(), chip_name.size() + 1, chip);
 
         if (res < 0)
         {


### PR DESCRIPTION
Apparently intermixing C strings and C++ strings is a bad idea (tm), so keep it as split as possible by using an intermediate std::vector

This fixes #258