### PR TITLE
feat(sampling): Remove support for systems that do not have use_clockid

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,7 +14,6 @@ jobs:
         compiler: [g++-9, g++-10, clang++-10, clang++-11, clang++-12]
         build-type: [Debug, RelWithDebInfo]
         hw_breakpoint: [ON, OFF]
-        perf_clockid: [ON, OFF]
 
     runs-on: ${{ matrix.os }}
 
@@ -42,7 +41,7 @@ jobs:
       - name: Run CMake configure
         env:
           CXX: ${{ matrix.compiler }}
-        run: cmake . -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DUSE_HW_BREAKPOINT_COMPAT=${{ matrix.hw_breakpoint }} -DUSE_PERF_CLOCKID=${{ matrix.perf_clockid }}
+        run: cmake . -DCMAKE_BUILD_TYPE=${{ matrix.build-type }} -DUSE_HW_BREAKPOINT_COMPAT=${{ matrix.hw_breakpoint }}}
       - name: Build
         run: make -j 2
       - name: Create source tarball

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,8 +115,6 @@ endif()
 CMAKE_DEPENDENT_OPTION(USE_RADARE "Enable Radare support." ON "Radare_FOUND" OFF)
 option(USE_HW_BREAKPOINT_COMPAT "Time synchronization fallback for old kernels without hardware breakpoint support." OFF)
 add_feature_info("USE_HW_BREAKPOINT_COMPAT" USE_HW_BREAKPOINT_COMPAT "Time synchronization fallback for old kernels without hardware breakpoint support.")
-option(USE_PERF_CLOCKID "Enables specifying a custom reference clock for recorded events" ON)
-add_feature_info("USE_PERF_CLOCKID" USE_PERF_CLOCKID "Enables specifying a custom reference clock for recorded events")
 option(IWYU "Developer option for include what you use." OFF)
 option(UML_LOOK "Generate graphs with an UML look" OFF)
 add_feature_info("USE_RADARE" USE_RADARE "Use Radare to add instruction information to samples.")
