### PR TITLE
feat(sampling): Implement sampling for NEC vector accelerators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,7 @@ find_package(Doxygen COMPONENTS dot)
 find_package(x86_energy 2.0 CONFIG)
 find_package(StdFilesystem REQUIRED)
 find_package(Sensors)
+find_package(Veosinfo)
 find_package(PkgConfig)
 
 if(PkgConfig_FOUND)
@@ -118,7 +119,8 @@ CMAKE_DEPENDENT_OPTION(USE_SENSORS "Use the libsensors to read system metrics." 
 add_feature_info("USE_SENSORS" USE_SENSORS "Use the libsensors to read system metrics.")
 CMAKE_DEPENDENT_OPTION(USE_LIBAUDIT "Use libaudit for syscall name resolution" ON Audit_FOUND OFF)
 add_feature_info("USE_LIBAUDIT" USE_LIBAUDIT "Use libaudit for syscall name resolution.")
-
+CMAKE_DEPENDENT_OPTION(USE_VEOSINFO "Use veosinfo to sample NEC SX-Aurora Tsubasa cards." ON "Veosinfo_FOUND" OFF)
+add_feature_info("USE_VEOSINFO" USE_VEOSINFO "Use veosinfo to sample NEC SX-Aurora  Tsubasa cards.")
 # system configuration checks
 CHECK_INCLUDE_FILES(linux/hw_breakpoint.h HAVE_HW_BREAKPOINT_H)
 CHECK_STRUCT_HAS_MEMBER("struct perf_event_attr" clockid linux/perf_event.h HAVE_PERF_EVENT_ATTR_CLOCKID)
@@ -264,6 +266,17 @@ if (USE_SENSORS)
         )
     else()
         message(SEND_ERROR "Sensors not found but requested.")
+    endif()
+endif()
+
+if (USE_VEOSINFO)
+    if(Veosinfo_FOUND)
+        target_compile_definitions(lo2s PUBLIC HAVE_VEOSINFO)
+        target_link_libraries(lo2s PRIVATE Veosinfo::veosinfo)
+        target_sources(lo2s PRIVATE src/monitor/nec_thread_monitor.cpp
+                                    src/monitor/nec_monitor_main.cpp)
+    else()
+        message(SEND_ERROR "Veosinfo not found but requested.")
     endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,8 +119,8 @@ CMAKE_DEPENDENT_OPTION(USE_SENSORS "Use the libsensors to read system metrics." 
 add_feature_info("USE_SENSORS" USE_SENSORS "Use the libsensors to read system metrics.")
 CMAKE_DEPENDENT_OPTION(USE_LIBAUDIT "Use libaudit for syscall name resolution" ON Audit_FOUND OFF)
 add_feature_info("USE_LIBAUDIT" USE_LIBAUDIT "Use libaudit for syscall name resolution.")
-CMAKE_DEPENDENT_OPTION(USE_VEOSINFO "Use veosinfo to sample NEC SX-Aurora Tsubasa cards." ON "Veosinfo_FOUND" OFF)
-add_feature_info("USE_VEOSINFO" USE_VEOSINFO "Use veosinfo to sample NEC SX-Aurora  Tsubasa cards.")
+CMAKE_DEPENDENT_OPTION(USE_VEOSINFO "Use libveosinfo to sample NEC SX-Aurora Tsubasa cards." ON "Veosinfo_FOUND" OFF)
+add_feature_info("USE_VEOSINFO" USE_VEOSINFO "Use libveosinfo to sample NEC SX-Aurora  Tsubasa cards.")
 # system configuration checks
 CHECK_INCLUDE_FILES(linux/hw_breakpoint.h HAVE_HW_BREAKPOINT_H)
 CHECK_STRUCT_HAS_MEMBER("struct perf_event_attr" clockid linux/perf_event.h HAVE_PERF_EVENT_ATTR_CLOCKID)

--- a/cmake/FindVeosinfo.cmake
+++ b/cmake/FindVeosinfo.cmake
@@ -1,0 +1,18 @@
+
+find_path(Veosinfo_INCLUDE_DIRS veosinfo/veosinfo.h PATHS ENV C_INCLUDE_PATH ENV CPATH PATH_SUFFIXES include)
+
+find_library(Veosinfo_LIBRARIES veosinfo HINT ENV LIBRARY_PATH ENV LD_LIBRARY_PATH)
+
+
+include (FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(Veosinfo DEFAULT_MSG Veosinfo_LIBRARIES Veosinfo_INCLUDE_DIRS)
+
+if(Veosinfo_FOUND)
+    add_library(libveosinfo INTERFACE)
+    target_link_libraries(libveosinfo INTERFACE ${Veosinfo_LIBRARIES})
+    target_include_directories(libveosinfo SYSTEM INTERFACE ${Veosinfo_INCLUDE_DIRS})
+    add_library(Veosinfo::veosinfo ALIAS libveosinfo)
+endif()
+
+mark_as_advanced(Veosinfo_LIBRARIES Veosinfo_INCLUDE_DIRS)

--- a/include/lo2s/config.hpp
+++ b/include/lo2s/config.hpp
@@ -95,6 +95,7 @@ struct Config
     // NEC SX-Aurora Tsubasa
     bool use_nec;
     std::chrono::microseconds nec_read_interval;
+    std::chrono::milliseconds nec_check_interval;
 };
 
 const Config& config();

--- a/include/lo2s/config.hpp
+++ b/include/lo2s/config.hpp
@@ -94,7 +94,7 @@ struct Config
     std::vector<int64_t> syscall_filter;
     // NEC SX-Aurora Tsubasa
     bool use_nec;
-    std::chrono::nanoseconds nec_readout_interval;
+    std::chrono::microseconds nec_read_interval;
 };
 
 const Config& config();

--- a/include/lo2s/config.hpp
+++ b/include/lo2s/config.hpp
@@ -92,6 +92,9 @@ struct Config
     // syscalls
     bool use_syscalls = false;
     std::vector<int64_t> syscall_filter;
+    // NEC SX-Aurora Tsubasa
+    bool use_nec;
+    std::chrono::nanoseconds nec_readout_interval;
 };
 
 const Config& config();

--- a/include/lo2s/monitor/main_monitor.hpp
+++ b/include/lo2s/monitor/main_monitor.hpp
@@ -85,7 +85,7 @@ protected:
     std::unique_ptr<metric::sensors::Recorder> sensors_recorder_;
 #endif
 #ifdef HAVE_VEOSINFO
-  std::vector<std::unique_ptr<nec::NecMonitorMain>> nec_monitors_;
+    std::vector<std::unique_ptr<nec::NecMonitorMain>> nec_monitors_;
 #endif
 };
 } // namespace monitor

--- a/include/lo2s/monitor/main_monitor.hpp
+++ b/include/lo2s/monitor/main_monitor.hpp
@@ -85,7 +85,7 @@ protected:
     std::unique_ptr<metric::sensors::Recorder> sensors_recorder_;
 #endif
 #ifdef HAVE_VEOSINFO
