### PR TITLE
Drop root privileges before forking

### DIFF
--- a/include/lo2s/config.hpp
+++ b/include/lo2s/config.hpp
@@ -52,6 +52,8 @@ struct Config
     std::vector<std::string> command;
     std::string command_line;
     bool quiet;
+    bool drop_root;
+    std::string user = "";
     // Optional features
     std::vector<std::string> tracepoint_events;
 #ifdef HAVE_X86_ADAPT

--- a/man/lo2s.1.pod
+++ b/man/lo2s.1.pod
@@ -154,6 +154,14 @@ determine the trace path instead, including variable substitution.
 Attach to a running process with process ID I<PID> instead of launching
 I<COMMAND>.
 
+=item B<-u>, B<--as-pre-sudo-user>
+
+Launch I<COMMAND> as the user that called on sudo. Requires a lo2s call with sudo.
+
+=item B<-U>, B<--as-user> I<USERNAME>
+
+Launch I<COMMAND> as I<USERNAME>. The caller needs to have CAP_SETUID. Will take priority over B<-u> if specified together.
+
 =item B<-m>, B<--mmap-pages> I<N> (default: C<16>)
 
 Allocate I<N> pages for each internal buffer shared between B<lo2s> and the


### PR DESCRIPTION
Implemented a way for lo2s to detect a call with sudo and then drop its privileges before launching any process. Different methods of gaining root aren't taken into account (yet).

This refers to #301 

To Do:

- [x] test functionality in real use case
- [x] ensure compatibility with lo2s -a
- [x] look into doas support (then update manpage)