### PR TITLE
Add CUPTI. libpfm4, radare2 and libaudit to CI build

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04]
-        compiler: [g++-9, g++-10, clang++-10, clang++-11, clang++-12]
+        os: [ubuntu-24.04]
+        compiler: [g++-12, g++-13, g++-14, clang++-16, clang++-17, clang++-18]
         build-type: [Debug, RelWithDebInfo]
         hw_breakpoint: [ON, OFF]
 
@@ -22,12 +22,8 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install binutils-dev libiberty-dev libsensors-dev libpfm4-dev libaudit-dev libcupti-dev nvidia-cuda-toolkit nvidia-cuda-dev
+          sudo apt-get install binutils-dev libiberty-dev libsensors-dev libpfm4-dev libaudit-dev libcupti-dev nvidia-cuda-toolkit nvidia-cuda-dev libradare2-dev
           sudo pip install git-archive-all
-          wget https://github.com/radareorg/radare2/releases/download/5.9.8/radare2-dev_5.9.8_amd64.deb
-          wget https://github.com/radareorg/radare2/releases/download/5.9.8/radare2_5.9.8_amd64.deb
-          sudo dpkg -i radare2-dev_5.9.8_amd64.deb
-          sudo dpkg -i radare2_5.9.8_amd64.deb
       - name: Cache OTF2
         id: cache-otf2
         uses: actions/cache@v2
@@ -49,10 +45,10 @@ jobs:
       - name: Build
         run: make -j 2
       - name: Create source tarball
-        if: ${{ matrix.compiler == 'g++-10' && matrix.os == 'ubuntu-20.04' && matrix.build-type == 'RelWithDebInfo' && matrix.hw_breakpoint == 'ON' && github.event_name != 'pull_request'}}
+        if: ${{ matrix.compiler == 'g++-12' && matrix.os == 'ubuntu-24.04' && matrix.build-type == 'RelWithDebInfo' && matrix.hw_breakpoint == 'ON' && github.event_name != 'pull_request'}}
         run: make dist
       - uses: actions/upload-artifact@v4
-        if: ${{ matrix.compiler == 'g++-10' && matrix.os == 'ubuntu-20.04' && matrix.build-type == 'RelWithDebInfo' && matrix.hw_breakpoint == 'ON' && github.event_name != 'pull_request'}}
+        if: ${{ matrix.compiler == 'g++-12' && matrix.os == 'ubuntu-24.04' && matrix.build-type == 'RelWithDebInfo' && matrix.hw_breakpoint == 'ON' && github.event_name != 'pull_request'}}
         with:
           overwrite: true
           path: lo2s*.tar.bz2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install binutils-dev libiberty-dev libsensors-dev libpfm4-dev
+          sudo apt-get install binutils-dev libiberty-dev libsensors-dev libpfm4-dev libaudit-dev
           sudo pip install git-archive-all
       - name: Cache OTF2
         id: cache-otf2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,6 +24,10 @@ jobs:
           sudo apt-get update
           sudo apt-get install binutils-dev libiberty-dev libsensors-dev libpfm4-dev libaudit-dev
           sudo pip install git-archive-all
+          wget https://github.com/radareorg/radare2/releases/download/5.9.8/radare2-dev_5.9.8_amd64.deb
+          wget https://github.com/radareorg/radare2/releases/download/5.9.8/radare2_5.9.8_amd64.deb
+          sudo dpkg -i radare2-dev_5.9.8_amd64.deb
+          sudo dpkg -i radare2_5.9.8_amd64.deb
       - name: Cache OTF2
         id: cache-otf2
         uses: actions/cache@v2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install binutils-dev libiberty-dev libsensors-dev
+          sudo apt-get install binutils-dev libiberty-dev libsensors-dev libpfm4-dev
           sudo pip install git-archive-all
       - name: Cache OTF2
         id: cache-otf2

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install binutils-dev libiberty-dev libsensors-dev libpfm4-dev libaudit-dev
+          sudo apt-get install binutils-dev libiberty-dev libsensors-dev libpfm4-dev libaudit-dev libcupti-dev nvidia-cuda-toolkit nvidia-cuda-dev
           sudo pip install git-archive-all
           wget https://github.com/radareorg/radare2/releases/download/5.9.8/radare2-dev_5.9.8_amd64.deb
           wget https://github.com/radareorg/radare2/releases/download/5.9.8/radare2_5.9.8_amd64.deb

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install binutils-dev libiberty-dev libsensors-dev libpfm4-dev libaudit-dev libcupti-dev nvidia-cuda-toolkit nvidia-cuda-dev libradare2-dev libotf2-trace-dev
+          sudo apt-get install binutils-dev libiberty-dev libsensors-dev libpfm4-dev libaudit-dev libcupti-dev nvidia-cuda-toolkit nvidia-cuda-dev libradare2-dev libotf2-trace-dev otf2-tools
           sudo pip install git-archive-all
       - name: Run CMake configure
         env:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,22 +22,8 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install binutils-dev libiberty-dev libsensors-dev libpfm4-dev libaudit-dev libcupti-dev nvidia-cuda-toolkit nvidia-cuda-dev libradare2-dev
+          sudo apt-get install binutils-dev libiberty-dev libsensors-dev libpfm4-dev libaudit-dev libcupti-dev nvidia-cuda-toolkit nvidia-cuda-dev libradare2-dev libotf2-trace-dev
           sudo pip install git-archive-all
-      - name: Cache OTF2
-        id: cache-otf2
-        uses: actions/cache@v2
-        with:
-          path: /opt/otf2/
-          key: ${{ matrix.os }}-otf2-${OTF2_VERSION}
-      - name: Install OTF2
-        if: steps.cache-otf2.outputs.cache-hit != 'true'
-        run: |
-          wget https://perftools.pages.jsc.fz-juelich.de/cicd/otf2/tags/otf2-${OTF2_VERSION}/otf2-${OTF2_VERSION}.tar.gz
-          tar -xf otf2-${OTF2_VERSION}.tar.gz
-          cd otf2-${OTF2_VERSION}
-          ./configure --prefix=/opt/otf2
-          make -j2 install
       - name: Run CMake configure
         env:
           CXX: ${{ matrix.compiler }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ find_package(CUDAToolkit)
 
 if(PkgConfig_FOUND)
     pkg_check_modules(Audit audit)
-    pkg_check_modules(Radare IMPORTED_TARGET r_main>=5.8.0)
+    pkg_check_modules(Radare IMPORTED_TARGET r_asm>=5.8.0 r_anal>=5.8.0)
 endif()
 
 


### PR DESCRIPTION
This pr adds libpfm4, radare2, libaudit and CUPTI to the CI build.

With this, all optional lo2s dependencies besides:

- veosinfo (No installable build for Ubuntu 20.04 available)
- x86_adapt/x86_energy (Broken even in the https://github.com/s9105947/x86_adapt/tree/fix-linux-5.18 branch)

get build.

One remaining issue is that Ubuntu ships the ancient CUDA 10, resulting in CUPTI support failing to build. Should I patch lo2s to work with CUDA 10, find a way to install a newer CUDA version in the CI, or remove it from the CI? 