### PR TITLE
fix(cmake): Fix static build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,7 +35,10 @@ IfUpdatedUnsetAll(lo2s_USE_STATIC_LIBS
     X86Adapt_STATIC
     x86_energy_STATIC
     CUDA_USE_STATIC_LIBS
-)
+    Radare_USE_STATIC_LIBS
+    Sensors_USE_STATIC_LIBS
+    Veosinfo_USE_STATIC_LIBS
+    Audit_USE_STATIC_LIBS)
 
 if(lo2s_USE_STATIC_LIBS STREQUAL "OFF")
     set(Dl_USE_STATIC_LIBS       OFF CACHE BOOL "")
@@ -45,39 +48,36 @@ if(lo2s_USE_STATIC_LIBS STREQUAL "OFF")
     set(X86Adapt_STATIC          OFF CACHE BOOL "")
     set(x86_energy_STATIC        OFF CACHE BOOL "")
     set(Sensors_USE_STATIC_LIBS  OFF CACHE BOOL "")
-    set(Libpfm_USE_STATIC_LIBS  OFF CACHE BOOL "")
+    set(Libpfm_USE_STATIC_LIBS   OFF CACHE BOOL "")
     set(CUDA_USE_STATIC_LIBS     OFF CACHE BOOL "")
-endif()
+    set(Veosinfo_USE_STATIC_LIBS OFF CACHE BOOL "")
+    set(Radare_USE_STATIC_LIBS   OFF CACHE BOOL "")
+    set(Audit_USE_STATIC_LIBS    OFF CACHE BOOL "")
+else()
+    if(lo2s_USE_STATIC_LIBS STREQUAL "MOSTLY")
+        set(Dl_USE_STATIC_LIBS       OFF CACHE BOOL "")
 
-if(lo2s_USE_STATIC_LIBS STREQUAL "MOSTLY")
-    set(Dl_USE_STATIC_LIBS       OFF CACHE BOOL "")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -static-libgcc")
+    elseif(lo2s_USE_STATIC_LIBS STREQUAL "ALL")
+        set(Dl_USE_STATIC_LIBS       ON CACHE BOOL "")
+
+        # Doesn't seem to work with clang, even though it should,
+        # but at least it doesn't complain about it either
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -static-libgcc -static")
+        set(CMAKE_LINK_SEARCH_START_STATIC 1)
+        set(CMAKE_LINK_SEARCH_END_STATIC 1)
+    endif()
     set(Binutils_USE_STATIC_LIBS ON CACHE BOOL "")
     set(OTF2_USE_STATIC_LIBS     ON CACHE BOOL "")
     set(OTF2XX_USE_STATIC_LIBS   ON CACHE BOOL "")
     set(X86Adapt_STATIC          ON CACHE BOOL "")
     set(x86_energy_STATIC        ON CACHE BOOL "")
     set(Sensors_USE_STATIC_LIBS  ON CACHE BOOL "")
-    set(Libpfm_USE_STATIC_LIBS  ON CACHE BOOL "")
+    set(Libpfm_USE_STATIC_LIBS   ON CACHE BOOL "")
     set(CUDA_USE_STATIC_LIBS     ON CACHE BOOL "")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -static-libgcc")
-endif()
-
-if(lo2s_USE_STATIC_LIBS STREQUAL "ALL")
-    set(Dl_USE_STATIC_LIBS       ON CACHE BOOL "")
-    set(Binutils_USE_STATIC_LIBS ON CACHE BOOL "")
-    set(OTF2_USE_STATIC_LIBS     ON CACHE BOOL "")
-    set(OTF2XX_USE_STATIC_LIBS   ON CACHE BOOL "")
-    set(X86Adapt_STATIC          ON CACHE BOOL "")
-    set(x86_energy_STATIC        ON CACHE BOOL "")
-    set(Sensors_USE_STATIC_LIBS  ON CACHE BOOL "")
-    set(Libpfm_USE_STATIC_LIBS  ON CACHE BOOL "")
-    set(CUDA_USE_STATIC_LIBS     ON CACHE BOOL "")
-
-    # Doesn't seem to work with clang, even though it should,
-    # but at least it doesn't complain about it either
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static-libstdc++ -static-libgcc -static")
-    set(CMAKE_LINK_SEARCH_START_STATIC 1)
-    set(CMAKE_LINK_SEARCH_END_STATIC 1)
+    set(Veosinfo_USE_STATIC_LIBS ON CACHE BOOL "")
+    set(Radare_USE_STATIC_LIBS   ON CACHE BOOL "")
+    set(Audit_USE_STATIC_LIBS    ON CACHE BOOL "")
 endif()
 
 # Check if we are running Linux
@@ -110,13 +110,9 @@ find_package(StdFilesystem REQUIRED)
 find_package(Sensors)
 find_package(Veosinfo)
 find_package(Libpfm)
-find_package(PkgConfig)
 find_package(CUDAToolkit)
-
-if(PkgConfig_FOUND)
-    pkg_check_modules(Audit audit)
-    pkg_check_modules(Radare IMPORTED_TARGET r_asm>=5.8.0 r_anal>=5.8.0)
-endif()
+find_package(Radare)
+find_package(Audit)
 
 
 # configurable options
@@ -323,7 +319,7 @@ endif()
 if (USE_LIBAUDIT)
     if (Audit_FOUND)
         target_compile_definitions(lo2s PUBLIC HAVE_LIBAUDIT)
-        target_link_libraries(lo2s PRIVATE ${Audit_LIBRARIES})
+        target_link_libraries(lo2s PRIVATE Audit::Audit)
     else()
         message(SEND_ERROR "Libaudit not found but requested.")
     endif()

