### PR TITLE
feat (sampling): Put kernel threads in own group.

### DIFF
--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -359,6 +359,7 @@ private:
     otf2::definition::comm_locations_group& hardware_comm_locations_group_;
     otf2::definition::regions_group& lo2s_regions_group_;
     otf2::definition::regions_group& syscall_regions_group_;
+    otf2::definition::regions_group& kernel_regions_group_;
 
     otf2::definition::detail::weak_ref<otf2::definition::metric_class> cpuid_metric_class_;
     std::map<std::set<Cpu>, otf2::definition::detail::weak_ref<otf2::definition::metric_class>>

--- a/include/lo2s/util.hpp
+++ b/include/lo2s/util.hpp
@@ -128,4 +128,7 @@ int timerfd_from_ns(std::chrono::nanoseconds duration);
 bool known_non_executable(const std::string& filename);
 
 std::map<Mapping, std::string> read_maps(Process p);
+
+bool is_kernel_thread(Thread thread);
+
 } // namespace lo2s

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -97,6 +97,9 @@ Trace::Trace()
   syscall_regions_group_(registry_.create<otf2::definition::regions_group>(
       intern("<syscalls>"), otf2::common::paradigm_type::user,
       otf2::common::group_flag_type::none)),
+  kernel_regions_group_(registry_.create<otf2::definition::regions_group>(
+      intern("<kernel threads>"), otf2::common::paradigm_type::user,
+      otf2::common::group_flag_type::none)),
   system_tree_root_node_(registry_.create<otf2::definition::system_tree_node>(
       intern(nitro::env::hostname()), intern("machine"))),
   groups_(ExecutionScopeGroup::instance())
@@ -952,6 +955,11 @@ void Trace::emplace_thread_exclusive(Thread thread, const std::string& name,
     auto& thread_region = registry_.emplace<otf2::definition::region>(
         ByThread(thread), iname, iname, iname, otf2::common::role_type::function,
         otf2::common::paradigm_type::user, otf2::common::flags_type::none, iname, 0, 0);
+
+    if (is_kernel_thread(thread))
+    {
+        kernel_regions_group_.add_member(thread_region);
+    }
 
     // create calling context
     registry_.create<otf2::definition::calling_context>(ByThread(thread), thread_region,

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -494,4 +494,26 @@ std::map<Mapping, std::string> read_maps(Process p)
 
     return mappings;
 }
+
+bool is_kernel_thread(Thread thread)
+{
+
+    std::ifstream cmdline(std::filesystem::path(fmt::format("/proc/{}", thread.as_pid_t())) /
+                          "cmdline");
+
+    if (cmdline.good())
+    {
+        std::string cmdline_str = "";
+        cmdline >> cmdline_str;
+
+        // Kernel threads can be distinguished from normal threads by the empty
+        // /proc/[pid]/cmdline file. This is how the ps utility does it.
+        if (cmdline_str == "")
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 } // namespace lo2s


### PR DESCRIPTION
Put all kernel threads in the same regions group based on whether /proc/[pid]/cmdline is empty (this is also how ps checks if something is a kernel thread).

This makes it easier to distinguish kernel threads from normal threads in visualization utilites such as Vampir.