@@ -128,6 +126,11 @@ add_feature_info("USE_LIBAUDIT" USE_LIBAUDIT "Use libaudit for syscall name reso
 # system configuration checks
 CHECK_INCLUDE_FILES(linux/hw_breakpoint.h HAVE_HW_BREAKPOINT_H)
 CHECK_STRUCT_HAS_MEMBER("struct perf_event_attr" clockid linux/perf_event.h HAVE_PERF_EVENT_ATTR_CLOCKID)
+
+if(NOT HAVE_PERF_EVENT_ATTR_CLOCKID)
+    message(FATAL_ERROR "The system is not able to use custom reference clocks for perf events. Make sure that you are running on system that supports use_clockid with perf")
+endif()
+
 check_function_exists(clock_gettime CLOCK_GETTIME_FOUND)
 if(NOT CLOCK_GETTIME_FOUND)
     set(CMAKE_REQUIRED_LIBRARIES "rt")
@@ -328,16 +331,6 @@ else()
     endif()
 endif()
 
-# extra feature for newer kernel version
-if (USE_PERF_CLOCKID)
-    if(NOT HAVE_PERF_EVENT_ATTR_CLOCKID)
-        message(SEND_ERROR "The system is not able to use custom reference clocks for perf events. Consider deactivating USE_PERF_CLOCKID.")
-    endif()
-else()
-    if (HAVE_PERF_EVENT_ATTR_CLOCKID)
-        message(WARNING "The system claims to support custom reference clocks for perf events. Consider activating USE_PERF_CLOCKID to enable the options -k,--clockid.")
-    endif()
-endif()
 
 configure_file(include/lo2s/build_config.hpp.in include/lo2s/build_config.hpp)
 

--- a/README.md
+++ b/README.md
@@ -107,8 +107,7 @@ Combine that with the abundance of backports of particular features by different
 In the effort to keep compatible with older kernels, several quirks have been added to `lo2s`:
 
 1. The initial time synchronization between lo2s and the kernel-space perf is done with a hardware breakpoint. If your kernel doesn't support that, you can disable it using the CMake option `USE_HW_BREAKPOINT_COMPAT`.
-2. The used clock source for the kernel-space time measurments can be changed, however if you kernel doesn't support that, you can disable it with the CMake option `USE_PERF_CLOCKID`.
-3. If you get the following error message: `event 'ref-cycles' is not available as a metric leader!`, you can fallback to the bus-cycles metric as leader using `--metric-leader bus-cycles`.
+2. If you get the following error message: `event 'ref-cycles' is not available as a metric leader!`, you can fallback to the bus-cycles metric as leader using `--metric-leader bus-cycles`.
 
 # Working with traces
 

--- a/include/lo2s/build_config.hpp.in
+++ b/include/lo2s/build_config.hpp.in
@@ -32,6 +32,5 @@
 
 #cmakedefine USE_HW_BREAKPOINT_COMPAT
 
-#cmakedefine USE_PERF_CLOCKID
 
 #cmakedefine LO2S_COPYRIGHT_YEAR "@LO2S_COPYRIGHT_YEAR@"

--- a/include/lo2s/perf/sample/reader.hpp
+++ b/include/lo2s/perf/sample/reader.hpp
@@ -85,12 +85,11 @@ protected:
                      << ", enable_on_exec: " << enable_on_exec;
 
         struct perf_event_attr perf_attr = common_perf_event_attrs();
-#ifdef USE_PERF_CLOCKID
+
         if (config().use_pebs)
         {
             perf_attr.use_clockid = 0;
         }
-#endif
 
         perf_attr.exclude_kernel = config().exclude_kernel;
         perf_attr.sample_period = config().sampling_period;
@@ -165,12 +164,10 @@ protected:
         if (fd_ < 0)
         {
             Log::error() << "perf_event_open for sampling failed";
-#ifdef USE_PERF_CLOCKID
             if (perf_attr.use_clockid)
             {
                 Log::error() << "maybe the specified clock is unavailable?";
             }
-#endif
             throw_errno();
         }
         Log::debug() << "Using precise_ip level: " << perf_attr.precise_ip;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -578,7 +578,7 @@ void parse_program_options(int argc, const char** argv)
         const auto& clock = lo2s::time::ClockProvider::get_clock_by_name(requested_clock_name);
 
         lo2s::Log::debug() << "Using clock \'" << clock.name << "\'.";
-#if defined(USE_PERF_CLOCKID) && !defined(USE_HW_BREAKPOINT_COMPAT)
+#ifndef USE_HW_BREAKPOINT_COMPAT
         config.use_clockid = true;
         config.clockid = clock.id;
 #else

--- a/src/perf/util.cpp
+++ b/src/perf/util.cpp
@@ -58,7 +58,7 @@ struct perf_event_attr common_perf_event_attrs()
     attr.size = sizeof(struct perf_event_attr);
     attr.disabled = 1;
 
-#if !defined(USE_HW_BREAKPOINT_COMPAT) && defined(USE_PERF_CLOCKID)
+#ifndef USE_HW_BREAKPOINT_COMPAT
     attr.use_clockid = config().use_clockid;
     attr.clockid = config().clockid;
 #endif
@@ -125,7 +125,7 @@ int perf_event_description_open(ExecutionScope scope, const EventDescription& de
     // Needed when scaling multiplexed events, and recognize activation phases
     perf_attr.read_format = PERF_FORMAT_TOTAL_TIME_ENABLED | PERF_FORMAT_TOTAL_TIME_RUNNING;
 
-#if !defined(USE_HW_BREAKPOINT_COMPAT) && defined(USE_PERF_CLOCKID)
+#ifndef USE_HW_BREAKPOINT_COMPAT
     perf_attr.use_clockid = config().use_clockid;
     perf_attr.clockid = config().clockid;
 #endif


### PR DESCRIPTION
use_clockid is present since Linux 4.1 and allows for finer grained control over the used perf clock.

All observed systems, like ZIH's Taurus and DKRZ' Levante, have support for use_clockid, so we can safely remove this codepath.