### PR TITLE
feat(gpu): Implement AMD HIP kernel recording

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ find_package(LibElf REQUIRED)
 find_package(LibDw REQUIRED)
 find_package(Debuginfod)
 find_package(OpenMP)
+find_package(rocprofiler-sdk)
 
 include(CheckIncludeFileCXX)
 
@@ -158,6 +159,8 @@ CMAKE_DEPENDENT_OPTION(USE_DEBUGINFOD "Use Debuginfod to download debug informat
 add_feature_info("USE_DEBUGINFOD" USE_DEBUGINFOD "Use Debuginfod to download debug information on-demand.")
 CMAKE_DEPENDENT_OPTION(USE_OPENMP "Use OMPT to record OpenMP activity" ON "OMPT_FOUND" OFF)
 add_feature_info("USE_OPENMP" USE_OPENMP "Use OMPT to record OpenMP activity")
+CMAKE_DEPENDENT_OPTION(USE_HIP "Use rocprofiler-sdk to record AMD HIP activity" ON "rocprofiler-sdk_FOUND" OFF)
+add_feature_info("USE_HIP" USE_HIP "Use rocprofiler-sdk to record AMD HIP activity")
 
 # system configuration checks
 CHECK_INCLUDE_FILES(linux/hw_breakpoint.h HAVE_HW_BREAKPOINT_H)
@@ -210,7 +213,7 @@ set(SOURCE_FILES
     src/perf/event_resolver.cpp
     src/perf/event_attr.cpp
     src/monitor/socket_monitor.cpp
-    src/monitor/cuda_monitor.cpp
+    src/monitor/gpu_monitor.cpp
     src/monitor/openmp_monitor.cpp
 
     src/perf/bio/block_device.cpp
@@ -370,7 +373,7 @@ endif()
 
 set(LO2S_INJECTIONLIB_PATH "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 
-if(USE_CUPTI OR USE_OPENMP)
+if(USE_CUPTI OR USE_OPENMP OR USE_HIP)
     add_library(lo2s_injection SHARED)
 
     target_include_directories(lo2s_injection PRIVATE include
@@ -415,6 +418,16 @@ if(USE_OPENMP)
         target_compile_definitions(lo2s PUBLIC HAVE_OPENMP)
     else()
         message(SEND_ERROR "OpenMP not supported but requested.")
+    endif()
+endif()
+
+if(USE_HIP)
+    if(rocprofiler-sdk_FOUND)
+        target_sources(lo2s_injection PRIVATE src/hip/lib.cpp)
+        target_link_libraries(lo2s_injection PRIVATE rocprofiler-sdk::rocprofiler-sdk)
+        target_compile_definitions(lo2s PUBLIC HAVE_HIP)
+    else()
+        message(SEND_ERROR "HIP activity recording not supported but requested.")
     endif()
 endif()
 

--- a/include/lo2s/calling_context.hpp
+++ b/include/lo2s/calling_context.hpp
@@ -39,7 +39,7 @@ enum class CallingContextType
     PROCESS,
     THREAD,
     SAMPLE_ADDR,
-    CUDA,
+    GPU_KERNEL,
     SYSCALL,
     OPENMP
 };
@@ -72,10 +72,10 @@ public:
         return c;
     }
 
-    static CallingContext cuda(uint64_t kernel_id)
+    static CallingContext gpu_kernel(uint64_t kernel_id)
     {
         CallingContext c;
-        c.type = CallingContextType::CUDA;
+        c.type = CallingContextType::GPU_KERNEL;
         c.kernel_id = kernel_id;
         return c;
     }
@@ -125,12 +125,12 @@ public:
 
     uint64_t to_kernel_id() const
     {
-        if (type == CallingContextType::CUDA)
+        if (type == CallingContextType::GPU_KERNEL)
         {
             return kernel_id;
         }
 
-        throw std::runtime_error("Not a CUDA kernel!");
+        throw std::runtime_error("Not a GPU kernel!");
     }
 
     omp::OMPTCctx to_omp_cctx() const
@@ -178,7 +178,7 @@ public:
                 return lhs.p < rhs.p;
             case CallingContextType::THREAD:
                 return lhs.t < rhs.t;
-            case CallingContextType::CUDA:
+            case CallingContextType::GPU_KERNEL:
                 return lhs.kernel_id < rhs.kernel_id;
             case CallingContextType::SAMPLE_ADDR:
                 return lhs.addr < rhs.addr;
@@ -207,7 +207,7 @@ public:
                 return lhs.t == rhs.t;
             case CallingContextType::SAMPLE_ADDR:
                 return lhs.addr == rhs.addr;
-            case CallingContextType::CUDA:
+            case CallingContextType::GPU_KERNEL:
                 return lhs.kernel_id == rhs.kernel_id;
             case CallingContextType::SYSCALL:
                 return lhs.syscall_id == rhs.syscall_id;
@@ -234,7 +234,7 @@ public:
                 return lhs.p != rhs.p;
             case CallingContextType::THREAD:
                 return lhs.t != rhs.t;
-            case CallingContextType::CUDA:
+            case CallingContextType::GPU_KERNEL:
                 return lhs.kernel_id != rhs.kernel_id;
             case CallingContextType::SAMPLE_ADDR:
                 return lhs.addr != rhs.addr;
@@ -263,8 +263,8 @@ public:
             return fmt::format("thread {}", t.as_pid_t());
         case CallingContextType::SAMPLE_ADDR:
             return fmt::format("sample addr {}", addr);
-        case CallingContextType::CUDA:
-            return fmt::format("cuda kernel {}", kernel_id);
+        case CallingContextType::GPU_KERNEL:
+            return fmt::format("gpu kernel {}", kernel_id);
         case CallingContextType::SYSCALL:
             return fmt::format("syscall {}", syscall_id);
         case CallingContextType::OPENMP:

--- a/include/lo2s/config.hpp
+++ b/include/lo2s/config.hpp
@@ -116,6 +116,8 @@ struct Config
     bool use_nvidia = false;
     // OpenMP
     bool use_openmp = false;
+    // AMD HIP
+    bool use_hip = false;
     // Function resolution
     DwarfUsage dwarf;
     // Python

--- a/include/lo2s/gpu/events.hpp
+++ b/include/lo2s/gpu/events.hpp
@@ -25,7 +25,7 @@
 
 namespace lo2s
 {
-namespace cuda
+namespace gpu
 {
 
 enum class EventType : uint64_t
@@ -50,5 +50,5 @@ struct __attribute__((packed)) kernel
     uint64_t kernel_id;
 };
 
-} // namespace cuda
+} // namespace gpu
 } // namespace lo2s

