### PR TITLE
Add the ability to have system-mode without process tracking

### DIFF
--- a/include/lo2s/config.hpp
+++ b/include/lo2s/config.hpp
@@ -67,6 +67,7 @@ struct Config
     // perf
     std::size_t mmap_pages;
     bool exclude_kernel = false;
+    bool process_recording = false;
     // Instruction sampling
     bool sampling = false;
     std::uint64_t sampling_period;

--- a/include/lo2s/perf/counter/metric_writer.hpp
+++ b/include/lo2s/perf/counter/metric_writer.hpp
@@ -38,7 +38,7 @@ public:
     MetricWriter(MeasurementScope scope, trace::Trace& trace)
     : time_converter_(time::Converter::instance()), writer_(trace.metric_writer(scope)),
       metric_instance_(trace.metric_instance(trace.perf_metric_class(scope), writer_.location(),
-                                             trace.location(scope.scope))),
+                                             trace.sample_writer(scope.scope).location())),
       metric_event_(otf2::chrono::genesis(), metric_instance_)
     {
     }

--- a/man/lo2s.1.pod
+++ b/man/lo2s.1.pod
@@ -199,6 +199,11 @@ way to support the large PEBS feature of newer (Skylake+) Intel processors
 
 If set, only perf events for processes in the I<NAME> cgroup are recorded.
 
+=item B<-->[B<no->]B<process-recording>
+
+If set, process scheduling information is recorded. This is enabled by default in
+system-monitoring mode.
+
 =item B<--list-clockids>
 
 List the names of clocks that can be used as I<CLOCKID> argument.

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -245,6 +245,12 @@ void parse_program_options(int argc, const char** argv)
     general_options.toggle("list-knobs", "List available x86_adapt CPU knobs.");
 
     system_mode_options
+        .toggle("process-recording", "Record process activity. In system monitoring: "
+                                     "(default: enabled)")
+        .allow_reverse()
+        .default_value(true);
+
+    system_mode_options
         .toggle("all-cpus", "Start in system-monitoring mode for all CPUs. "
                             "Monitor as long as COMMAND is running or until PID exits.")
         .short_name("a");
@@ -646,6 +652,7 @@ void parse_program_options(int argc, const char** argv)
     {
         config.monitor_type = lo2s::MonitorType::CPU_SET;
         config.sampling = false;
+        config.process_recording = arguments.given("process-recording");
 
         // The check for instruction sampling is a bit more complicated, because the default value
         // is different depending on the monitoring mode. This check here is only relevant for
@@ -679,6 +686,7 @@ void parse_program_options(int argc, const char** argv)
 
         config.monitor_type = lo2s::MonitorType::PROCESS;
         config.sampling = true;
+        config.process_recording = false;
 
         if (!arguments.given("instruction-sampling"))
         {

--- a/src/monitor/cpu_set_monitor.cpp
+++ b/src/monitor/cpu_set_monitor.cpp
@@ -63,7 +63,10 @@ CpuSetMonitor::CpuSetMonitor() : MainMonitor()
         }
     }
 
-    trace_.add_threads(get_comms_for_running_threads());
+    if (config().sampling || config().process_recording)
+    {
+        trace_.add_threads(get_comms_for_running_threads());
+    }
 
     try
     {
@@ -138,8 +141,10 @@ void CpuSetMonitor::run()
         }
     }
 
-    trace_.add_threads(get_comms_for_running_threads());
-
+    if (config().sampling || config().process_recording)
+    {
+        trace_.add_threads(get_comms_for_running_threads());
+    }
     for (auto& monitor_elem : monitors_)
     {
         monitor_elem.second.stop();

--- a/src/monitor/scope_monitor.cpp
+++ b/src/monitor/scope_monitor.cpp
@@ -43,7 +43,7 @@ ScopeMonitor::ScopeMonitor(ExecutionScope scope, MainMonitor& parent, bool enabl
                            bool is_process)
 : PollMonitor(parent.trace(), scope.name(), config().perf_read_interval), scope_(scope)
 {
-    if (config().sampling || scope.is_cpu())
+    if (config().sampling || config().process_recording)
     {
         sample_writer_ =
             std::make_unique<perf::sample::Writer>(scope, parent, parent.trace(), enable_on_exec);

--- a/src/perf/event_composer.cpp
+++ b/src/perf/event_composer.cpp
@@ -114,7 +114,7 @@ EventAttr EventComposer::create_sampling_event()
     }
     else
     {
-        EventAttr event = EventResolver::instance().get_event_by_name("dummy");
+        sampling_event_ = EventResolver::instance().get_event_by_name("dummy");
     }
 
     sampling_event_->set_sample_id_all();


### PR DESCRIPTION
This should reduce the overhead in situations where you really only want to track metrics in system-wide mode.