### PR TITLE
fix(block-io): Fix block I/O support

### DIFF
--- a/include/lo2s/perf/bio/reader.hpp
+++ b/include/lo2s/perf/bio/reader.hpp
@@ -60,19 +60,20 @@ enum class BioEventType
 
 struct __attribute((__packed__)) RecordBlock
 {
-    uint16_t common_type;         // 2
-    uint8_t common_flag;          // 3
-    uint8_t common_preempt_count; // 4
-    int32_t common_pid;           // 8
+    uint16_t common_type; // common fields included in all tracepoints, ignored here
+    uint8_t common_flag;
+    uint8_t common_preempt_count;
+    int32_t common_pid;
 
-    uint32_t dev;    // 12
-    char padding[4]; // 16
-    uint64_t sector; // 24
+    uint32_t dev;    // the accessed device (as dev_t)
+    char padding[4]; // padding because of struct alignment
+    uint64_t sector; // the accessed sector on the device
 
-    uint32_t nr_sector;     // 28
-    int32_t error_or_bytes; // 32
+    uint32_t nr_sector;     // the number of sectors written
+    int32_t error_or_bytes; // for insert/issue: number of bytes written (nr_sector * 512)
+                            // for complete: the error code of the operation
 
-    char rwbs[8]; // 40
+    char rwbs[8]; // the type of the operation. "R" for read, "W" for write, etc.
 };
 
 struct RecordBlockSampleType

--- a/include/lo2s/perf/bio/writer.hpp
+++ b/include/lo2s/perf/bio/writer.hpp
@@ -72,22 +72,23 @@ public:
         otf2::writer::local& writer = trace_.bio_writer(dev);
         otf2::definition::io_handle& handle = trace_.block_io_handle(dev);
 
-        auto size = record->sector * SECTOR_SIZE;
+        auto size = record->nr_sector * SECTOR_SIZE;
 
         if (identity.type == BioEventType::INSERT)
         {
             writer << otf2::event::io_operation_begin(
                 time_converter_(event->time), handle, mode,
-                otf2::common::io_operation_flag_type::non_blocking, record->nr_sector, size);
+                otf2::common::io_operation_flag_type::non_blocking, size, record->sector);
         }
         else if (identity.type == BioEventType::ISSUE)
         {
-            writer << otf2::event::io_operation_issued(time_converter_(event->time), handle, size);
+            writer << otf2::event::io_operation_issued(time_converter_(event->time), handle,
+                                                       record->sector);
         }
         else
         {
-            writer << otf2::event::io_operation_complete(time_converter_(event->time), handle,
-                                                         record->nr_sector, size);
+            writer << otf2::event::io_operation_complete(time_converter_(event->time), handle, size,
+                                                         record->sector);
         }
     }
 


### PR DESCRIPTION
nr_sector and sector were switched

in the code path where we need to drop an I/O event if it arrived late, the I/O event was never dropped, resulting in an infinite loop.

This does _not_ fix NVMe support as the cause for that issue is unrelated to our handling of block I/O events.

This fixes #288