### PR TITLE
fix: CPU metric has value wrong value

### DIFF
--- a/src/perf/sample/writer.cpp
+++ b/src/perf/sample/writer.cpp
@@ -177,7 +177,8 @@ bool Writer::handle(const Reader::RecordSwitchType* context_switch)
                            is_switch_out);
 
     cpuid_metric_event_.timestamp(tp);
-    cpuid_metric_event_.raw_values()[0] = is_switch_out ? -1 : context_switch->cpu;
+    cpuid_metric_event_.raw_values()[0] =
+        is_switch_out ? -1 : static_cast<std::int64_t>(context_switch->cpu);
     otf2_writer_ << cpuid_metric_event_;
 
     return false;

--- a/src/perf/syscall/sample/writer.cpp
+++ b/src/perf/syscall/sample/writer.cpp
@@ -178,7 +178,8 @@ bool Writer::handle(const Reader::RecordSwitchType* context_switch)
     bool is_switch_out = context_switch->header.misc & PERF_RECORD_MISC_SWITCH_OUT;
 
     cpuid_metric_event_.timestamp(tp);
-    cpuid_metric_event_.raw_values()[0] = is_switch_out ? -1 : context_switch->cpu;
+    cpuid_metric_event_.raw_values()[0] =
+        is_switch_out ? -1 : static_cast<std::int64_t>(context_switch->cpu);
     otf2_writer_ << cpuid_metric_event_;
 
     return false;


### PR DESCRIPTION
For not scheduled threads/processes, the CPU should show -1, but due to implicit casting to unsigned, it used UINT_MAX instead.

Fixes #324 