### PR TITLE
feat(sampling): Add perf.map support for JIT compilers/interpreters that support it

### DIFF
--- a/include/lo2s/config.hpp
+++ b/include/lo2s/config.hpp
@@ -116,6 +116,8 @@ struct Config
     std::string cuda_injectionlib_path;
     uint64_t nvidia_ringbuf_size;
     DwarfUsage dwarf;
+    // Python
+    bool use_python = true;
 };
 
 const Config& config();

--- a/include/lo2s/function_resolver.hpp
+++ b/include/lo2s/function_resolver.hpp
@@ -155,5 +155,108 @@ private:
     uint64_t start_ = UINT64_MAX;
 };
 
+class PerfMap : public FunctionResolver
+{
+public:
+    PerfMap(Process process) : FunctionResolver(fmt::format("JIT functions for {}", process))
+    {
+        std::ifstream perf_map_file(fmt::format("/tmp/perf-{}.map", process.as_pid_t()));
+
+        // Entries in the perf-[PID].map file have the form:
+        // START SIZE SYMBOL
+        // Example:
+        // ff00ff deadbeef py::foo
+        std::regex perf_map_regex("([0-9a-f]+) ([0-9a-f]+) (.+)");
+
+        // python mapfiles have the symbols in the form
+        // py::[functioname]:[filename]
+        std::regex python_regex("py::(.+):(.+)");
+
+        std::string line;
+        while (std::getline(perf_map_file, line))
+        {
+
+            std::smatch perf_map_match;
+            if (std::regex_match(line, perf_map_match, perf_map_regex))
+            {
+                LineInfo info = LineInfo::for_unknown_function();
+                Address start(perf_map_match[1]);
+
+                if (start_ == UINT64_MAX)
+                {
+                    start_ = start;
+                }
+
+                Address end(start + Address(perf_map_match[2]));
+
+                std::smatch python_match;
+
+                std::string symbol_string = perf_map_match[3].str();
+
+                if (std::regex_match(symbol_string, python_match, python_regex))
+                {
+                    // symbols where the filename starts with '<' (e.g '<frozen os>')
+                    // are compiled into the Python interpreter
+                    if (python_match[2].str()[0] == '<')
+                    {
+                        std::string dso = python_match[2];
+                        std::string function = python_match[1];
+                        info = LineInfo::for_function("<unknown file>", function.c_str(), 0,
+                                                      dso.c_str());
+                    }
+                    else
+                    {
+                        std::string function = python_match[1];
+                        std::string filename = python_match[2];
+                        info = LineInfo::for_function(filename.c_str(), function.c_str(), 0,
+                                                      filename.c_str());
+                    }
+                }
+                else
+                {
+                    info =
+                        LineInfo::for_function("<unknown file>", symbol_string.c_str(), 0, "<jit>");
+                }
+
+                entries_.emplace(Range(start, end), info);
+            }
+        }
+
+        if (entries_.size() != 0)
+        {
+            end_ = (--entries_.end())->first.end;
+        }
+    }
+
+    static std::shared_ptr<PerfMap> cache(Process process)
+    {
+        static std::map<Process, std::shared_ptr<PerfMap>> m;
+        return m.emplace(process, std::make_shared<PerfMap>(process)).first->second;
+    }
+
+    Mapping mapping()
+    {
+        return { start_, end_, 0 };
+    }
+
+    virtual LineInfo lookup_line_info(Address addr) override
+    {
+        auto it = entries_.find(addr + start_);
+        if (it != entries_.end())
+        {
+            return it->second;
+        }
+        else
+        {
+            return LineInfo::for_unknown_function();
+        }
+    }
+
+private:
+    std::map<Range, LineInfo> entries_;
+    Address start_ = UINT64_MAX;
+    Address end_ = UINT64_MAX;
+};
+
 std::shared_ptr<FunctionResolver> function_resolver_for(const std::string& filename);
 } // namespace lo2s

--- a/include/lo2s/memory_map.hpp
+++ b/include/lo2s/memory_map.hpp
@@ -200,10 +200,12 @@ private:
 class ProcessFunctionMap : public MemoryMap<FunctionResolver>
 {
 public:
-    ProcessFunctionMap()
+    ProcessFunctionMap(Process process)
     {
         auto kall = Kallsyms::cache();
         emplace(Mapping(Kallsyms::cache()->start(), (uint64_t)-1, 0), kall);
+        auto perf_map = PerfMap::cache(process);
+        emplace(perf_map->mapping(), perf_map);
     }
 };
 

--- a/include/lo2s/resolvers.hpp
+++ b/include/lo2s/resolvers.hpp
@@ -35,7 +35,10 @@ struct Resolvers
 
     void fork(Process parent, Process process)
     {
-        function_resolvers[process] = function_resolvers[parent];
+        if (function_resolvers.count(parent) != 0)
+        {
+            function_resolvers.emplace(process, function_resolvers.at(parent));
+        }
         instruction_resolvers[process] = instruction_resolvers[parent];
     }
 };

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -252,8 +252,7 @@ void parse_program_options(int argc, const char** argv)
         .metavar("DWARFMODE");
 
     system_mode_options
-        .toggle("process-recording", "Record process activity. In system monitoring: "
-                                     "(default: enabled)")
+        .toggle("process-recording", "Record process activity. In system monitoring: ")
         .allow_reverse()
         .default_value(true);
 