-    std::vector<std::unique_ptr<NecMonitorMain>> nec_monitors_;
+  std::vector<std::unique_ptr<nec::NecMonitorMain>> nec_monitors_;
 #endif
 };
 } // namespace monitor

--- a/include/lo2s/monitor/main_monitor.hpp
+++ b/include/lo2s/monitor/main_monitor.hpp
@@ -33,8 +33,10 @@
 #endif
 #include <lo2s/mmap.hpp>
 #include <lo2s/monitor/io_monitor.hpp>
+#ifdef HAVE_VEOSINFO
+#include <lo2s/monitor/nec_monitor_main.hpp>
+#endif
 #include <lo2s/monitor/tracepoint_monitor.hpp>
-#include <lo2s/perf/bio/writer.hpp>
 #include <lo2s/process_info.hpp>
 #include <lo2s/trace/trace.hpp>
 #include <lo2s/types.hpp>
@@ -81,6 +83,9 @@ protected:
 #endif
 #ifdef HAVE_SENSORS
     std::unique_ptr<metric::sensors::Recorder> sensors_recorder_;
+#endif
+#ifdef HAVE_VEOSINFO
+    std::vector<std::unique_ptr<NecMonitorMain>> nec_monitors_;
 #endif
 };
 } // namespace monitor

--- a/include/lo2s/monitor/nec_monitor_main.hpp
+++ b/include/lo2s/monitor/nec_monitor_main.hpp
@@ -31,7 +31,7 @@
 
 extern "C"
 {
-#include  <veosinfo/veosinfo.h>
+#include <veosinfo/veosinfo.h>
 
 #include <libved.h>
 }
@@ -40,7 +40,7 @@ namespace lo2s
 {
 namespace nec
 {
-  class NecMonitorMain : public monitor::ThreadedMonitor
+class NecMonitorMain : public monitor::ThreadedMonitor
 {
 public:
     NecMonitorMain(trace::Trace& trace, NecDevice device);
@@ -57,13 +57,13 @@ protected:
     void finalize_thread() override;
 
 private:
-  std::optional<NecDevice> get_device_of(Thread thread);
-  std::vector<Thread> get_tasks_of(NecDevice device);
+    std::optional<NecDevice> get_device_of(Thread thread);
+    std::vector<Thread> get_tasks_of(NecDevice device);
     std::map<Thread, NecThreadMonitor> monitors_;
     trace::Trace& trace_;
     NecDevice device_;
-  std::atomic<bool> stopped_;
+    std::atomic<bool> stopped_;
     ve_nodeinfo nodeinfo_;
 };
-} // namespace monitor
+} // namespace nec
 } // namespace lo2s

--- a/include/lo2s/monitor/nec_monitor_main.hpp
+++ b/include/lo2s/monitor/nec_monitor_main.hpp
@@ -31,7 +31,7 @@
 
 extern "C"
 {
-#include<veosinfo / veosinfo.h>
+#include  <veosinfo/veosinfo.h>
 
 #include <libved.h>
 }