--- a/include/lo2s/gpu/ringbuf.hpp
+++ b/include/lo2s/gpu/ringbuf.hpp
@@ -1,17 +1,17 @@
 #pragma once
 
-#include <lo2s/cuda/events.hpp>
+#include <lo2s/gpu/events.hpp>
 #include <lo2s/ringbuf.hpp>
 
 namespace lo2s
 {
-namespace cuda
+namespace gpu
 {
 
 class RingbufWriter : public lo2s::RingbufWriter
 {
 public:
-    RingbufWriter(Process process) : lo2s::RingbufWriter(process, RingbufMeasurementType::CUDA)
+    RingbufWriter(Process process) : lo2s::RingbufWriter(process, RingbufMeasurementType::GPU)
     {
     }
 
@@ -44,6 +44,24 @@ public:
         return cctx.second;
     }
 
+    bool kernel_def(std::string func, uint64_t kernel_id)
+    {
+        struct kernel_def* ev = reserve<struct kernel_def>(func.size());
+
+        if (ev == nullptr)
+        {
+            return false;
+        }
+
+        memcpy(ev->function, func.c_str(), func.size());
+
+        ev->header.type = (uint64_t)EventType::KERNEL_DEF;
+        ev->kernel_id = kernel_id;
+
+        commit();
+        return true;
+    }
+
     bool kernel(uint64_t start_tp, uint64_t end_tp, uint64_t kernel_id)
     {
         struct kernel* ev = reserve<struct kernel>();
@@ -67,5 +85,5 @@ private:
     uint64_t next_cctx_ref_ = 0;
 };
 
-} // namespace cuda
+} // namespace gpu
 } // namespace lo2s

