### PR TITLE
Remove duplicate entries in .clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -37,8 +37,6 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 
 
-SpaceBeforeAssignmentOperators: true
-SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
 
 


### PR DESCRIPTION
clang-format 17.0.3 fails if there are duplicate entries in .clang-format, so remove them


This fixes #307