@@ -305,6 +304,10 @@ void parse_program_options(int argc, const char** argv)
         .allow_reverse();
 
     sampling_options.toggle("kernel", "Include events happening in kernel space.")
+        .allow_reverse()
+        .default_value(true);
+
+    sampling_options.toggle("python", "Control Python perf recording support")
         .allow_reverse()
         .default_value(true);
 
@@ -442,6 +445,7 @@ void parse_program_options(int argc, const char** argv)
 #ifdef HAVE_CUDA
     config.cuda_injectionlib_path = arguments.get("nvidia-injection-path");
 #endif
+    config.use_python = arguments.given("python");
     config.command = arguments.positionals();
 
     if (arguments.given("help"))

--- a/src/function_resolver.cpp
+++ b/src/function_resolver.cpp
@@ -32,7 +32,7 @@ std::shared_ptr<FunctionResolver> function_resolver_for(const std::string& filen
     std::shared_ptr<FunctionResolver> fr;
     if (known_non_executable(filename))
     {
-        fr = FunctionResolver::cache(filename);
+        return nullptr;
     }
     else
     {

--- a/src/monitor/cpu_set_monitor.cpp
+++ b/src/monitor/cpu_set_monitor.cpp
@@ -60,11 +60,14 @@ CpuSetMonitor::CpuSetMonitor() : MainMonitor()
                 auto maps = read_maps(Process(pid));
                 Process p(pid);
                 resolvers_.function_resolvers.emplace(
-                    std::piecewise_construct, std::forward_as_tuple(p), std::forward_as_tuple());
+                    std::piecewise_construct, std::forward_as_tuple(p), std::forward_as_tuple(p));
                 for (auto& map : maps)
                 {
                     auto fr = function_resolver_for(map.second);
-                    resolvers_.function_resolvers[p].emplace(map.first, fr);
+                    if (fr != nullptr)
+                    {
+                        resolvers_.function_resolvers.at(p).emplace(map.first, fr);
+                    }
                     auto ir = instruction_resolver_for(map.second);
 
                     if (ir != nullptr)

--- a/src/monitor/process_monitor_main.cpp
+++ b/src/monitor/process_monitor_main.cpp
@@ -153,6 +153,12 @@ std::vector<char*> to_vector_of_c_str(const std::vector<std::string>& vec)
     ptrace(PTRACE_TRACEME, 0, NULL, NULL);
 
     std::map<std::string, std::string> env;
+
+    if (config().use_python)
+    {
+        env.emplace("PYTHONPERFSUPPORT", "1");
+    }
+
 #ifdef HAVE_CUDA
     if (config().use_nvidia)
     {

--- a/src/perf/sample/writer.cpp
+++ b/src/perf/sample/writer.cpp
@@ -87,7 +87,12 @@ void Writer::emplace_resolvers(Resolvers& resolvers)
             Process p(mmap_event.get()->pid);
 
             auto fr = function_resolver_for(mmap_event.get()->filename);
-            resolvers.function_resolvers[p].emplace(m, fr);
+
+            resolvers.function_resolvers.emplace(p, p);
+            if (fr != nullptr)
+            {
+                resolvers.function_resolvers.at(p).emplace(m, fr);
+            }
             auto ir = instruction_resolver_for(mmap_event.get()->filename);
             if (ir != nullptr)
             {

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -722,8 +722,9 @@ otf2::definition::calling_context& Trace::cctx_for_address(Address addr, Resolve
 {
     LineInfo line_info = LineInfo::for_unknown_function();
 
-    auto it = r.function_resolvers[ctx.p].find(addr);
-    if (it != r.function_resolvers[ctx.p].end())
+    auto& fr = r.function_resolvers.emplace(ctx.p, ctx.p).first->second;
+    auto it = fr.find(addr);
+    if (it != fr.end())
     {
         line_info = it->second->lookup_line_info(addr - it->first.range.start + it->first.pgoff);
     }


### PR DESCRIPTION


... which for now is mainly targeted at Python. In general though, every JIT compiler is free to generate a perf.map file.

Python, if enabled through the PYTHONPERFSUPPORT env variable or the -X perf command line can now help with generating meaningful traces of Python applications [1].

This works through two parts:

1. The JIT/Interpreter generates a perf.map file at /tmp/perf-{pid}.map, this contains a listing of the location, names and sizes of the JIT symbols. Example content: 
 ```
  # Address, size, name
 deadbeef b my_function 
```

2. In the Python case, because it is not truly a JIT compiler, Python generates little assembler trampolines for every python function. Whenever it starts evaluating a Python function, it goes through this trampoline, so that if the address of the trampoline (in the example above 0xdeadbeef) is found on the stack, we can interpret it as we have entered the Python function associated with the trampoline.

While this solution is not perfect as, for example in the Python case, Python functions will only ever show up  in -g (Callstack) mode, because the top-most frame is almost always some PyEval_SomethingFoo function, it beats most of the solutions in #191 by 1. being standardized and enabled in most distributions of Python 2. not requiring us to mess with Python interpreter internals.

Maybe a otf2 transformer would be nice, which filters out all elements of the callstack that are not python functions.

In Vampir, it currently looks like this (<module>, for, bar and baz are Python functions)

![image](https://github.com/user-attachments/assets/0cc1a57e-8ff2-4de1-a610-41d528d67c7b)


[1] https://docs.python.org/3/howto/perf_profiling.html