@@ -40,10 +40,10 @@ namespace lo2s
 {
 namespace nec
 {
-class NecMonitorMain : public ThreadedMonitor
+  class NecMonitorMain : public monitor::ThreadedMonitor
 {
 public:
-    NecMonitorMain(trace::Trace& trace, int device);
+    NecMonitorMain(trace::Trace& trace, NecDevice device);
 
     void stop() override;
 
@@ -57,11 +57,11 @@ protected:
     void finalize_thread() override;
 
 private:
-  std::optional<int> get_device_of(Thread thread);
-
+  std::optional<NecDevice> get_device_of(Thread thread);
+  std::vector<Thread> get_tasks_of(NecDevice device);
     std::map<Thread, NecThreadMonitor> monitors_;
     trace::Trace& trace_;
-    int device_;
+    NecDevice device_;
   std::atomic<bool> stopped_;
     ve_nodeinfo nodeinfo_;
 };

--- a/include/lo2s/monitor/nec_monitor_main.hpp
+++ b/include/lo2s/monitor/nec_monitor_main.hpp
@@ -52,6 +52,8 @@ protected:
     void finalize_thread() override;
 
 private:
+    int get_nec_device_id_for_thread(Thread thread);
+
     std::map<Thread, NecThreadMonitor> monitors_;
     trace::Trace& trace_;
     int device_;

--- a/include/lo2s/monitor/nec_monitor_main.hpp
+++ b/include/lo2s/monitor/nec_monitor_main.hpp
@@ -26,14 +26,19 @@
 #include <lo2s/trace/trace.hpp>
 #include <lo2s/types.hpp>
 
-#include <veosinfo/veosinfo.h>
+#include <filesystem>
+#include <utility>
+
+extern "C"
+{
+#include<veosinfo / veosinfo.h>
 
 #include <libved.h>
+}
 
-#include <filesystem>
 namespace lo2s
 {
-namespace monitor
+namespace nec
 {
 class NecMonitorMain : public ThreadedMonitor
 {
@@ -52,13 +57,13 @@ protected:
     void finalize_thread() override;
 
 private:
-    int get_nec_device_id_for_thread(Thread thread);
+  std::optional<int> get_device_of(Thread thread);
 
     std::map<Thread, NecThreadMonitor> monitors_;
     trace::Trace& trace_;
     int device_;
-    bool stopped_;
-    struct ve_nodeinfo nodeinfo_;
+  std::atomic<bool> stopped_;
+    ve_nodeinfo nodeinfo_;
 };
 } // namespace monitor
 } // namespace lo2s

--- a/include/lo2s/monitor/nec_thread_monitor.hpp
+++ b/include/lo2s/monitor/nec_thread_monitor.hpp
@@ -31,10 +31,10 @@ namespace lo2s
 {
 namespace nec
 {
-class NecThreadMonitor : public PollMonitor
+  class NecThreadMonitor : public monitor::PollMonitor
 {
 public:
-    NecThreadMonitor(Thread thread, trace::Trace& trace, int device);
+    NecThreadMonitor(Thread thread, trace::Trace& trace, NecDevice device);
 
 protected:
     std::string group() const override
@@ -51,7 +51,7 @@ private:
     otf2::writer::local& otf2_writer_;
     Thread nec_thread_;
     trace::Trace& trace_;
-    int device_;
+    NecDevice device_;
     perf::CallingContextManager cctx_manager_;
 };
 } // namespace monitor

--- a/include/lo2s/monitor/nec_thread_monitor.hpp
+++ b/include/lo2s/monitor/nec_thread_monitor.hpp
@@ -21,12 +21,15 @@
 
 #pragma once
 
+#include <chrono>
+
 #include <lo2s/monitor/poll_monitor.hpp>
 #include <lo2s/perf/calling_context_manager.hpp>
 #include <lo2s/trace/trace.hpp>
+
 namespace lo2s
 {
-namespace monitor
+namespace nec
 {
 class NecThreadMonitor : public PollMonitor
 {
@@ -41,9 +44,10 @@ protected:
 
     void finalize_thread() override;
 
-    void monitor([[maybe_unused]] int fd) override;
+    void monitor(int fd) override;
 
 private:
+  std::chrono::microseconds nec_read_interval_;
     otf2::writer::local& otf2_writer_;
     Thread nec_thread_;
     trace::Trace& trace_;

--- a/include/lo2s/monitor/nec_thread_monitor.hpp
+++ b/include/lo2s/monitor/nec_thread_monitor.hpp
@@ -31,7 +31,7 @@ namespace lo2s
 {
 namespace nec
 {
-  class NecThreadMonitor : public monitor::PollMonitor
+class NecThreadMonitor : public monitor::PollMonitor
 {
 public:
     NecThreadMonitor(Thread thread, trace::Trace& trace, NecDevice device);
@@ -47,12 +47,12 @@ protected:
     void monitor(int fd) override;
 
 private:
-  std::chrono::microseconds nec_read_interval_;
+    std::chrono::microseconds nec_read_interval_;
     otf2::writer::local& otf2_writer_;
     Thread nec_thread_;
     trace::Trace& trace_;
     NecDevice device_;
     perf::CallingContextManager cctx_manager_;
 };
-} // namespace monitor
+} // namespace nec
 } // namespace lo2s

--- a/include/lo2s/monitor/nec_thread_monitor.hpp
+++ b/include/lo2s/monitor/nec_thread_monitor.hpp
@@ -21,19 +21,17 @@
 
 #pragma once
 
-#include <lo2s/monitor/threaded_monitor.hpp>
+#include <lo2s/monitor/poll_monitor.hpp>
 #include <lo2s/perf/calling_context_manager.hpp>
 #include <lo2s/trace/trace.hpp>
 namespace lo2s
 {
 namespace monitor
 {
-class NecThreadMonitor : public ThreadedMonitor
+class NecThreadMonitor : public PollMonitor
 {
 public:
     NecThreadMonitor(Thread thread, trace::Trace& trace, int device);
-
-    void stop() override;
 
 protected:
     std::string group() const override
@@ -41,16 +39,15 @@ protected:
         return "nec::ThreadMonitor";
     }
 
-    void run() override;
     void finalize_thread() override;
 
+    void monitor([[maybe_unused]] int fd) override;
+
 private:
-    otf2::chrono::nanoseconds nec_readout_interval_;
     otf2::writer::local& otf2_writer_;
     Thread nec_thread_;
     trace::Trace& trace_;
     int device_;
-    bool stopped_;
     perf::CallingContextManager cctx_manager_;
 };
 } // namespace monitor

--- a/include/lo2s/monitor/threaded_monitor.hpp
+++ b/include/lo2s/monitor/threaded_monitor.hpp
@@ -57,7 +57,6 @@ protected:
     virtual void run() = 0;
 
     void thread_main();
-    virtual void monitor() = 0;
 
     void register_thread();
 

--- a/include/lo2s/topology.hpp
+++ b/include/lo2s/topology.hpp
@@ -25,6 +25,7 @@
 #include <fstream>
 #include <iterator>
 #include <map>
+#include <regex>
 #include <set>
 #include <sstream>
 #include <stdexcept>
@@ -69,6 +70,26 @@ public:
     {
         return cpus_;
     }
+
+  const std::set<NecDevice> nec_devices() const
+  {
+    std::set<NecDevice> devices;
+
+    const std::regex nec_regex("/sys/class/ve/ve(\\d)");
+
+    for (auto& dir_entry : std::filesystem::directory_iterator("/sys/class/ve"))
+    {
+        std::smatch nec_match;
+
+        auto path = dir_entry.path().string();
+        if (std::regex_match(path, nec_match, nec_regex))
+        {
+          devices.emplace(NecDevice(std::stoi(nec_match[1])));
+        }
+    }
+
+    return devices;
+  }
 
     Core core_of(Cpu cpu) const
     {

--- a/include/lo2s/topology.hpp
+++ b/include/lo2s/topology.hpp
@@ -71,25 +71,25 @@ public:
         return cpus_;
     }
 
-  const std::set<NecDevice> nec_devices() const
-  {
-    std::set<NecDevice> devices;
-
-    const std::regex nec_regex("/sys/class/ve/ve(\\d)");
-
-    for (auto& dir_entry : std::filesystem::directory_iterator("/sys/class/ve"))
+    const std::set<NecDevice> nec_devices() const
     {
-        std::smatch nec_match;
+        std::set<NecDevice> devices;
 
-        auto path = dir_entry.path().string();
-        if (std::regex_match(path, nec_match, nec_regex))
+        const std::regex nec_regex("/sys/class/ve/ve(\\d)");
+
+        for (auto& dir_entry : std::filesystem::directory_iterator("/sys/class/ve"))
         {
-          devices.emplace(NecDevice(std::stoi(nec_match[1])));
-        }
-    }
+            std::smatch nec_match;
 
-    return devices;
-  }
+            auto path = dir_entry.path().string();
+            if (std::regex_match(path, nec_match, nec_regex))
+            {
+                devices.emplace(NecDevice(std::stoi(nec_match[1])));
+            }
+        }
+
+        return devices;
+    }
 
     Core core_of(Cpu cpu) const
     {

--- a/include/lo2s/trace/reg_keys.hpp
+++ b/include/lo2s/trace/reg_keys.hpp
@@ -74,6 +74,11 @@ struct ByThreadTag
 };
 using ByThread = SimpleKeyType<Thread, ByThreadTag>;
 
+struct ByNecThreadTag
+{
+};
+using ByNecThread = SimpleKeyType<Thread, ByNecThreadTag>;
+
 struct ByProcessTag
 {
 };
@@ -124,6 +129,12 @@ struct ByCounterCollectionTag
 
 using ByCounterCollection = SimpleKeyType<perf::counter::CounterCollection, ByCounterCollectionTag>;
 
+struct ByNecDeviceTag
+{
+};
+
+using ByNecDevice = SimpleKeyType<int, ByNecDeviceTag>;
+
 template <typename Definition>
 struct Holder
 {
@@ -132,8 +143,8 @@ struct Holder
 template <>
 struct Holder<otf2::definition::system_tree_node>
 {
-    using type = otf2::lookup_definition_holder<otf2::definition::system_tree_node, ByCore,
-                                                ByProcess, ByBlockDevice, ByCpu, ByPackage>;
+    using type = otf2::lookup_definition_holder<otf2::definition::system_tree_node, ByNecDevice,
+                                                ByCore, ByProcess, ByBlockDevice, ByCpu, ByPackage>;
 };
 template <>
 struct Holder<otf2::definition::regions_group>
@@ -174,13 +185,13 @@ struct Holder<otf2::definition::location_group>
 {
     using type =
         otf2::lookup_definition_holder<otf2::definition::location_group, ByMeasurementScope,
-                                       ByExecutionScope, ByBlockDevice>;
+                                       ByExecutionScope, ByNecThread, ByBlockDevice>;
 };
 template <>
 struct Holder<otf2::definition::location>
 {
     using type = otf2::lookup_definition_holder<otf2::definition::location, ByExecutionScope,
-                                                ByMeasurementScope, ByBlockDevice>;
+                                                ByMeasurementScope, ByNecThread, ByBlockDevice>;
 };
 template <>
 struct Holder<otf2::definition::region>

--- a/include/lo2s/trace/reg_keys.hpp
+++ b/include/lo2s/trace/reg_keys.hpp
@@ -133,7 +133,7 @@ struct ByNecDeviceTag
 {
 };
 
-using ByNecDevice = SimpleKeyType<int, ByNecDeviceTag>;
+using ByNecDevice = SimpleKeyType<NecDevice, ByNecDeviceTag>;
 
 template <typename Definition>
 struct Holder

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -227,6 +227,11 @@ public:
     {
         return interrupt_generator_;
     }
+
+  const otf2::definition::nec_interrupt_generator& nec_interrupt_generator() const
+  {
+    return nec_interrupt_generator_;
+  }
     const otf2::definition::system_tree_node& system_tree_cpu_node(Cpu cpu) const
     {
         return registry_.get<otf2::definition::system_tree_node>(ByCpu(cpu));
@@ -254,7 +259,7 @@ public:
     }
 
     const otf2::definition::location& location(const ExecutionScope& scope)
-    {
+    
         MeasurementScope sample_scope = MeasurementScope::sample(scope);
 
         const auto& intern_location = registry_.emplace<otf2::definition::location>(
@@ -329,6 +334,7 @@ private:
 
     otf2::definition::interrupt_generator& interrupt_generator_;
 
+  otf2::definition::detail::weak_ref<otf2::definition::interrupt_generator> nec_interrupt_generator_;
     // TODO add location groups (processes), read path from /proc/self/exe symlink
 
     std::map<Thread, std::string> thread_names_;

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -135,6 +135,7 @@ public:
     otf2::writer::local& syscall_writer(const Cpu& cpu);
     otf2::writer::local& bio_writer(BlockDevice dev);
     otf2::writer::local& create_metric_writer(const std::string& name);
+    otf2::writer::local& nec_writer(int device, const Thread& nec_thread);
 
     otf2::definition::io_handle& block_io_handle(BlockDevice dev);
 

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -228,10 +228,10 @@ public:
         return interrupt_generator_;
     }
 
-  const otf2::definition::interrupt_generator nec_interrupt_generator() const
-  {
-    return nec_interrupt_generator_;
-  }
+    const otf2::definition::interrupt_generator nec_interrupt_generator() const
+    {
+        return nec_interrupt_generator_;
+    }
 
     const otf2::definition::system_tree_node& system_tree_cpu_node(Cpu cpu) const
     {
@@ -260,7 +260,7 @@ public:
     }
 
     const otf2::definition::location& location(const ExecutionScope& scope)
-  {
+    {
         MeasurementScope sample_scope = MeasurementScope::sample(scope);
 
         const auto& intern_location = registry_.emplace<otf2::definition::location>(
@@ -335,7 +335,8 @@ private:
 
     otf2::definition::interrupt_generator& interrupt_generator_;
 
-  otf2::definition::detail::weak_ref<otf2::definition::interrupt_generator> nec_interrupt_generator_;
+    otf2::definition::detail::weak_ref<otf2::definition::interrupt_generator>
+        nec_interrupt_generator_;
     // TODO add location groups (processes), read path from /proc/self/exe symlink
 
     std::map<Thread, std::string> thread_names_;

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -135,7 +135,7 @@ public:
     otf2::writer::local& syscall_writer(const Cpu& cpu);
     otf2::writer::local& bio_writer(BlockDevice dev);
     otf2::writer::local& create_metric_writer(const std::string& name);
-    otf2::writer::local& nec_writer(int device, const Thread& nec_thread);
+    otf2::writer::local& nec_writer(NecDevice device, const Thread& nec_thread);
 
     otf2::definition::io_handle& block_io_handle(BlockDevice dev);
 
@@ -228,10 +228,11 @@ public:
         return interrupt_generator_;
     }
 
-  const otf2::definition::nec_interrupt_generator& nec_interrupt_generator() const
+  const otf2::definition::interrupt_generator nec_interrupt_generator() const
   {
     return nec_interrupt_generator_;
   }
+
     const otf2::definition::system_tree_node& system_tree_cpu_node(Cpu cpu) const
     {
         return registry_.get<otf2::definition::system_tree_node>(ByCpu(cpu));
@@ -259,7 +260,7 @@ public:
     }
 
     const otf2::definition::location& location(const ExecutionScope& scope)
-    
+  {
         MeasurementScope sample_scope = MeasurementScope::sample(scope);
 
         const auto& intern_location = registry_.emplace<otf2::definition::location>(

--- a/include/lo2s/types.hpp
+++ b/include/lo2s/types.hpp
@@ -256,6 +256,31 @@ public:
 private:
     int id_;
 };
+
+class NecDevice
+{
+public:
+    explicit NecDevice(int id) : id_(id)
+    {
+    }
+
+    int as_int() const
+    {
+        return id_;
+    }
+
+    friend bool operator==(const NecDevice& lhs, const NecDevice& rhs)
+    {
+        return lhs.id_ == rhs.id_;
+    }
+    friend bool operator<(const NecDevice& lhs, const NecDevice& rhs)
+    {
+        return lhs.id_ < rhs.id_;
+    }
+private:
+  int id_;
+};
+
 } // namespace lo2s
 
 namespace fmt
@@ -322,6 +347,27 @@ struct formatter<lo2s::Cpu>
         return fmt::format_to(ctx.out(), "cpu {}", cpu.as_int());
     }
 };
+
+  template <>
+  struct formatter<lo2s::NecDevice>
+  {
+    constexpr auto parse(format_parse_context& ctx)
+    {
+      auto it = ctx.begin(), end = ctx.end();
+      if(it != end && *it != '}')
+        {
+          throw format_error("invalid format");
+        }
+
+      return it;
+    }
+
+    template <typename FormatContext>
+    auto format(const lo2s::NecDevice& device, FormatContext& ctx) const
+    {
+      return fmt::format_to(ctx.out(), "VE {}", device.as_int());
+    }
+  };
 } // namespace fmt
 
 namespace std

--- a/include/lo2s/types.hpp
+++ b/include/lo2s/types.hpp
@@ -277,8 +277,9 @@ public:
     {
         return lhs.id_ < rhs.id_;
     }
+
 private:
-  int id_;
+    int id_;
 };
 
 } // namespace lo2s
@@ -348,26 +349,26 @@ struct formatter<lo2s::Cpu>
     }
 };
 
