### PR TITLE
fix(cmake): Split FindLibDw from FindLibElf

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ set_property(CACHE lo2s_USE_STATIC_LIBS PROPERTY STRINGS "MOSTLY" "OFF" "ALL")
 IfUpdatedUnsetAll(lo2s_USE_STATIC_LIBS
     Dl_USE_STATIC_LIBS
     LibElf_USE_STATIC_LIBS
+    LibDw_USE_STATIC_LIBS
     OTF2_USE_STATIC_LIBS
     OTF2XX_USE_STATIC_LIBS
     Libpfm_USE_STATIC_LIBS
@@ -45,6 +46,7 @@ IfUpdatedUnsetAll(lo2s_USE_STATIC_LIBS
 if(lo2s_USE_STATIC_LIBS STREQUAL "OFF")
     set(Dl_USE_STATIC_LIBS       OFF CACHE BOOL "")
     set(LibElf_USE_STATIC_LIBS   OFF CACHE BOOL "")
+    set(LibDw_USE_STATIC_LIBS    OFF CACHE BOOL "")
     set(OTF2_USE_STATIC_LIBS     OFF CACHE BOOL "")
     set(OTF2XX_USE_STATIC_LIBS   OFF CACHE BOOL "")
     set(X86Adapt_STATIC          OFF CACHE BOOL "")
@@ -72,6 +74,7 @@ else()
     endif()
     set(Dl_USE_STATIC_LIBS       OFF CACHE BOOL "")
     set(LibElf_USE_STATIC_LIBS   ON CACHE BOOL "")
+    set(LibDw_USE_STATIC_LIBS    ON CACHE BOOL "")
     set(OTF2_USE_STATIC_LIBS     ON CACHE BOOL "")
     set(OTF2XX_USE_STATIC_LIBS   ON CACHE BOOL "")
     set(X86Adapt_STATIC          ON CACHE BOOL "")
@@ -122,6 +125,7 @@ find_package(Radare)
 find_package(Audit)
 find_package(BpfObject)
 find_package(LibElf REQUIRED)
+find_package(LibDw REQUIRED)
 find_package(Debuginfod)
 
 
@@ -242,7 +246,7 @@ target_link_libraries(lo2s
         fmt::fmt
         std::filesystem
         LibElf::LibElf
-        LibElf::LibDw
+        LibDw::LibDw
         indicators::indicators
     )
 

--- a/cmake/FindLibDw.cmake
+++ b/cmake/FindLibDw.cmake
@@ -25,32 +25,32 @@
 
 include(${CMAKE_CURRENT_LIST_DIR}/UnsetIfUpdated.cmake)
 
-# Linking libelf statically isn't a great default because it produces warnings
-option(LibElf_USE_STATIC_LIBS "Link libelf statically." OFF)
+# Linking libdw statically isn't a great default because it produces warnings
+option(LibDw_USE_STATIC_LIBS "Link libelf statically." OFF)
 
-UnsetIfUpdated(LibElf_LIBRARIES LibElf_USE_STATIC_LIBS)
+UnsetIfUpdated(LibDw_LIBRARIES LibDw_USE_STATIC_LIBS)
 
-find_path(LibElf_INCLUDE_DIRS libelf.h
+find_path(LibDw_INCLUDE_DIRS elfutils/libdw.h
     PATHS ENV C_INCLUDE_PATH ENV CPATH
     PATH_SUFFIXES include)
 
-if(LibElf_USE_STATIC_LIBS)
-    find_library(LibElf_LIBRARY NAMES libelf.a
+if(LibDw_USE_STATIC_LIBS)
+    find_library(LibDw_LIBRARY NAMES libdw.a
             HINTS ENV LIBRARY_PATH)
 else()
-    find_library(LibElf_LIBRARY NAMES libelf.so
+    find_library(LibDw_LIBRARY NAMES libdw.so
             HINTS ENV LIBRARY_PATH LD_LIBRARY_PATH)
 endif()
 
 include (FindPackageHandleStandardArgs)
-FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibElf DEFAULT_MSG
-        LibElf_LIBRARY
-        LibElf_INCLUDE_DIRS)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibDw DEFAULT_MSG
+        LibDw_LIBRARY
+        LibDw_INCLUDE_DIRS)
 
-if(LibElf_FOUND)
-    add_library(LibElf::LibElf UNKNOWN IMPORTED)
-    set_property(TARGET LibElf::LibElf PROPERTY IMPORTED_LOCATION ${LibElf_LIBRARY})
-    target_include_directories(LibElf::LibElf INTERFACE ${LibElf_INCLUDE_DIRS})
+if(LibDw_FOUND)
+    add_library(LibDw::LibDw UNKNOWN IMPORTED)
+    set_property(TARGET LibDw::LibDw PROPERTY IMPORTED_LOCATION ${LibDw_LIBRARY})
+    target_include_directories(LibDw::LibDw INTERFACE ${LibDw_INCLUDE_DIRS})
 endif()
 
-mark_as_advanced(LibElf_LIBRARY LibElf_INCLUDE_DIRS)
+mark_as_advanced(LibDw_LIBRARY LibDw_INCLUDE_DIRS)


### PR DESCRIPTION
The current cmake logic can be a little bit confusing, because libelf will be reported missing
if libdw can not be found.

So give libdw its own cmake code.