### PR TITLE
fix(process monitoring): dont abort lo2s on unexpected child process exit

### DIFF
--- a/src/monitor/process_monitor.cpp
+++ b/src/monitor/process_monitor.cpp
@@ -54,12 +54,19 @@ void ProcessMonitor::insert_thread(Process process, Thread thread, std::string n
         perf::counter::CounterProvider::instance().has_group_counters(ExecutionScope(thread)) ||
         perf::counter::CounterProvider::instance().has_userspace_counters(ExecutionScope(thread)))
     {
-        auto inserted =
-            threads_.emplace(std::piecewise_construct, std::forward_as_tuple(thread),
-                             std::forward_as_tuple(ExecutionScope(thread), *this, spawn));
-        assert(inserted.second);
-        // actually start thread
-        inserted.first->second.start();
+        try
+        {
+            auto inserted =
+                threads_.emplace(std::piecewise_construct, std::forward_as_tuple(thread),
+                                 std::forward_as_tuple(ExecutionScope(thread), *this, spawn));
+            assert(inserted.second);
+            // actually start thread
+            inserted.first->second.start();
+        }
+        catch (const std::exception& e)
+        {
+            Log::warn() << "Could not start measurement for " << thread << ": " << e.what();
+        }
     }
 
     trace_.update_thread_name(thread, name);


### PR DESCRIPTION
If currently a process exits after ptrace catched it but before sampling with perf_event_open has been set up, perf_event_open will throw ESRCH ("no such process"), aborting lo2s.

Instead, handle ESRCH more gracefully by printing a warning but otherwise ignoring the non-existent process.