-  template <>
-  struct formatter<lo2s::NecDevice>
-  {
+template <>
+struct formatter<lo2s::NecDevice>
+{
     constexpr auto parse(format_parse_context& ctx)
     {
-      auto it = ctx.begin(), end = ctx.end();
-      if(it != end && *it != '}')
+        auto it = ctx.begin(), end = ctx.end();
+        if (it != end && *it != '}')
         {
-          throw format_error("invalid format");
+            throw format_error("invalid format");
         }
 
-      return it;
+        return it;
     }
 
     template <typename FormatContext>
     auto format(const lo2s::NecDevice& device, FormatContext& ctx) const
     {
-      return fmt::format_to(ctx.out(), "VE {}", device.as_int());
+        return fmt::format_to(ctx.out(), "VE {}", device.as_int());
     }
-  };
+};
 } // namespace fmt
 
 namespace std

--- a/include/lo2s/util.hpp
+++ b/include/lo2s/util.hpp
@@ -83,7 +83,10 @@ private:
 std::size_t get_page_size();
 std::string get_process_exe(Process process);
 std::string get_process_comm(Process process);
+std::vector<std::string> get_thread_cmdline(Thread thread);
 std::string get_task_comm(Process process, Thread thread);
+
+std::string get_nec_thread_comm(Thread thread);
 
 std::chrono::duration<double> get_cpu_time();
 std::string get_datetime();

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -335,7 +335,7 @@ void parse_program_options(int argc, const char** argv)
                       "Enable recording of block I/O events (requires access to debugfs)");
 
     nec_options.toggle("nec", "Enable NEC SX-Aurora Tsubasa sampling");
