### PR TITLE
feat(symbol resolution): implement kallsyms support

### DIFF
--- a/src/mmap.cpp
+++ b/src/mmap.cpp
@@ -40,6 +40,11 @@ MemoryMap::MemoryMap()
 
 MemoryMap::MemoryMap(Process process, bool read_initial)
 {
+    Binary* kall = &Kallsyms::cache();
+    map_.emplace(std::piecewise_construct,
+                 std::forward_as_tuple(Kallsyms::cache().start(), (uint64_t)-1),
+                 std::forward_as_tuple(Kallsyms::cache().start(), (uint64_t)-1, 0, *kall));
+
     if (!read_initial)
     {
         return;


### PR DESCRIPTION
lo2s is currently not able to resolve the symbols from instruction pointers coming from the kernel.

I have implemented in this PR support for parsing kallsyms to alleviate this.

/proc/kallsyms is a file which records the addresses of symbols inside the running kernel.

One issue is that it only reports the location, not the size of symbols. I simply assume that a symbol ends at the start of the next symbol and the last symbol in the kernel ending at the highest address.


This is how it looks in Vampir currently (callstack view):

![image](https://github.com/user-attachments/assets/8a4193c4-a7ac-4275-a068-8ce09f17cfb9)