--- a/cmake/FindAudit.cmake
+++ b/cmake/FindAudit.cmake
@@ -1,0 +1,54 @@
+# Copyright (c) 2017, Technische Universität Dresden, Germany
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+#    and the following disclaimer in the documentation and/or other materials provided with the
+#    distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+#    or promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+find_package(PkgConfig)
+
+include (FindPackageHandleStandardArgs)
+include(${CMAKE_CURRENT_LIST_DIR}/UnsetIfUpdated.cmake)
+
+option(Audit_USE_STATIC_LIBS "Link libaudit statically" OFF)
+
+UnsetIfUpdated(Audit_LIBRARIES Audit_USE_STATIC_LIBS)
+
+
+find_path(Audit_INCLUDE_DIRS libaudit.h
+    PATHS ENV C_INCLUDE_PATH ENV CPATH PATH_SUFFIXES include)
+
+if(Audit_USE_STATIC_LIBS)
+    find_library(Audit_LIBRARIES NAMES libaudit.a HINTS ENV LIBRARY_PATH)
+else()
+    find_library(Audit_LIBRARIES NAMES libaudit.so HINT ENV LIBRARY_PATH LD_LIBRARY_PATH)
+endif()
+
+
+find_package_handle_standard_args(Audit DEFAULT_MSG
+    Audit_LIBRARIES
+    Audit_INCLUDE_DIRS)
+
+add_library(Audit::Audit IMPORTED UNKNOWN)
+set_property(TARGET Audit::Audit PROPERTY IMPORTED_LOCATION ${Audit_LIBRARIES})
+target_include_directories(Audit::Audit INTERFACE ${Audit_INCLUDE_DIRS})
+
+mark_as_advanced(Audit_LIBRARIES Audit_INCLUDE_DIRS)

--- a/cmake/FindRadare.cmake
+++ b/cmake/FindRadare.cmake
@@ -1,0 +1,59 @@
+# Copyright (c) 2017, Technische Universität Dresden, Germany
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted
+# provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this list of conditions
+#    and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+#    and the following disclaimer in the documentation and/or other materials provided with the
+#    distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse
+#    or promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+# FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+# IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+# THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+find_package(PkgConfig)
+
+include(${CMAKE_CURRENT_LIST_DIR}/UnsetIfUpdated.cmake)
+
+option(Radare_USE_STATIC_LIBS "Link Radare statically" OFF)
+
+UnsetIfUpdated(Radare_LIBRARIES Radare_USE_STATIC_LIBS)
+
+if(PkgConfig_FOUND)
+    # Breaking API changes in 5.8.0
+    pkg_check_modules(Radare IMPORTED_TARGET r_asm>=5.8.0 r_anal>=5.8.0)
+
+    if(Radare_FOUND)
+        # pkg-config does not know if Radare_STATIC_LIBRARIES really only contains
+        # static libraries, so use try_compile.
+        if(Radare_USE_STATIC_LIBS)
+            try_compile(BUILD_RADARE
+                SOURCES "${CMAKE_CURRENT_LIST_DIR}/test_static_radare.c"
+                LINK_LIBRARIES ${Radare_STATIC_LIBRARIES}
+                COMPILE_DEFINITIONS "-static")
+            if(NOT BUILD_RADARE)
+                set(Radare_FOUND OFF CACHE INTERNAL "")
+            endif()
+        endif()
+        if(Radare_USE_STATIC_LIBS)
+            add_library(Radare::Radare IMPORTED STATIC)
+            set_property(TARGET Radare::Radare PROPERTY IMPORTED_LOCATION ${Radare_STATIC_LIBRARIES})
+        else()
+            add_library(Radare::Radare IMPORTED SHARED)
+            set_property(TARGET Radare::Radare PROPERTY IMPORTED_LOCATION ${Radare_LIBRARIES})
+        endif()
+        target_include_directories(Radare::Radare INTERFACE ${Radare_INCLUDE_DIRS})
+    endif()
+endif()

--- a/cmake/FindVeosinfo.cmake
+++ b/cmake/FindVeosinfo.cmake
@@ -1,8 +1,15 @@
+include(${CMAKE_CURRENT_LIST_DIR}/UnsetIfUpdated.cmake)
+
+option(Veosinfo_USE_STATIC_LIBS "link veosinfo statically" OFF)
+UnsetIfUpdated(Veosinfo_LIBRARIES Veosinfo_USE_STATIC_LIBS)
 
 find_path(Veosinfo_INCLUDE_DIRS veosinfo/veosinfo.h PATHS ENV C_INCLUDE_PATH ENV CPATH PATH_SUFFIXES include)
 
-find_library(Veosinfo_LIBRARIES veosinfo HINT ENV LIBRARY_PATH ENV LD_LIBRARY_PATH)
-
+if(Veosinfo_USE_STATIC_LIBS)
+    find_library(Veosinfo_LIBRARIES libveosinfo.a HINT ENV LIBRARY_PATH ENV LD_LIBRARY_PATH)
+else()
+    find_library(Veosinfo_LIBRARIES libveosinfo.so HINT ENV LIBRARY_PATH ENV LD_LIBRARY_PATH)
+endif()
 
 include (FindPackageHandleStandardArgs)
 

--- a/cmake/test_static_radare.c
+++ b/cmake/test_static_radare.c
@@ -1,0 +1,6 @@
+#include <libr/r_lib.h>
+
+int main(void)
+{
+    r_lib_path("foo");
+}


### PR DESCRIPTION
Some libraries were not correctly (or at all) checking for static variants if lo2s_USE_STATIC_LIBS was requested, so I fixed that.