### PR TITLE
fix(formatting): Update formatting to clang 15

### DIFF
--- a/include/lo2s/perf/syscall/reader.hpp
+++ b/include/lo2s/perf/syscall/reader.hpp
@@ -188,8 +188,8 @@ private:
 };
 
 template <typename T>
-const std::filesystem::path
-    Reader<T>::base_path = std::filesystem::path("/sys/kernel/debug/tracing/events");
+const std::filesystem::path Reader<T>::base_path =
+    std::filesystem::path("/sys/kernel/debug/tracing/events");
 } // namespace syscall
 } // namespace perf
 } // namespace lo2s

--- a/include/lo2s/perf/tracepoint/reader.hpp
+++ b/include/lo2s/perf/tracepoint/reader.hpp
@@ -190,8 +190,8 @@ private:
 };
 
 template <typename T>
-const std::filesystem::path
-    Reader<T>::base_path = std::filesystem::path("/sys/kernel/debug/tracing/events");
+const std::filesystem::path Reader<T>::base_path =
+    std::filesystem::path("/sys/kernel/debug/tracing/events");
 } // namespace tracepoint
 } // namespace perf
 } // namespace lo2s


### PR DESCRIPTION
Totally sane behaviour for a code formatting tool to have breaking changes every single version.