### PR TITLE
Preliminary support for OpenMP recording through OMPT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,7 +127,13 @@ find_package(BpfObject)
 find_package(LibElf REQUIRED)
 find_package(LibDw REQUIRED)
 find_package(Debuginfod)
+find_package(OpenMP)
 
+include(CheckIncludeFileCXX)
+
+if(OpenMP_CXX_FOUND)
+    check_include_file_cxx("omp-tools.h" OMPT_FOUND CMAKE_REQUIRED_LIBRARIES OpenMP::OpenMP_CXX)
+endif()
 
 # configurable options
 CMAKE_DEPENDENT_OPTION(USE_RADARE "Enable Radare support." ON Radare_FOUND OFF)
@@ -150,6 +156,8 @@ CMAKE_DEPENDENT_OPTION(USE_BPF "Use BPF to record POSIX I/O activity" ON BpfObje
 add_feature_info("USE_BPF" USE_BPF "Use BPF to record POSIX I/O activity")
 CMAKE_DEPENDENT_OPTION(USE_DEBUGINFOD "Use Debuginfod to download debug information on-demand." ON "Debuginfod_FOUND" OFF)
 add_feature_info("USE_DEBUGINFOD" USE_DEBUGINFOD "Use Debuginfod to download debug information on-demand.")
+CMAKE_DEPENDENT_OPTION(USE_OPENMP "Use OMPT to record OpenMP activity" ON "OMPT_FOUND" OFF)
+add_feature_info("USE_OPENMP" USE_OPENMP "Use OMPT to record OpenMP activity")
 
 # system configuration checks
 CHECK_INCLUDE_FILES(linux/hw_breakpoint.h HAVE_HW_BREAKPOINT_H)
@@ -203,6 +211,7 @@ set(SOURCE_FILES
     src/perf/event_attr.cpp
     src/monitor/socket_monitor.cpp
     src/monitor/cuda_monitor.cpp
+    src/monitor/openmp_monitor.cpp
 
     src/perf/bio/block_device.cpp
     src/perf/event_composer.cpp
@@ -360,36 +369,54 @@ if (USE_LIBAUDIT)
 endif()
 
 set(LO2S_INJECTIONLIB_PATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+
+if(USE_CUPTI OR USE_OPENMP)
+    add_library(lo2s_injection SHARED)
+
+    target_include_directories(lo2s_injection PRIVATE include
+            ${CMAKE_CURRENT_BINARY_DIR}/include)
+    target_link_libraries(lo2s_injection PRIVATE fmt::fmt-header-only
+            Nitro::log
+            Nitro::env
+            Nitro::dl
+            Nitro::options
+            otf2xx::Writer)
+
+    if(SHM_OPEN_FOUND_WITH_RT)
+        target_link_libraries(lo2s_injection PRIVATE rt)
+    endif()
+
+    install(TARGETS lo2s_injection LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+endif()
+
 if(USE_CUPTI)
     if(CUDAToolkit_FOUND)
-        add_library(lo2s_injection SHARED src/cuda/lib.cpp src/types.cpp src/time/time.cpp)
-        target_include_directories(lo2s_injection PRIVATE include
-            ${CMAKE_CURRENT_BINARY_DIR}/include)
-
+        target_sources(lo2s_injection PRIVATE src/cuda/lib.cpp src/types.cpp src/time/time.cpp)
         if (CUDA_USE_STATIC_LIBS)
             target_link_libraries(lo2s_injection PRIVATE CUDA::cupti_static)
         else()
             target_link_libraries(lo2s_injection PRIVATE CUDA::cupti)
         endif()
 
-	target_link_libraries(lo2s_injection PRIVATE fmt::fmt-header-only
-            Nitro::log
-            Nitro::env
-            Nitro::dl
-            Nitro::options
-	    otf2xx::Writer)
-
         if(SHM_OPEN_FOUND_WITH_RT)
             target_link_libraries(lo2s_injection PRIVATE rt)
         endif()
 
         target_compile_definitions(lo2s PUBLIC HAVE_CUDA)
-        install(TARGETS lo2s_injection LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
     else()
         message(SEND_ERROR "Cupti not found but requested.")
     endif()
 endif()
 
+if(USE_OPENMP)
+    if(OMPT_FOUND)
+        target_sources(lo2s_injection PRIVATE src/ompt/lib.cpp)
+        target_link_libraries(lo2s_injection PRIVATE OpenMP::OpenMP_CXX)
+        target_compile_definitions(lo2s PUBLIC HAVE_OPENMP)
+    else()
+        message(SEND_ERROR "OpenMP not supported but requested.")
+    endif()
+endif()
 
 
 # generate version string used in lo2s

--- a/include/lo2s/config.hpp
+++ b/include/lo2s/config.hpp
@@ -114,6 +114,8 @@ struct Config
     std::chrono::milliseconds nec_check_interval;
     // Nvidia CUPTI
     bool use_nvidia = false;
+    // OpenMP
+    bool use_openmp = false;
     // Function resolution
     DwarfUsage dwarf;
     // Python

--- a/include/lo2s/local_cctx_tree.hpp
+++ b/include/lo2s/local_cctx_tree.hpp
@@ -65,7 +65,7 @@ public:
                         const Cctxs&... ctxs)
     {
         uint64_t level = cur_level() + 1;
-        cctx_enter(tp, level, 0, ctx, ctxs...);
+        cctx_enter(tp, level, ctx, ctxs...);
         return level;
     }
 

--- a/include/lo2s/measurement_scope.hpp
+++ b/include/lo2s/measurement_scope.hpp
@@ -37,6 +37,7 @@ enum class MeasurementScopeType
     CUDA,
     TRACEPOINT,
     POSIX_IO,
+    OPENMP,
     UNKNOWN
 };
 
@@ -86,6 +87,11 @@ struct MeasurementScope
     static MeasurementScope cuda(ExecutionScope s)
     {
         return { MeasurementScopeType::CUDA, s };
+    }
+
+    static MeasurementScope openmp(ExecutionScope s)
+    {
+        return { MeasurementScopeType::OPENMP, s };
     }
 
     static MeasurementScope tracepoint(ExecutionScope s)
@@ -143,6 +149,8 @@ struct MeasurementScope
             return fmt::format("POSIX I/O events for {}", scope.name());
         case MeasurementScopeType::NEC_SAMPLE:
             return fmt::format("samples for NEC process {}", scope.name());
+        case MeasurementScopeType::OPENMP:
+            return fmt::format("OpenMP events for {}", scope.name());
         default:
             throw new std::runtime_error("Unknown ExecutionScopeType!");
         }

--- a/include/lo2s/ompt/events.hpp
+++ b/include/lo2s/ompt/events.hpp
@@ -1,0 +1,117 @@
+/*
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2016-2018, Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+#include <lo2s/ringbuf_events.hpp>
+
+#include <fmt/core.h>
+
+#include <string.h>
+
+namespace lo2s
+{
+namespace omp
+{
+enum class OMPType : uint64_t
+{
+    PARALLEL = 0,
+    MASTER = 1,
+    SYNC = 2,
+    LOOP = 3,
+    WORKSHARE = 4,
+    OTHER = 5
+};
+
+enum class EventType : uint64_t
+{
+    OMPT_ENTER = 0,
+    OMPT_EXIT = 1
+};
+
+struct OMPTCctx
+{
+    OMPType type;
+    uint64_t tid;
+    uint64_t addr;
+    uint64_t num_threads;
+
+    friend bool operator<(const OMPTCctx& lhs, const OMPTCctx& rhs)
+    {
+        if (lhs.type == rhs.type)
+        {
+            if (lhs.num_threads == rhs.num_threads)
+            {
+                return lhs.addr < rhs.addr;
+            }
+            else
+            {
+                return lhs.num_threads < rhs.num_threads;
+            }
+        }
+        return lhs.type < rhs.type;
+    }
+
+    friend bool operator==(const OMPTCctx& lhs, const OMPTCctx& rhs)
+    {
+        return lhs.type == rhs.type && lhs.num_threads == rhs.num_threads && lhs.addr == rhs.addr;
+    }
+
+    friend bool operator!=(const OMPTCctx& lhs, const OMPTCctx& rhs)
+    {
+        return lhs.type != rhs.type || lhs.num_threads != rhs.num_threads || lhs.addr != rhs.addr;
+    }
+
+    std::string name() const
+    {
+        switch (type)
+        {
+        case lo2s::omp::OMPType::MASTER:
+            return fmt::format("master {}", addr);
+        case lo2s::omp::OMPType::PARALLEL:
+            return fmt::format("parallel {} {}", num_threads, addr);
+        case lo2s::omp::OMPType::SYNC:
+            return fmt::format("sync {}", addr);
+        case OMPType::WORKSHARE:
+            return fmt::format("workshare {}", addr);
+        case OMPType::LOOP:
+            return fmt::format("loop {}", addr);
+        case OMPType::OTHER:
+            return fmt::format("other {}", addr);
+        }
+        return "";
+    }
+};
+
+struct ompt_enter
+{
+    struct event_header header;
+    uint64_t tp;
+    OMPTCctx cctx;
+};
+
+struct ompt_exit
+{
+    struct event_header header;
+    uint64_t tp;
+    OMPTCctx cctx;
+};
+
+} // namespace omp
+} // namespace lo2s

--- a/include/lo2s/ompt/ringbuf.hpp
+++ b/include/lo2s/ompt/ringbuf.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <lo2s/ompt/events.hpp>
+#include <lo2s/ringbuf.hpp>
+
+namespace lo2s
+{
+namespace omp
+{
+
+class RingbufWriter : public lo2s::RingbufWriter
+{
+public:
+    RingbufWriter(Process process) : lo2s::RingbufWriter(process, RingbufMeasurementType::OPENMP)
+    {
+    }
+
+    bool ompt_enter(uint64_t tp, OMPTCctx cctx)
+    {
+        std::lock_guard<std::mutex> guard(mutex_);
+
+        struct ompt_enter* ev = reserve<struct ompt_enter>();
+
+        if (ev == nullptr)
+        {
+            return false;
+        }
+
+        ev->tp = tp;
+        ev->header.type = (uint64_t)EventType::OMPT_ENTER;
+        ev->cctx = cctx;
+
+        commit();
+
+        return true;
+    }
+
+    bool ompt_leave(uint64_t tp, OMPTCctx cctx)
+    {
+        std::lock_guard<std::mutex> guard(mutex_);
+
+        struct ompt_exit* ev = reserve<struct ompt_exit>();
+
+        if (ev == nullptr)
+        {
+            return false;
+        }
+
+        ev->header.type = (uint64_t)EventType::OMPT_EXIT;
+        ev->tp = tp;
+        ev->cctx = cctx;
+
+        commit();
+
+        return true;
+    }
+
+private:
+    std::mutex mutex_;
+};
+
+} // namespace omp
+} // namespace lo2s

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -272,6 +272,9 @@ private:
     otf2::definition::calling_context& cctx_for_cuda(uint64_t kernel_id, Resolvers& r,
                                                      struct MergeContext& ctx,
                                                      GlobalCctxMap::value_type* parent);
+    otf2::definition::calling_context& cctx_for_openmp(const CallingContext& addr, Resolvers& r,
+                                                       struct MergeContext& ctx,
+                                                       GlobalCctxMap::value_type* parent);
     otf2::definition::calling_context& cctx_for_address(Address addr, Resolvers& r,
                                                         struct MergeContext& ctx,
                                                         GlobalCctxMap::value_type* parent);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -390,6 +390,9 @@ void parse_program_options(int argc, const char** argv)
 #ifdef HAVE_VEOSINFO
     accelerators.push_back("nec");
 #endif
+#ifdef HAVE_OPENMP
+    accelerators.push_back("openmp");
+#endif
 
     accel_options
         .multi_option(
@@ -627,6 +630,15 @@ void parse_program_options(int argc, const char** argv)
             config.use_nvidia = true;
 #else
             std::cerr << "lo2s was built without support for CUDA kernel recording\n";
+            std::exit(EXIT_FAILURE);
+#endif
+        }
+        else if (accel == "openmp")
+        {
+#ifdef HAVE_OPENMP
+            config.use_openmp = true;
+#else
+            std::cerr << "lo2s was built without support for OpenMP recording\n";
             std::exit(EXIT_FAILURE);
 #endif
         }

--- a/src/monitor/openmp_monitor.cpp
+++ b/src/monitor/openmp_monitor.cpp
@@ -1,0 +1,114 @@
+/*
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2016,
+ *    Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <lo2s/config.hpp>
+#include <lo2s/log.hpp>
+#include <lo2s/monitor/openmp_monitor.hpp>
+#include <lo2s/ompt/events.hpp>
+#include <lo2s/time/time.hpp>
+#include <lo2s/trace/trace.hpp>
+
+#include <memory>
+
+extern "C"
+{
+#include <sys/mman.h>
+#include <sys/socket.h>
+}
+
+namespace lo2s
+{
+namespace monitor
+{
+
+OpenMPMonitor::OpenMPMonitor(trace::Trace& trace, int fd)
+: PollMonitor(trace, "OpenMPMonitor", config().ringbuf_read_interval),
+  ringbuf_reader_(fd, config().clockid.value_or(0)), process_(ringbuf_reader_.header()->pid),
+  trace_(trace), time_converter_(perf::time::Converter::instance())
+{
+}
+
+void OpenMPMonitor::finalize_thread()
+{
+    for (auto& reader : local_cctx_trees_)
+    {
+        reader.second->cctx_leave(last_tp_[reader.first], 1);
+
+        reader.second->finalize();
+    }
+}
+
+void OpenMPMonitor::create_thread_writer(otf2::chrono::time_point tp, uint64_t thread)
+{
+    local_cctx_trees_.emplace(thread, &trace_.create_local_cctx_tree(
+                                          MeasurementScope::openmp(Thread(thread).as_scope())));
+
+    local_cctx_trees_.at(thread)->cctx_enter(tp, CCTX_LEVEL_PROCESS,
+                                             CallingContext::process(process_));
+}
+
+void OpenMPMonitor::monitor(int fd [[maybe_unused]])
+{
+    while (!ringbuf_reader_.empty())
+    {
+        omp::EventType event_type =
+            static_cast<omp::EventType>(ringbuf_reader_.get_top_event_type());
+
+        if (event_type == omp::EventType::OMPT_ENTER)
+        {
+            struct omp::ompt_enter* kernel = ringbuf_reader_.get<struct omp::ompt_enter>();
+
+            auto tp = time_converter_(kernel->tp);
+
+            if (local_cctx_trees_.count(kernel->cctx.tid) == 0)
+            {
+                create_thread_writer(tp, kernel->cctx.tid);
+            }
+
+            local_cctx_trees_.at(kernel->cctx.tid)
+                ->cctx_enter(tp, CallingContext::openmp(kernel->cctx));
+
+            last_tp_[kernel->cctx.tid] = tp;
+        }
+        else if (event_type == omp::EventType::OMPT_EXIT)
+        {
+            struct omp::ompt_exit* kernel = ringbuf_reader_.get<struct omp::ompt_exit>();
+
+            auto tp = time_converter_(kernel->tp);
+
+            if (local_cctx_trees_.count(kernel->cctx.tid) == 0)
+            {
+                create_thread_writer(tp, kernel->cctx.tid);
+            }
+
+            if (local_cctx_trees_[kernel->cctx.tid]->cur_level() != CCTX_LEVEL_PROCESS)
+            {
+                local_cctx_trees_.at(kernel->cctx.tid)->cctx_leave(tp);
+            }
+
+            last_tp_[kernel->cctx.tid] = tp;
+        }
+
+        ringbuf_reader_.pop();
+    }
+}
+} // namespace monitor
+} // namespace lo2s

--- a/src/monitor/process_monitor_main.cpp
+++ b/src/monitor/process_monitor_main.cpp
@@ -181,6 +181,14 @@ std::vector<char*> to_vector_of_c_str(const std::vector<std::string>& vec)
     }
 #endif
 
+#ifdef HAVE_OPENMP
+    if (config().use_openmp)
+    {
+        env.emplace("OMP_TOOL", "enabled");
+        env.emplace("OMP_TOOL_LIBRARIES", "liblo2s_injection.so");
+    }
+#endif
+
     std::vector<char*> c_args = to_vector_of_c_str(command_and_args);
 
     for (const auto& env_var : env)

--- a/src/monitor/socket_monitor.cpp
+++ b/src/monitor/socket_monitor.cpp
@@ -118,6 +118,12 @@ void SocketMonitor::finalize_thread()
     {
         monitor.second.stop();
     }
+
+    for (auto& monitor : openmp_monitors_)
+    {
+        monitor.second.stop();
+    }
+
     close(socket);
     unlink(config().socket_path.c_str());
 }
@@ -144,6 +150,14 @@ void SocketMonitor::monitor(int fd)
             auto res =
                 cuda_monitors_.emplace(std::piecewise_construct, std::forward_as_tuple(foo_fd),
                                        std::forward_as_tuple(trace_, type_fd.value().second));
+            res.first->second.start();
+        }
+        else if (type_fd.value().first == RingbufMeasurementType::OPENMP)
+
+        {
+            auto res =
+                openmp_monitors_.emplace(std::piecewise_construct, std::forward_as_tuple(foo_fd),
+                                         std::forward_as_tuple(trace_, type_fd.value().second));
             res.first->second.start();
         }
         else

--- a/src/ompt/lib.cpp
+++ b/src/ompt/lib.cpp
@@ -1,0 +1,162 @@
+/*
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2016,
+ *    Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <lo2s/ompt/events.hpp>
+#include <lo2s/ompt/ringbuf.hpp>
+#include <lo2s/ringbuf.hpp>
+
+#include <omp-tools.h>
+#include <omp.h>
+
+std::unique_ptr<lo2s::omp::RingbufWriter> ompt_rb_writer = nullptr;
+static ompt_set_callback_t ompt_set_callback;
+
+static void on_ompt_callback_parallel_begin(ompt_data_t* parent_task_data,
+                                            const ompt_frame_t* parent_task_frame,
+                                            ompt_data_t* parallel_data,
+                                            uint32_t requested_team_size, int flag,
+                                            const void* codeptr_ra)
+{
+
+    struct lo2s::omp::OMPTCctx cctx;
+
+    cctx.type = lo2s::omp::OMPType::PARALLEL;
+    cctx.addr = (uint64_t)codeptr_ra;
+    cctx.tid = gettid();
+    cctx.num_threads = requested_team_size;
+
+    ompt_rb_writer->ompt_enter(ompt_rb_writer->timestamp(), cctx);
+}
+
+static void on_ompt_callback_parallel_end(ompt_data_t* parallel_data, ompt_data_t* task_data,
+                                          int flag, const void* codeptr_ra)
+{
+    struct lo2s::omp::OMPTCctx cctx;
+
+    cctx.type = lo2s::omp::OMPType::PARALLEL;
+    cctx.addr = (uint64_t)codeptr_ra;
+    cctx.tid = gettid();
+
+    ompt_rb_writer->ompt_leave(ompt_rb_writer->timestamp(), cctx);
+}
+
+static void on_ompt_callback_master(ompt_scope_endpoint_t endpoint, ompt_data_t* parallel_data,
+                                    ompt_data_t* task_data, const void* codeptr_ra)
+{
+    struct lo2s::omp::OMPTCctx cctx;
+
+    cctx.type = lo2s::omp::OMPType::MASTER;
+    cctx.addr = (uint64_t)codeptr_ra;
+    cctx.tid = gettid();
+
+    if (endpoint == ompt_scope_begin)
+    {
+        ompt_rb_writer->ompt_enter(ompt_rb_writer->timestamp(), cctx);
+    }
+    else if (endpoint == ompt_scope_end)
+    {
+        ompt_rb_writer->ompt_leave(ompt_rb_writer->timestamp(), cctx);
+    }
+}
+
+static void on_ompt_callback_work(ompt_work_t wstype, ompt_scope_endpoint_t endpoint,
+                                  ompt_data_t* parallel_data, ompt_data_t* task_data,
+                                  uint64_t count, const void* codeptr_ra)
+{
+    struct lo2s::omp::OMPTCctx cctx;
+
+    switch (wstype)
+    {
+    case ompt_work_loop:
+    case ompt_work_loop_static:
+        cctx.type = lo2s::omp::OMPType::LOOP;
+        break;
+    case ompt_work_workshare:
+        cctx.type = lo2s::omp::OMPType::WORKSHARE;
+        break;
+    default:
+        cctx.type = lo2s::omp::OMPType::OTHER;
+        break;
+    }
+
+    cctx.addr = (uint64_t)codeptr_ra;
+    cctx.tid = gettid();
+
+    if (endpoint == ompt_scope_begin)
+    {
+        ompt_rb_writer->ompt_enter(ompt_rb_writer->timestamp(), cctx);
+    }
+    else if (endpoint == ompt_scope_end)
+    {
+        ompt_rb_writer->ompt_leave(ompt_rb_writer->timestamp(), cctx);
+    }
+}
+
+static void on_ompt_callback_sync_region(ompt_sync_region_t kind, ompt_scope_endpoint_t endpoint,
+                                         ompt_data_t* parallel_data, ompt_data_t* task_data,
+                                         const void* codeptr_ra)
+{
+    struct lo2s::omp::OMPTCctx cctx;
+
+    cctx.type = lo2s::omp::OMPType::SYNC;
+    cctx.addr = (uint64_t)codeptr_ra;
+    cctx.tid = gettid();
+
+    if (endpoint == ompt_scope_begin)
+    {
+        ompt_rb_writer->ompt_enter(ompt_rb_writer->timestamp(), cctx);
+    }
+    else if (endpoint == ompt_scope_end)
+    {
+        ompt_rb_writer->ompt_leave(ompt_rb_writer->timestamp(), cctx);
+    }
+}
+
+#define register_callback_t(name, type) ompt_set_callback(name, (ompt_callback_t)on_##name)
+
+#define register_callback(name) register_callback_t(name, name##_t)
+
+int ompt_initialize(ompt_function_lookup_t lookup, int initial_device_num, ompt_data_t* tool_data)
+{
+    pid_t pid = getpid();
+    ompt_rb_writer = std::make_unique<lo2s::omp::RingbufWriter>(lo2s::Process(pid));
+    ompt_set_callback = (ompt_set_callback_t)lookup("ompt_set_callback");
+    register_callback(ompt_callback_parallel_begin);
+    register_callback(ompt_callback_parallel_end);
+    register_callback(ompt_callback_master);
+    register_callback(ompt_callback_work);
+    register_callback(ompt_callback_sync_region);
+
+    return 1;
+}
+
+void ompt_finalize(ompt_data_t* tool_data)
+{
+}
+
+extern "C" ompt_start_tool_result_t* ompt_start_tool(unsigned int omp_version,
+                                                     const char* runtime_version)
+{
+    static ompt_start_tool_result_t ompt_start_tool_result = { &ompt_initialize, &ompt_finalize,
+                                                               0 };
+    return &ompt_start_tool_result;
+    return NULL;
+}

--- a/src/process_controller.cpp
+++ b/src/process_controller.cpp
@@ -301,7 +301,21 @@ ProcessController::SignalHandlingState ProcessController::handle_signal(Thread c
 
         default:
             Log::debug() << "Forwarding signal for " << child << ": " << WSTOPSIG(status);
-            ptrace_cont(child, WSTOPSIG(status));
+            try
+            {
+                ptrace_cont(child, WSTOPSIG(status));
+            }
+            catch (const std::system_error& e)
+            {
+                if (e.code().value() == ESRCH)
+                {
+                    Log::info() << "Received ESRCH for PTRACE_CONT on " << child;
+                }
+                else
+                {
+                    throw e;
+                }
+            }
             return SignalHandlingState::KeepRunning;
         }
     }


### PR DESCRIPTION
The content of this commit produces traces of OpenMP program activity which can already capture quite some information about OpenMP programs, but at no point claim to be correct or complete or anything.

On the technical side, the functionality here is based on the ringbuf interface, attaching lo2s to the relevant OMPT callbacks.