### PR TITLE
Bump file descriptor rlimit to hard rlimit by default

### DIFF
--- a/include/lo2s/util.hpp
+++ b/include/lo2s/util.hpp
@@ -40,6 +40,7 @@
 
 extern "C"
 {
+#include <sys/resource.h>
 #include <sys/types.h>
 #include <sys/utsname.h>
 #include <unistd.h>
@@ -113,6 +114,9 @@ std::unordered_map<Thread, std::string> get_comms_for_running_threads();
 void try_pin_to_scope(ExecutionScope scope);
 
 int get_cgroup_mountpoint_fd(std::string cgroup);
+
+void bump_rlimit_fd();
+struct rlimit initial_rlimit_fd();
 
 Thread gettid();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -24,11 +24,20 @@
 #include <lo2s/monitor/process_monitor.hpp>
 #include <lo2s/monitor/process_monitor_main.hpp>
 #include <lo2s/summary.hpp>
+#include <lo2s/util.hpp>
 
 #include <system_error>
 
 int main(int argc, const char** argv)
 {
+    // The resource limit for file descriptors (which lo2s uses a lot of, especially in
+    // system-monitoring mode) is artifically low to cope with the ancient select() systemcall. We
+    // do not use select(), so we can safely bump the limit, but whatever command we are running
+    // under lo2s might (and resource limits are preserved accross fork()) so preserve it here so
+    // that we can restore it later
+    lo2s::initial_rlimit_fd();
+    lo2s::bump_rlimit_fd();
+
     try
     {
         lo2s::parse_program_options(argc, argv);

--- a/src/monitor/process_monitor_main.cpp
+++ b/src/monitor/process_monitor_main.cpp
@@ -55,6 +55,9 @@ namespace monitor
 
 [[noreturn]] static void run_command(const std::vector<std::string>& command_and_args)
 {
+    struct rlimit initial_rlimit = initial_rlimit_fd();
+    setrlimit(RLIMIT_NOFILE, &initial_rlimit);
+
     /* kill yourself if the parent dies */
     prctl(PR_SET_PDEATHSIG, SIGHUP);
 
@@ -109,6 +112,7 @@ void process_monitor_main(AbstractProcessMonitor& monitor)
             throw_errno();
         }
     }
+
     if (process == Process::invalid())
     {
         Log::error() << "Fork failed.";

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -366,4 +366,25 @@ std::string get_nec_thread_comm(Thread thread)
     // If no '--' is found, fall back to the complete commandline as a name
     return std::accumulate(args.begin(), args.end(), std::string(""));
 }
+
+struct rlimit initial_rlimit_fd()
+{
+    static struct rlimit current;
+
+    if (current.rlim_cur == 0)
+    {
+        getrlimit(RLIMIT_NOFILE, &current);
+    }
+
+    return current;
+}
+
+void bump_rlimit_fd()
+{
+    struct rlimit highest;
+    getrlimit(RLIMIT_NOFILE, &highest);
+
+    highest.rlim_cur = highest.rlim_max;
+    setrlimit(RLIMIT_NOFILE, &highest);
+}
 } // namespace lo2s


### PR DESCRIPTION
The default soft limit for the number of open file descriptors per-process in most Linux systems is 1024. This results in crashes on most HPC systems I've used recently as even simple lo2s invocations will exceed this limit with all the per-core perf_event_open calls.

This microscopic soft limit is in place because select() only allows fd's < 1024. If you do not plan to use select() in your code, it is safe to bump the file descriptor limit from the soft limit to the hard limit.

We need to save and restore the old limit before we start the program under measurement however, as the resource limits are inherited by forked processes and we can not guarantee that the program under measurement does not do stupid stuff with select() 