--- a/include/lo2s/measurement_scope.hpp
+++ b/include/lo2s/measurement_scope.hpp
@@ -34,7 +34,7 @@ enum class MeasurementScopeType
     NEC_METRIC,
     BIO,
     SYSCALL,
-    CUDA,
+    GPU,
     TRACEPOINT,
     POSIX_IO,
     OPENMP,
@@ -84,9 +84,9 @@ struct MeasurementScope
         return { MeasurementScopeType::SYSCALL, s };
     }
 
-    static MeasurementScope cuda(ExecutionScope s)
+    static MeasurementScope gpu(ExecutionScope s)
     {
-        return { MeasurementScopeType::CUDA, s };
+        return { MeasurementScopeType::GPU, s };
     }
 
     static MeasurementScope openmp(ExecutionScope s)
@@ -141,8 +141,8 @@ struct MeasurementScope
             return fmt::format("block layer I/O events for {}", scope.name());
         case MeasurementScopeType::SYSCALL:
             return fmt::format("syscall events for {}", scope.name());
-        case lo2s::MeasurementScopeType::CUDA:
-            return fmt::format("cuda kernel events for {}", scope.name());
+        case lo2s::MeasurementScopeType::GPU:
+            return fmt::format("gpu kernel events for {}", scope.name());
         case MeasurementScopeType::TRACEPOINT:
             return fmt::format("tracepoint events for {}", scope.name());
         case MeasurementScopeType::POSIX_IO:

--- a/include/lo2s/monitor/fwd.hpp
+++ b/include/lo2s/monitor/fwd.hpp
@@ -37,6 +37,6 @@ class MainMonitor;
 class ProcessMonitor;
 class CpuSetMonitor;
 class SocketMonitor;
-class CUDAMonitor;
+class GPUMonitor;
 } // namespace monitor
 } // namespace lo2s