-    nec_options.option("nec-readout-interval").optional().metavar("MSEC").default_value("1");
+    nec_options.option("nec-readout-interval", "NEC sampling interval in microseconds").optional().metavar("MSEC").default_value("1");
     nitro::options::arguments arguments;
     try
     {
@@ -617,8 +617,9 @@ void parse_program_options(int argc, const char** argv)
     config.userspace_read_interval =
         std::chrono::milliseconds(arguments.as<std::uint64_t>("userspace-readout-interval"));
 
-    config.nec_readout_interval =
-        std::chrono::milliseconds(arguments.as<std::uint64_t>("nec-readout-interval"));
+    config.nec_read_interval =
+
+        std::chrono::microseconds(arguments.as<std::uint64_t>("nec-readout-interval"));
 
     if (arguments.provided("perf-readout-interval"))
     {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -160,6 +160,7 @@ void parse_program_options(int argc, const char** argv)
     auto& x86_energy_options = parser.group("x86_energy options");
     auto& sensors_options = parser.group("sensors options");
     auto& io_options = parser.group("I/O recording options");
+    auto& nec_options = parser.group("NEC SX-Aurora Tsubasa recording options");
 
     lo2s::Config config;
 
@@ -333,6 +334,8 @@ void parse_program_options(int argc, const char** argv)
     io_options.toggle("block-io",
                       "Enable recording of block I/O events (requires access to debugfs)");
 
+    nec_options.toggle("nec", "Enable NEC SX-Aurora Tsubasa sampling");
+    nec_options.option("nec-readout-interval").optional().metavar("MSEC").default_value("1");
     nitro::options::arguments arguments;
     try
     {
@@ -358,6 +361,7 @@ void parse_program_options(int argc, const char** argv)
     config.use_x86_energy = arguments.given("x86-energy");
     config.use_sensors = arguments.given("sensors");
     config.use_block_io = arguments.given("block-io");
+    config.use_nec = arguments.given("nec");
     config.command = arguments.positionals();
 
     if (arguments.given("help"))
@@ -612,6 +616,9 @@ void parse_program_options(int argc, const char** argv)
 
     config.userspace_read_interval =
         std::chrono::milliseconds(arguments.as<std::uint64_t>("userspace-readout-interval"));
+
+    config.nec_readout_interval =
+        std::chrono::milliseconds(arguments.as<std::uint64_t>("nec-readout-interval"));
 
     if (arguments.provided("perf-readout-interval"))
     {

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -334,8 +334,16 @@ void parse_program_options(int argc, const char** argv)
     io_options.toggle("block-io",
                       "Enable recording of block I/O events (requires access to debugfs)");
 
-    nec_options.toggle("nec", "Enable NEC SX-Aurora Tsubasa sampling");
-    nec_options.option("nec-readout-interval", "NEC sampling interval in microseconds").optional().metavar("MSEC").default_value("1");
+    nec_options.toggle("nec", "Enable NEC Vector Engine sampling");
+    nec_options.option("nec-readout-interval", "NEC sampling interval")
+        .optional()
+        .metavar("USEC")
+        .default_value("1");
+    nec_options.option("nec-check-interval", "The interval between checks for new VE processes")
+        .optional()
+        .metavar("MSEC")
+        .default_value("100");
+
     nitro::options::arguments arguments;
     try
     {
@@ -618,8 +626,10 @@ void parse_program_options(int argc, const char** argv)
         std::chrono::milliseconds(arguments.as<std::uint64_t>("userspace-readout-interval"));
 
     config.nec_read_interval =
-
         std::chrono::microseconds(arguments.as<std::uint64_t>("nec-readout-interval"));
+
+    config.nec_check_interval =
+        std::chrono::milliseconds(arguments.as<std::uint64_t>("nec-check-interval"));
 
     if (arguments.provided("perf-readout-interval"))
     {

--- a/src/monitor/main_monitor.cpp
+++ b/src/monitor/main_monitor.cpp
@@ -129,7 +129,7 @@ MainMonitor::MainMonitor() : trace_(), metrics_(trace_)
         {
             auto monitor = nec_monitors_.emplace_back(
                 std::make_unique<NecMonitorMain>(trace_, std::stoi(nec_match[1])));
-            std::asssert(monitor.first);
+            std::assert(monitor.first);
 
             nec_monitors_.back()->start();
         }
@@ -187,13 +187,10 @@ MainMonitor::~MainMonitor()
     }
 
 #ifdef HAVE_VEOSINFO
-    if (!nec_monitors_.empty())
-    {
         for (auto& nec_monitor : nec_monitors_)
         {
             nec_monitor->stop();
         }
-    }
 #endif
 
     // Notify trace, that we will end recording now. That means, get_time() of this call will be

--- a/src/monitor/main_monitor.cpp
+++ b/src/monitor/main_monitor.cpp
@@ -127,8 +127,10 @@ MainMonitor::MainMonitor() : trace_(), metrics_(trace_)
         auto path = dir_entry.path().string();
         if (std::regex_match(path, nec_match, nec_regex))
         {
-            nec_monitors_.emplace_back(
+            auto monitor = nec_monitors_.emplace_back(
                 std::make_unique<NecMonitorMain>(trace_, std::stoi(nec_match[1])));
+            std::asssert(monitor.first);
+
             nec_monitors_.back()->start();
         }
     }

--- a/src/monitor/main_monitor.cpp
+++ b/src/monitor/main_monitor.cpp
@@ -119,11 +119,11 @@ MainMonitor::MainMonitor() : trace_(), metrics_(trace_)
 
 #ifdef HAVE_VEOSINFO
 
-    for(auto device : Topology::instance().nec_devices())
-      {
-        nec_monitors_.emplace_back(std::make_unique<nec::NecMonitorMain>(trace_, device ));
+    for (auto device : Topology::instance().nec_devices())
+    {
+        nec_monitors_.emplace_back(std::make_unique<nec::NecMonitorMain>(trace_, device));
 
-            nec_monitors_.back()->start();
+        nec_monitors_.back()->start();
     }
 #endif
 }
@@ -178,10 +178,10 @@ MainMonitor::~MainMonitor()
     }
 
 #ifdef HAVE_VEOSINFO
-        for (auto& nec_monitor : nec_monitors_)
-        {
-            nec_monitor->stop();
-        }
+    for (auto& nec_monitor : nec_monitors_)
+    {
+        nec_monitor->stop();
+    }
 #endif
 
     // Notify trace, that we will end recording now. That means, get_time() of this call will be

--- a/src/monitor/main_monitor.cpp
+++ b/src/monitor/main_monitor.cpp
@@ -118,21 +118,12 @@ MainMonitor::MainMonitor() : trace_(), metrics_(trace_)
 #endif
 
 #ifdef HAVE_VEOSINFO
-    const std::regex nec_regex("/sys/class/ve/ve(\\d)");
 
-    for (auto& dir_entry : std::filesystem::directory_iterator("/sys/class/ve"))
-    {
-        std::smatch nec_match;
-
-        auto path = dir_entry.path().string();
-        if (std::regex_match(path, nec_match, nec_regex))
-        {
-            auto monitor = nec_monitors_.emplace_back(
-                std::make_unique<NecMonitorMain>(trace_, std::stoi(nec_match[1])));
-            std::assert(monitor.first);
+    for(auto device : Topology::instance().nec_devices())
+      {
+        nec_monitors_.emplace_back(std::make_unique<nec::NecMonitorMain>(trace_, device ));
 
             nec_monitors_.back()->start();
-        }
     }
 #endif
 }

--- a/src/monitor/nec_monitor_main.cpp
+++ b/src/monitor/nec_monitor_main.cpp
@@ -26,22 +26,22 @@ namespace lo2s
 namespace monitor
 {
 
-  int NecMonitorMain::get_nec_device_id_for_thread(Thread thread)
-  {
-            // /sys/class/ve/ve0 is not device 0, because that would make too much sense
-            // So look the device id up here
+int NecMonitorMain::get_nec_device_id_for_thread(Thread thread)
+{
+    // /sys/class/ve/ve0 is not device 0, because that would make too much sense
+    // So look the device id up here
 
-            int real_device_id = -1;
-            for (int i = 0; i < nodeinfo_.total_node_count; i++)
-            {
-                if (!ve_check_pid(nodeinfo_.nodeid[i], thread.as_pid_t()))
-                {
-                    real_device_id = nodeinfo_.nodeid[i];
-                    break;
-                }
-            }
-            return real_device_id;
-  }
+    int real_device_id = -1;
+    for (int i = 0; i < nodeinfo_.total_node_count; i++)
+    {
+        if (!ve_check_pid(nodeinfo_.nodeid[i], thread.as_pid_t()))
+        {
+            real_device_id = nodeinfo_.nodeid[i];
+            break;
+        }
+    }
+    return real_device_id;
+}
 NecMonitorMain::NecMonitorMain(trace::Trace& trace, int device)
 : ThreadedMonitor(trace, fmt::format("VE {}", device)), trace_(trace), device_(device),
   stopped_(false)
@@ -64,7 +64,7 @@ void NecMonitorMain::run()
             threads.emplace_back(Thread(pid));
         }
 
-        //For some god-forsaken reason, the last read entry from task_id_all will always be invalid
+        // For some god-forsaken reason, the last read entry from task_id_all will always be invalid
 
         threads.pop_back();
 

--- a/src/monitor/nec_monitor_main.cpp
+++ b/src/monitor/nec_monitor_main.cpp
@@ -26,6 +26,22 @@ namespace lo2s
 namespace monitor
 {
 
+  int NecMonitorMain::get_nec_device_id_for_thread(Thread thread)
+  {
+            // /sys/class/ve/ve0 is not device 0, because that would make too much sense
+            // So look the device id up here
+
+            int real_device_id = -1;
+            for (int i = 0; i < nodeinfo_.total_node_count; i++)
+            {
+                if (!ve_check_pid(nodeinfo_.nodeid[i], thread.as_pid_t()))
+                {
+                    real_device_id = nodeinfo_.nodeid[i];
+                    break;
+                }
+            }
+            return real_device_id;
+  }
 NecMonitorMain::NecMonitorMain(trace::Trace& trace, int device)
 : ThreadedMonitor(trace, fmt::format("VE {}", device)), trace_(trace), device_(device),
   stopped_(false)
@@ -47,6 +63,8 @@ void NecMonitorMain::run()
             task_stream >> pid;
             threads.emplace_back(Thread(pid));
         }
+
+        //For some god-forsaken reason, the last read entry from task_id_all will always be invalid
 
         threads.pop_back();
 
@@ -70,18 +88,7 @@ void NecMonitorMain::run()
                 continue;
             }
 
-            // /sys/class/ve/ve0 is not device 0, because that would make too much sense
-            // So look the device id up here
-
-            int real_device_id = -1;
-            for (int i = 0; i < nodeinfo_.total_node_count; i++)
-            {
-                if (!ve_check_pid(nodeinfo_.nodeid[i], thread.as_pid_t()))
-                {
-                    real_device_id = nodeinfo_.nodeid[i];
-                    break;
-                }
-            }
+            int real_device_id = get_nec_device_id_for_thread(thread);
 
             if (real_device_id == -1)
             {

--- a/src/monitor/nec_monitor_main.cpp
+++ b/src/monitor/nec_monitor_main.cpp
@@ -1,0 +1,118 @@
+/*
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2017,
+ *    Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <lo2s/monitor/nec_monitor_main.hpp>
+
+namespace lo2s
+{
+namespace monitor
+{
+
+NecMonitorMain::NecMonitorMain(trace::Trace& trace, int device)
+: ThreadedMonitor(trace, fmt::format("VE {}", device)), trace_(trace), device_(device),
+  stopped_(false)
+{
+    ve_node_info(&nodeinfo_);
+}
+
+void NecMonitorMain::run()
+{
+    while (!stopped_)
+    {
+        std::ifstream task_stream(fmt::format("/sys/class/ve/ve{}/task_id_all", device_));
+
+        std::vector<Thread> threads;
+
+        while (task_stream.good())
+        {
+            pid_t pid;
+            task_stream >> pid;
+            threads.emplace_back(Thread(pid));
+        }
+
+        threads.pop_back();
+
+        for (auto monitor = monitors_.begin(); monitor != monitors_.end();)
+        {
+            if (std::find(threads.begin(), threads.end(), monitor->first) == threads.end())
+            {
+                monitor->second.stop();
+                monitor = monitors_.erase(monitor);
+            }
+            else
+            {
+                monitor++;
+            }
+        }
+
+        for (auto& thread : threads)
+        {
+            if (monitors_.count(thread))
+            {
+                continue;
+            }
+
+            // /sys/class/ve/ve0 is not device 0, because that would make too much sense
+            // So look the device id up here
+
+            int real_device_id = -1;
+            for (int i = 0; i < nodeinfo_.total_node_count; i++)
+            {
+                if (!ve_check_pid(nodeinfo_.nodeid[i], thread.as_pid_t()))
+                {
+                    real_device_id = nodeinfo_.nodeid[i];
+                    break;
+                }
+            }
+
+            if (real_device_id == -1)
+            {
+                Log::warn() << "Could not find real vector accelerator id for "
+                            << thread.as_pid_t();
+                continue;
+            }
+
+            auto ret = monitors_.emplace(std::piecewise_construct, std::forward_as_tuple(thread),
+                                         std::forward_as_tuple(thread, trace_, real_device_id));
+            if (ret.second)
+            {
+                ret.first->second.start();
+            }
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+}
+
+void NecMonitorMain::stop()
+{
+    stopped_ = true;
+    thread_.join();
+}
+
+void NecMonitorMain::finalize_thread()
+{
+    for (auto& monitor : monitors_)
+    {
+        monitor.second.stop();
+    }
+}
+} // namespace monitor
+} // namespace lo2s

--- a/src/monitor/nec_thread_monitor.cpp
+++ b/src/monitor/nec_thread_monitor.cpp
@@ -34,10 +34,10 @@ namespace lo2s
 namespace nec
 {
 NecThreadMonitor::NecThreadMonitor(Thread thread, trace::Trace& trace, NecDevice device)
-  : PollMonitor(trace, fmt::format("VE{} {}", device, thread.as_pid_t()), std::chrono::duration_cast<std::chrono::nanoseconds>(config().nec_read_interval)),
-  nec_read_interval_(config().nec_read_interval),
-  otf2_writer_(trace.nec_writer(device, thread)), nec_thread_(thread), trace_(trace),
-  device_(device), cctx_manager_(trace)
+: PollMonitor(trace, fmt::format("VE{} {}", device, thread.as_pid_t()),
+              std::chrono::duration_cast<std::chrono::nanoseconds>(config().nec_read_interval)),
+  nec_read_interval_(config().nec_read_interval), otf2_writer_(trace.nec_writer(device, thread)),
+  nec_thread_(thread), trace_(trace), device_(device), cctx_manager_(trace)
 {
     cctx_manager_.thread_enter(nec_thread_.as_process(), thread);
     otf2_writer_.write_calling_context_enter(lo2s::time::now(), cctx_manager_.current(), 2);
@@ -50,11 +50,11 @@ void NecThreadMonitor::monitor([[maybe_unused]] int fd)
 
     auto ret = ve_get_regvals(device_.as_int(), nec_thread_.as_pid_t(), 1, reg, &val);
 
-    if(ret == -1)
-      {
+    if (ret == -1)
+    {
         Log::error() << "Failed to the vector engine instruction counter value!";
         throw_errno();
-      }
+    }
 
     otf2::chrono::time_point tp = lo2s::time::now();
     otf2_writer_.write_calling_context_sample(tp, cctx_manager_.sample_ref(val), 2,
@@ -70,5 +70,5 @@ void NecThreadMonitor::finalize_thread()
 
     cctx_manager_.finalize(&otf2_writer_);
 }
-} // namespace monitor
+} // namespace nec
 } // namespace lo2s

--- a/src/monitor/nec_thread_monitor.cpp
+++ b/src/monitor/nec_thread_monitor.cpp
@@ -28,7 +28,6 @@ extern "C"
 
 #include <libved.h>
 
-int reg[] = { IC };
 
 namespace lo2s
 {
@@ -50,17 +49,16 @@ void NecThreadMonitor::stop()
     thread_.join();
 }
 
-void NecThreadMonitor::run()
+void NecThreadMonitor::monitor()
 {
-    uint64_t vals[1];
-    while (!stopped_)
-    {
-        ve_get_regvals(device_, nec_thread_.as_pid_t(), 1, reg, vals);
+    static int reg[] = { IC };
+    uint64_t val;
+
+        ve_get_regvals(device_, nec_thread_.as_pid_t(), 1, reg, &val);
         otf2::chrono::time_point tp = lo2s::time::now();
-        otf2_writer_.write_calling_context_sample(tp, cctx_manager_.sample_ref(vals[0]), 2,
+        otf2_writer_.write_calling_context_sample(tp, cctx_manager_.sample_ref(val), 2,
                                                   trace_.interrupt_generator().ref());
         std::this_thread::sleep_for(nec_readout_interval_);
-    }
 }
 
 void NecThreadMonitor::finalize_thread()

--- a/src/monitor/nec_thread_monitor.cpp
+++ b/src/monitor/nec_thread_monitor.cpp
@@ -28,7 +28,6 @@ extern "C"
 
 #include <libved.h>
 
-
 namespace lo2s
 {
 namespace monitor
@@ -54,11 +53,11 @@ void NecThreadMonitor::monitor()
     static int reg[] = { IC };
     uint64_t val;
 
-        ve_get_regvals(device_, nec_thread_.as_pid_t(), 1, reg, &val);
-        otf2::chrono::time_point tp = lo2s::time::now();
-        otf2_writer_.write_calling_context_sample(tp, cctx_manager_.sample_ref(val), 2,
-                                                  trace_.interrupt_generator().ref());
-        std::this_thread::sleep_for(nec_readout_interval_);
+    ve_get_regvals(device_, nec_thread_.as_pid_t(), 1, reg, &val);
+    otf2::chrono::time_point tp = lo2s::time::now();
+    otf2_writer_.write_calling_context_sample(tp, cctx_manager_.sample_ref(val), 2,
+                                              trace_.interrupt_generator().ref());
+    std::this_thread::sleep_for(nec_readout_interval_);
 }
 
 void NecThreadMonitor::finalize_thread()

--- a/src/monitor/nec_thread_monitor.cpp
+++ b/src/monitor/nec_thread_monitor.cpp
@@ -1,0 +1,76 @@
+/*
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2016,
+ *    Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <lo2s/monitor/nec_thread_monitor.hpp>
+
+extern "C"
+{
+#include <veosinfo/veosinfo.h>
+}
+
+#include <libved.h>
+
+int reg[] = { IC };
+
+namespace lo2s
+{
+namespace monitor
+{
+NecThreadMonitor::NecThreadMonitor(Thread thread, trace::Trace& trace, int device)
+: ThreadedMonitor(trace, fmt::format("VE{} {}", device, thread.as_pid_t())),
+  nec_readout_interval_(config().nec_readout_interval),
+  otf2_writer_(trace.nec_writer(device, thread)), nec_thread_(thread), trace_(trace),
+  device_(device), stopped_(false), cctx_manager_(trace)
+{
+    cctx_manager_.thread_enter(nec_thread_.as_process(), thread);
+    otf2_writer_.write_calling_context_enter(lo2s::time::now(), cctx_manager_.current(), 2);
+}
+
+void NecThreadMonitor::stop()
+{
+    stopped_ = true;
+    thread_.join();
+}
+
+void NecThreadMonitor::run()
+{
+    uint64_t vals[1];
+    while (!stopped_)
+    {
+        ve_get_regvals(device_, nec_thread_.as_pid_t(), 1, reg, vals);
+        otf2::chrono::time_point tp = lo2s::time::now();
+        otf2_writer_.write_calling_context_sample(tp, cctx_manager_.sample_ref(vals[0]), 2,
+                                                  trace_.interrupt_generator().ref());
+        std::this_thread::sleep_for(nec_readout_interval_);
+    }
+}
+
+void NecThreadMonitor::finalize_thread()
+{
+    if (!cctx_manager_.current().is_undefined())
+    {
+        otf2_writer_.write_calling_context_leave(lo2s::time::now(), cctx_manager_.current());
+    }
+
+    cctx_manager_.finalize(&otf2_writer_);
+}
+} // namespace monitor
+} // namespace lo2s

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -411,13 +411,13 @@ otf2::writer::local& Trace::sample_writer(const ExecutionScope& writer_scope)
     return archive_(location(writer_scope));
 }
 
-otf2::writer::local& Trace::nec_writer(int device, const Thread& nec_thread)
+otf2::writer::local& Trace::nec_writer(NecDevice device, const Thread& nec_thread)
 {
 
-    auto& intern_name = intern(fmt::format("VE{} {}", device, get_nec_thread_comm(nec_thread)));
+    auto& intern_name = intern(fmt::format("{} {}", device, get_nec_thread_comm(nec_thread)));
 
     const auto& node = registry_.emplace<otf2::definition::system_tree_node>(
-        ByNecDevice(device), intern(fmt::format("VE{}", device)), intern("NEC vector accelerator"),
+        ByNecDevice(device), intern(fmt::format("{}", device)), intern("NEC vector accelerator"),
         system_tree_root_node_);
 
     const auto& nec_location_group = registry_.emplace<otf2::definition::location_group>(

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -194,6 +194,13 @@ Trace::Trace()
             }
         }
     }
+
+    if(config().use_nec)
+      {
+        nec_interrupt_generator_ = registry_.create<otf2::definition::interrupt_generator>(
+            intern("NEC sampling timer"), otf2::common::interrupt_generator_mode_type::count,
+            otf2::common::base_type::decimal, 0, config().sampling_period);
+      }
 }
 
 void Trace::begin_record()

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -406,33 +406,8 @@ otf2::writer::local& Trace::sample_writer(const ExecutionScope& writer_scope)
 
 otf2::writer::local& Trace::nec_writer(int device, const Thread& nec_thread)
 {
-    std::ifstream cmdline(fmt::format("/proc/{}/cmdline", nec_thread.as_pid_t()));
-    std::string cmdline_str;
-    cmdline >> cmdline_str;
-    ;
 
-    const char* cmdline_c_str = cmdline_str.c_str();
-    std::vector<std::string> args;
-    while (cmdline_c_str < cmdline_str.c_str() + cmdline_str.length())
-    {
-        args.emplace_back(std::string(cmdline_c_str));
-        cmdline_c_str += args.back().length() + 1;
-    }
-
-    std::string thread_name = fmt::format("{}", nec_thread);
-
-    for (std::size_t i = 0; i < args.size(); i++)
-    {
-        if (args[i] == "--")
-        {
-            if (i + 1 < args.size())
-            {
-                thread_name = fmt::format("{} ({})", args[i + 1], nec_thread.as_pid_t());
-            }
-        }
-    }
-
-    auto& intern_name = intern(fmt::format("VE{} {}", device, thread_name));
+    auto& intern_name = intern(fmt::format("VE{} {}", device, get_nec_thread_comm(nec_thread)));
 
     const auto& node = registry_.emplace<otf2::definition::system_tree_node>(
         ByNecDevice(device), intern(fmt::format("VE{}", device)), intern("NEC vector accelerator"),

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -195,12 +195,12 @@ Trace::Trace()
         }
     }
 
-    if(config().use_nec)
-      {
+    if (config().use_nec)
+    {
         nec_interrupt_generator_ = registry_.create<otf2::definition::interrupt_generator>(
             intern("NEC sampling timer"), otf2::common::interrupt_generator_mode_type::count,
             otf2::common::base_type::decimal, 0, config().sampling_period);
-      }
+    }
 }
 
 void Trace::begin_record()

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -346,9 +346,10 @@ std::vector<std::string> get_thread_cmdline(Thread thread)
 
 std::string get_nec_thread_comm(Thread thread)
 {
-  // For normal processes, /proc/{PID}/comm contains the name of the program running in that process
-  // For NEC processes, it instead contains the name of the program loader, ve_exec
-  // So instead, we have to extract the name of the actual NEC program we are executing from the commandline arguments to ve_exec
+    // For normal processes, /proc/{PID}/comm contains the name of the program running in that
+    // process For NEC processes, it instead contains the name of the program loader, ve_exec So
+    // instead, we have to extract the name of the actual NEC program we are executing from the
+    // commandline arguments to ve_exec
     std::string thread_name = fmt::format("{}", thread);
 
     auto args = get_thread_cmdline(thread);

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -347,7 +347,7 @@ std::vector<std::string> get_thread_cmdline(Thread thread)
 std::string get_nec_thread_comm(Thread thread)
 {
     // For normal processes, /proc/{PID}/comm contains the name of the program running in that
-    // process For NEC processes, it instead contains the name of the program loader, ve_exec So
+    // process. For NEC processes, it instead contains the name of the program loader, ve_exec, So
     // instead, we have to extract the name of the actual NEC program we are executing from the
     // commandline arguments to ve_exec
     std::string thread_name = fmt::format("{}", thread);


### PR DESCRIPTION
This PR implements sampling for NEC Vector accelerators, such as the NEC SX-Aurora Tsubasa cards.

The "--nec" enables NEC sampling. This records the activity of every thread on every card, regardles of the overall sampling mode.

"--nec-readout-interval" controls the interval of the readouts

This fixes #253 