### PR TITLE
Fix --block-io

### DIFF
--- a/include/lo2s/perf/multi_reader.hpp
+++ b/include/lo2s/perf/multi_reader.hpp
@@ -93,7 +93,6 @@ public:
                 {
                     state.time = event->time;
                     earliest_available.push(state);
-                    readers_.at(state.identity).pop();
                     break;
                 }
 


### PR DESCRIPTION
Due to a bug, when the multi-reader switches from one reader with later events to one that has earlier events, a block I/O event was discarded from the reader with the later events. This predictably led to event loss.

Further, the insert event was switched from block_rq_insert to block_bio_queue. The reason for this is that block_rq_insert never matched the amount of data reported by block_rq_issue and block_rq_complete. I could not find another block_rq_* tracepoint that accounts for the block I/O request that do not enter through block_rq_insert. However, block_bio_queue matches the amount of data that block_rq_issue and block_rq_complete report.

This results in somewhat of a mismatch, as block_bio_* is one level higher up than block_rq_*. This is most notable in that one block_bio_queue "struct bio" is split into multiple (usually less than 10) "struct rq" on the block_rq_* level.

I remedy this situation by only writing the first block_rq_insert/issue event that I encounter (which is the one with the matching sector to the block_bio_queue event) and discarding the others.

We might want to discuss if using the timestamp of the last block_rq_* event is the more correct variant.

This Fixes #290