--- a/include/lo2s/monitor/gpu_monitor.hpp
+++ b/include/lo2s/monitor/gpu_monitor.hpp
@@ -31,24 +31,24 @@ namespace lo2s
 namespace monitor
 {
 
-class CUDAMonitor : public PollMonitor
+class GPUMonitor : public PollMonitor
 {
 public:
-    CUDAMonitor(trace::Trace& trace, int fd);
+    GPUMonitor(trace::Trace& trace, int fd);
 
     void finalize_thread() override;
     void monitor(int fd) override;
 
     std::string group() const override
     {
-        return "lo2s::CUDAMonitor";
+        return "lo2s::GPUMonitor";
     }
 
     void emplace_resolvers(Resolvers& resolvers)
     {
-        resolvers.cuda_function_resolvers[process_].emplace(
+        resolvers.gpu_function_resolvers[process_].emplace(
             Mapping(Address(0), Address(highest_func_ + 1), 0),
-            std::make_shared<ManualFunctionResolver>("cuda kernels", functions_));
+            std::make_shared<ManualFunctionResolver>("gpu kernels", functions_));
     }
 
 private:

--- a/include/lo2s/monitor/socket_monitor.hpp
+++ b/include/lo2s/monitor/socket_monitor.hpp
@@ -25,7 +25,7 @@
 #include <lo2s/monitor/poll_monitor.hpp>
 #include <lo2s/resolvers.hpp>
 
-#include <lo2s/monitor/cuda_monitor.hpp>
+#include <lo2s/monitor/gpu_monitor.hpp>
 #include <lo2s/monitor/openmp_monitor.hpp>
 
 extern "C"
@@ -54,7 +54,7 @@ public:
 
     void emplace_resolvers(Resolvers& resolvers)
     {
-        for (auto& monitor : cuda_monitors_)
+        for (auto& monitor : gpu_monitors_)
         {
             monitor.second.emplace_resolvers(resolvers);
         }
@@ -62,7 +62,7 @@ public:
 
 private:
     trace::Trace& trace_;
-    std::map<int, CUDAMonitor> cuda_monitors_;
+    std::map<int, GPUMonitor> gpu_monitors_;
     std::map<int, OpenMPMonitor> openmp_monitors_;
 
     int socket = -1;

--- a/include/lo2s/resolvers.hpp
+++ b/include/lo2s/resolvers.hpp
@@ -33,7 +33,7 @@ struct Resolvers
     std::map<Process, ProcessFunctionMap> function_resolvers;
     std::map<Process, MemoryMap<InstructionResolver>> instruction_resolvers;
 
-    std::map<Process, MemoryMap<ManualFunctionResolver>> cuda_function_resolvers;
+    std::map<Process, MemoryMap<ManualFunctionResolver>> gpu_function_resolvers;
 
     void fork(Process parent, Process process)
     {

--- a/include/lo2s/ringbuf.hpp
+++ b/include/lo2s/ringbuf.hpp
@@ -55,7 +55,7 @@ namespace lo2s
 
 enum class RingbufMeasurementType : uint64_t
 {
-    CUDA = 0,
+    GPU = 0,
     OPENMP = 1,
 };
 

--- a/include/lo2s/trace/trace.hpp
+++ b/include/lo2s/trace/trace.hpp
@@ -269,9 +269,9 @@ private:
         Process p;
     };
 
-    otf2::definition::calling_context& cctx_for_cuda(uint64_t kernel_id, Resolvers& r,
-                                                     struct MergeContext& ctx,
-                                                     GlobalCctxMap::value_type* parent);
+    otf2::definition::calling_context& cctx_for_gpu_kernel(uint64_t kernel_id, Resolvers& r,
+                                                           struct MergeContext& ctx,
+                                                           GlobalCctxMap::value_type* parent);
     otf2::definition::calling_context& cctx_for_openmp(const CallingContext& addr, Resolvers& r,
                                                        struct MergeContext& ctx,
                                                        GlobalCctxMap::value_type* parent);

--- a/include/lo2s/types.hpp
+++ b/include/lo2s/types.hpp
@@ -24,6 +24,7 @@
 extern "C"
 {
 #include <sys/types.h>
+#include <unistd.h>
 }
 
 #include <fmt/format.h>
@@ -135,6 +136,11 @@ public:
     static Process idle()
     {
         return Process(0);
+    }
+
+    static Process me()
+    {
+        return Process(getpid());
     }
 
     pid_t as_pid_t() const

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -642,6 +642,15 @@ void parse_program_options(int argc, const char** argv)
             std::exit(EXIT_FAILURE);
 #endif
         }
+        else if (accel == "amd")
+        {
+#ifdef HAVE_HIP
+            config.use_hip = true;
+#else
+            std::cerr << "lo2s was built without support for AMD HIP recording\n";
+            std::exit(EXIT_FAILURE);
+#endif
+        }
         else
         {
             std::cerr << "Unknown Accelerator " << accel << "!";

--- a/src/cuda/lib.cpp
+++ b/src/cuda/lib.cpp
@@ -19,7 +19,7 @@
  * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <lo2s/cuda/ringbuf.hpp>
+#include <lo2s/gpu/ringbuf.hpp>
 
 #include <iostream>
 #include <memory>
@@ -39,7 +39,7 @@ extern "C"
 // Allocate 8 MiB every time CUPTI asks for more event memory
 constexpr size_t CUPTI_BUFFER_SIZE = 8 * 1024 * 1024;
 
-std::unique_ptr<lo2s::cuda::RingbufWriter> rb_writer = nullptr;
+std::unique_ptr<lo2s::gpu::RingbufWriter> rb_writer = nullptr;
 
 CUpti_SubscriberHandle subscriber = nullptr;
 
@@ -166,9 +166,7 @@ uint64_t timestampfunc()
 
 extern "C" int InitializeInjection(void)
 {
-    pid_t pid = getpid();
-
-    rb_writer = std::make_unique<lo2s::cuda::RingbufWriter>(lo2s::Process(pid));
+    rb_writer = std::make_unique<lo2s::gpu::RingbufWriter>(lo2s::Process::me());
 
     // Register an atexit() handler for clean-up
     atexit(&atExitHandler);

--- a/src/hip/lib.cpp
+++ b/src/hip/lib.cpp
@@ -1,0 +1,200 @@
+/*
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2025,
+ *    Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <lo2s/gpu/ringbuf.hpp>
+
+#include <queue>
+#include <regex>
+
+#include <rocprofiler-sdk/registration.h>
+#include <rocprofiler-sdk/rocprofiler.h>
+
+constexpr size_t HIP_BUFFER_SIZE = 8 * 1024 * 1024;
+
+uint64_t last_timestamp = 0;
+int64_t offset;
+
+rocprofiler_buffer_id_t client_buffer;
+
+std::unique_ptr<lo2s::gpu::RingbufWriter> rb_writer = nullptr;
+
+struct kernel_cache
+{
+    kernel_cache(uint64_t kernel_id, uint64_t start_timestamp, uint64_t end_timestamp)
+    : kernel_id(kernel_id), start_timestamp(start_timestamp), end_timestamp(end_timestamp)
+    {
+    }
+
+    uint64_t kernel_id;
+    uint64_t start_timestamp;
+    uint64_t end_timestamp;
+
+    friend bool operator<(const struct kernel_cache& lhs, const struct kernel_cache& rhs)
+    {
+        return lhs.start_timestamp > rhs.start_timestamp;
+    }
+};
+
+// Unlike NVidia, with AMD you can not supply an alternative
+// timestamp source and the clock source used, BOOTTIME,
+// can lead to problems if used with perf.
+//
+// So instead, use this crude time synchronization.
+int64_t calculate_offset()
+{
+    uint64_t roc_timestamp;
+    rocprofiler_get_timestamp(&roc_timestamp);
+
+    uint64_t lo2s_timestamp = rb_writer->timestamp();
+
+    return roc_timestamp - lo2s_timestamp;
+}
+
+void tool_tracing_callback(rocprofiler_context_id_t context, rocprofiler_buffer_id_t buffer_id,
+                           rocprofiler_record_header_t** headers, size_t num_headers,
+                           void* user_data, uint64_t drop_count)
+{
+    std::priority_queue<struct kernel_cache> reorder_buffer;
+
+    for (size_t i = 0; i < num_headers; ++i)
+    {
+        rocprofiler_record_header_t* header = headers[i];
+
+        if (header->category == ROCPROFILER_BUFFER_CATEGORY_TRACING &&
+            header->kind == ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH)
+        {
+            auto* record = reinterpret_cast<rocprofiler_buffer_tracing_kernel_dispatch_record_t*>(
+                header->payload);
+
+            reorder_buffer.emplace(record->dispatch_info.kernel_id,
+                                   record->start_timestamp - offset,
+                                   record->end_timestamp - offset);
+
+            if (reorder_buffer.size() >= 100)
+            {
+                struct kernel_cache ev = reorder_buffer.top();
+                reorder_buffer.pop();
+
+                if (ev.start_timestamp >= last_timestamp)
+                {
+                    rb_writer->kernel(ev.start_timestamp, ev.end_timestamp, ev.kernel_id);
+                    last_timestamp = ev.end_timestamp;
+                }
+                else
+                {
+                    std::cerr << "HIP GPU kernel event arriving late!" << std::endl;
+                }
+            }
+        }
+    }
+
+    while (!reorder_buffer.empty())
+    {
+        struct kernel_cache ev = reorder_buffer.top();
+        reorder_buffer.pop();
+
+        if (ev.start_timestamp >= last_timestamp)
+        {
+            rb_writer->kernel(ev.start_timestamp, ev.end_timestamp, ev.kernel_id);
+            last_timestamp = ev.end_timestamp;
+        }
+        else
+        {
+            std::cerr << "HIP GPU kernel event arriving late!!" << std::endl;
+        }
+    }
+}
+
+void code_object_cb(rocprofiler_callback_tracing_record_t record,
+                    rocprofiler_user_data_t* user_data, void* callback_data)
+{
+    if (record.kind == ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT)
+    {
+        if (record.operation == ROCPROFILER_CODE_OBJECT_LOAD &&
+            record.phase == ROCPROFILER_CALLBACK_PHASE_UNLOAD)
+        {
+            rocprofiler_flush_buffer(client_buffer);
+        }
+        else if (record.operation == ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER)
+        {
+            auto* data = static_cast<
+                rocprofiler_callback_tracing_code_object_kernel_symbol_register_data_t*>(
+                record.payload);
+
+            auto kernel_name = std::regex_replace(data->kernel_name, std::regex{ "(\\.kd)$" }, "");
+            rb_writer->kernel_def(kernel_name, data->kernel_id);
+        }
+    }
+}
+
+int tool_init(rocprofiler_client_finalize_t fini_func, void* tool_data)
+{
+    rb_writer = std::make_unique<lo2s::gpu::RingbufWriter>(lo2s::Process::me());
+
+    offset = calculate_offset();
+
+    rocprofiler_context_id_t client_ctx = { 0 };
+    rocprofiler_create_context(&client_ctx);
+
+    rocprofiler_configure_callback_tracing_service(client_ctx,
+                                                   ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT,
+                                                   nullptr, 0, code_object_cb, tool_data);
+
+    // Create buffer for asynchronous event recording, set watermark to 80% buffer size
+    rocprofiler_create_buffer(client_ctx, HIP_BUFFER_SIZE, HIP_BUFFER_SIZE * 0.8,
+                              ROCPROFILER_BUFFER_POLICY_LOSSLESS, tool_tracing_callback, tool_data,
+                              &client_buffer);
+
+    rocprofiler_configure_buffer_tracing_service(
+        client_ctx, ROCPROFILER_BUFFER_TRACING_KERNEL_DISPATCH, nullptr, 0, client_buffer);
+
+    rocprofiler_callback_thread_t client_thread;
+    rocprofiler_create_callback_thread(&client_thread);
+    rocprofiler_assign_callback_thread(client_buffer, client_thread);
+
+    int valid_ctx = 0;
+    rocprofiler_context_is_valid(client_ctx, &valid_ctx);
+    if (valid_ctx == 0)
+    {
+        return -1;
+    }
+
+    rocprofiler_start_context(client_ctx);
+
+    return 0;
+}
+
+void tool_fini(void* tool_data)
+{
+    rocprofiler_flush_buffer(client_buffer);
+}
+
+extern "C" rocprofiler_tool_configure_result_t* rocprofiler_configure(uint32_t version,
+                                                                      const char* runtime_version,
+                                                                      uint32_t priority,
+                                                                      rocprofiler_client_id_t* id)
+{
+    id->name = "lo2s";
+
+    static rocprofiler_tool_configure_result_t cfg{ sizeof(rocprofiler_tool_configure_result_t),
+                                                    &tool_init, &tool_fini, nullptr };
+    return &cfg;
+}

--- a/src/monitor/gpu_monitor.cpp
+++ b/src/monitor/gpu_monitor.cpp
@@ -20,9 +20,9 @@
  */
 
 #include <lo2s/config.hpp>
-#include <lo2s/cuda/events.hpp>
+#include <lo2s/gpu/events.hpp>
 #include <lo2s/log.hpp>
-#include <lo2s/monitor/cuda_monitor.hpp>
+#include <lo2s/monitor/gpu_monitor.hpp>
 #include <lo2s/monitor/process_monitor.hpp>
 #include <lo2s/perf/sample/writer.hpp>
 #include <lo2s/time/time.hpp>
@@ -40,45 +40,45 @@ namespace lo2s
 namespace monitor
 {
 
-CUDAMonitor::CUDAMonitor(trace::Trace& trace, int fd)
-: PollMonitor(trace, "CUDAMonitor", config().ringbuf_read_interval),
+GPUMonitor::GPUMonitor(trace::Trace& trace, int fd)
+: PollMonitor(trace, "GPUMonitor", config().ringbuf_read_interval),
   ringbuf_reader_(fd, config().clockid.value_or(0)), process_(ringbuf_reader_.header()->pid),
   time_converter_(perf::time::Converter::instance()),
   local_cctx_tree_(
-      trace.create_local_cctx_tree(MeasurementScope::cuda(ExecutionScope(process_.as_thread()))))
+      trace.create_local_cctx_tree(MeasurementScope::gpu(ExecutionScope(process_.as_thread()))))
 {
 }
 
-void CUDAMonitor::finalize_thread()
+void GPUMonitor::finalize_thread()
 {
     local_cctx_tree_.cctx_leave(last_tp_, CCTX_LEVEL_PROCESS);
 
     local_cctx_tree_.finalize();
 }
 
-void CUDAMonitor::monitor(int fd [[maybe_unused]])
+void GPUMonitor::monitor(int fd [[maybe_unused]])
 {
     while (!ringbuf_reader_.empty())
     {
         uint64_t event_type = ringbuf_reader_.get_top_event_type();
 
-        if (event_type == (uint64_t)cuda::EventType::KERNEL)
+        if (event_type == (uint64_t)gpu::EventType::KERNEL)
         {
-            struct cuda::kernel* kernel = ringbuf_reader_.get<struct cuda::kernel>();
+            struct gpu::kernel* kernel = ringbuf_reader_.get<struct gpu::kernel>();
 
             auto start_tp = time_converter_(kernel->start_tp);
             auto end_tp = time_converter_(kernel->end_tp);
 
             local_cctx_tree_.cctx_enter(start_tp, CCTX_LEVEL_PROCESS,
                                         CallingContext::process(process_),
-                                        CallingContext::cuda(kernel->kernel_id));
+                                        CallingContext::gpu_kernel(kernel->kernel_id));
             local_cctx_tree_.cctx_leave(end_tp, CCTX_LEVEL_KERNEL);
 
             last_tp_ = end_tp;
         }
-        else if (event_type == (uint64_t)cuda::EventType::KERNEL_DEF)
+        else if (event_type == (uint64_t)gpu::EventType::KERNEL_DEF)
         {
-            struct cuda::kernel_def* kernel = ringbuf_reader_.get<struct cuda::kernel_def>();
+            struct gpu::kernel_def* kernel = ringbuf_reader_.get<struct gpu::kernel_def>();
             functions_.emplace(Address(kernel->kernel_id), std::string(kernel->function));
 
             if (kernel->kernel_id > highest_func_)

--- a/src/monitor/process_monitor_main.cpp
+++ b/src/monitor/process_monitor_main.cpp
@@ -189,6 +189,13 @@ std::vector<char*> to_vector_of_c_str(const std::vector<std::string>& vec)
     }
 #endif
 
+#ifdef HAVE_HIP
+    if (config().use_hip)
+    {
+        env.emplace("LD_PRELOAD", "liblo2s_injection.so");
+    }
+#endif
+
     std::vector<char*> c_args = to_vector_of_c_str(command_and_args);
 
     for (const auto& env_var : env)

--- a/src/monitor/socket_monitor.cpp
+++ b/src/monitor/socket_monitor.cpp
@@ -23,7 +23,7 @@
 
 #include <lo2s/config.hpp>
 #include <lo2s/log.hpp>
-#include <lo2s/monitor/cuda_monitor.hpp>
+#include <lo2s/monitor/gpu_monitor.hpp>
 #include <lo2s/perf/sample/writer.hpp>
 #include <lo2s/time/time.hpp>
 
@@ -114,7 +114,7 @@ std::optional<std::pair<RingbufMeasurementType, int>> read_fd(int socket)
 
 void SocketMonitor::finalize_thread()
 {
-    for (auto& monitor : cuda_monitors_)
+    for (auto& monitor : gpu_monitors_)
     {
         monitor.second.stop();
     }
@@ -145,11 +145,11 @@ void SocketMonitor::monitor(int fd)
 
     if (type_fd.has_value())
     {
-        if (type_fd.value().first == RingbufMeasurementType::CUDA)
+        if (type_fd.value().first == RingbufMeasurementType::GPU)
         {
             auto res =
-                cuda_monitors_.emplace(std::piecewise_construct, std::forward_as_tuple(foo_fd),
-                                       std::forward_as_tuple(trace_, type_fd.value().second));
+                gpu_monitors_.emplace(std::piecewise_construct, std::forward_as_tuple(foo_fd),
+                                      std::forward_as_tuple(trace_, type_fd.value().second));
             res.first->second.start();
         }
         else if (type_fd.value().first == RingbufMeasurementType::OPENMP)

--- a/src/ompt/lib.cpp
+++ b/src/ompt/lib.cpp
@@ -136,8 +136,7 @@ static void on_ompt_callback_sync_region(ompt_sync_region_t kind, ompt_scope_end
 
 int ompt_initialize(ompt_function_lookup_t lookup, int initial_device_num, ompt_data_t* tool_data)
 {
-    pid_t pid = getpid();
-    ompt_rb_writer = std::make_unique<lo2s::omp::RingbufWriter>(lo2s::Process(pid));
+    ompt_rb_writer = std::make_unique<lo2s::omp::RingbufWriter>(lo2s::Process::me());
     ompt_set_callback = (ompt_set_callback_t)lookup("ompt_set_callback");
     register_callback(ompt_callback_parallel_begin);
     register_callback(ompt_callback_parallel_end);

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -692,15 +692,15 @@ otf2::definition::metric_class& Trace::metric_class()
                                                             otf2::common::recorder_kind::abstract);
 }
 
-otf2::definition::calling_context& Trace::cctx_for_cuda(uint64_t kernel_id, Resolvers& r,
-                                                        struct MergeContext& ctx,
-                                                        GlobalCctxMap::value_type* global_node)
+otf2::definition::calling_context&
+Trace::cctx_for_gpu_kernel(uint64_t kernel_id, Resolvers& r, struct MergeContext& ctx,
+                           GlobalCctxMap::value_type* global_node)
 {
     LineInfo line_info = LineInfo::for_unknown_function();
 
-    auto fr = r.cuda_function_resolvers.find(ctx.p);
+    auto fr = r.gpu_function_resolvers.find(ctx.p);
 
-    if (fr != r.cuda_function_resolvers.end())
+    if (fr != r.gpu_function_resolvers.end())
     {
         auto it = fr->second.find(kernel_id);
         if (it != fr->second.end())
@@ -910,8 +910,9 @@ void Trace::merge_nodes(const std::map<CallingContext, LocalCctxNode>::value_typ
             case lo2s::CallingContextType::SAMPLE_ADDR:
                 new_cctx = &cctx_for_address(local_child.first.to_addr(), r, ctx, global_node);
                 break;
-            case lo2s::CallingContextType::CUDA:
-                new_cctx = &cctx_for_cuda(local_child.first.to_kernel_id(), r, ctx, global_node);
+            case lo2s::CallingContextType::GPU_KERNEL:
+                new_cctx =
+                    &cctx_for_gpu_kernel(local_child.first.to_kernel_id(), r, ctx, global_node);
                 break;
             case lo2s::CallingContextType::OPENMP:
                 new_cctx = &cctx_for_openmp(local_child.first, r, ctx, global_node);


### PR DESCRIPTION
This commit introduces AMD HIP kernel event recording based on the rocprofiler-sdk.

This largely follows the NVidia CUDA kernel event recording we already have, although the AMD API is less sophisticated in some degrees:

- Events do not necessarily arrive ordered. Reorder using a limited size priority_queue, throw away events that have arrived after later ones have already been written.
- There is no way to set an external timestamp source and the internally used clock source, BOOTTIME has issues with being used with perf. Rectify this with a crude time synchronization mechanism.

Additionally move all the CUDA recording code that is used in the AMD code path into a GPU namespace.

This closes #371 