### PR TITLE
fix(build_system): depend libbpf on libdw, use more standardized find_library calls

### DIFF
--- a/cmake/FindLibBpf.cmake
+++ b/cmake/FindLibBpf.cmake
@@ -1,16 +1,30 @@
 # SPDX-License-Identifier: GPL-2.0 OR BSD-3-Clause
 option(LibBpf_USE_STATIC_LIBS "Link LibBpf statically." ON)
 
+find_package(PkgConfig)
+find_package(LibDw)
+
+if(NOT LibDw_FOUND)
+    return()
+endif()
+
+if(NOT PKG_CONFIG_FOUND)
+    return()
+endif()
+
+pkg_check_modules(LIBBPF_PKG_CONFIG libbpf)
+
+if(NOT LIBBPF_PKG_CONFIG_FOUND)
+    return()
+endif()
+
 find_path(LIBBPF_INCLUDE_DIRS
   NAMES
     bpf/bpf.h
     bpf/btf.h
     bpf/libbpf.h
-  PATHS
-    /usr/include
-    /usr/local/include
-    /opt/local/include
-    /sw/include
+    PATHS
+    ${LIBBPF_PKG_CONFIG_INCLUDDE_DIRS}
     ENV CPATH)
 
 
@@ -18,62 +32,16 @@ if(LibBpf_USE_STATIC_LIBS)
 find_library(LIBBPF_LIBRARIES
   NAMES
     libbpf.a
-  PATHS
-    /usr/lib
-    /usr/local/lib
-    /opt/local/lib
-    /sw/lib
+    HINTS
+    ${LIBBPF_PKG_CONFIG_STATIC_LIBRARY_DIRS}
     ENV LIBRARY_PATH
-    ENV LD_LIBRARY_PATH)
-find_library(LIBELF_LIBRARIES
-  NAMES
-    libelf.a
-  PATHS
-    /usr/lib
-    /usr/local/lib
-    /opt/local/lib
-    /sw/lib
-    ENV LIBRARY_PATH
-    ENV LD_LIBRARY_PATH)
-find_library(LIBZ_LIBRARIES
-  NAMES
-    libz.a
-  PATHS
-    /usr/lib
-    /usr/local/lib
-    /opt/local/lib
-    /sw/lib
-    ENV LIBRARY_PATH
-    ENV LD_LIBRARY_PATH)
+    )
 else()
 find_library(LIBBPF_LIBRARIES
   NAMES
     libbpf.so
-  PATHS
-    /usr/lib
-    /usr/local/lib
-    /opt/local/lib
-    /sw/lib
-    ENV LIBRARY_PATH
-    ENV LD_LIBRARY_PATH)
-find_library(LIBELF_LIBRARIES
-  NAMES
-  libelf.so
-  PATHS
-    /usr/lib
-    /usr/local/lib
-    /opt/local/lib
-    /sw/lib
-    ENV LIBRARY_PATH
-    ENV LD_LIBRARY_PATH)
-find_library(LIBZ_LIBRARIES
-  NAMES
-    libz.so
-  PATHS
-    /usr/lib
-    /usr/local/lib
-    /opt/local/lib
-    /sw/lib
+    HINTS
+    ${LIBBPF_PKG_CONFIG_LIBRARY_DIRS}
     ENV LIBRARY_PATH
     ENV LD_LIBRARY_PATH)
 endif()
@@ -82,17 +50,13 @@ include (FindPackageHandleStandardArgs)
 
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibBpf DEFAULT_MSG
   LIBBPF_LIBRARIES
-  LIBELF_LIBRARIES
-  LIBZ_LIBRARIES
   LIBBPF_INCLUDE_DIRS)
 
-list(APPEND LIBBPF_LIBRARIES ${LIBELF_LIBRARIES})
-list(APPEND LIBBPF_LIBRARIES ${LIBZ_LIBRARIES})
 
 if(LibBpf_FOUND)
-    add_library(libbpf INTERFACE)
-    target_link_libraries(libbpf INTERFACE ${LIBBPF_LIBRARIES})
-    target_include_directories(libbpf INTERFACE ${LIBBPF_INCLUDE_DIRS})
-    add_library(LibBpf::LibBpf ALIAS libbpf)
+    add_library(LibBpf::LibBpf UNKNOWN IMPORTED)
+    set_property(TARGET LibBpf::LibBpf PROPERTY IMPORTED_LOCATION ${LIBBPF_LIBRARIES})
+    target_link_libraries(LibBpf::LibBpf INTERFACE LibDw::LibDw)
+    target_include_directories(LibBpf::LibBpf INTERFACE ${LIBBPF_INCLUDE_DIRS})
 endif()
 mark_as_advanced(LIBBPF_INCLUDE_DIRS LIBBPF_LIBRARIES)

--- a/cmake/FindLibDw.cmake
+++ b/cmake/FindLibDw.cmake
@@ -30,6 +30,10 @@ option(LibDw_USE_STATIC_LIBS "Link libelf statically." OFF)
 
 UnsetIfUpdated(LibDw_LIBRARIES LibDw_USE_STATIC_LIBS)
 
+if(TARGET LibDw::LibDw)
+    return()
+endif()
+
 find_package(PkgConfig)
 pkg_check_modules(LIBDW_PKG_CONFIG REQUIRED libdw)
 
@@ -44,13 +48,13 @@ if(LIBDW_PKG_CONFIG_FOUND)
     if(LibDw_USE_STATIC_LIBS)
         foreach(LIBRARY IN LISTS LIBDW_PKG_CONFIG_STATIC_LIBRARIES)
             find_library(${LIBRARY}_LIBRARY NAMES "lib${LIBRARY}.a"
-                HINTS ENV LIBRARY_PATH)
+                HINTS ${LIBDW_PKG_CONFIG_STATIC_LIBRARY_DIRS} ENV LIBRARY_PATH)
             list(APPEND LIBDW_LIBRARIES "${LIBRARY}_LIBRARY")
         endforeach()
     else()
         foreach(LIBRARY IN LISTS LIBDW_PKG_CONFIG_LIBRARIES)
             find_library(${LIBRARY}_LIBRARY NAMES "lib${LIBRARY}.so"
-                HINTS ENV LIBRARY_PATH)
+                HINTS ${LIBDW_PKG_CONFIG_LIBRARY_DIRS} ENV LIBRARY_PATH)
             list(APPEND LIBDW_LIBRARIES "${LIBRARY}_LIBRARY")
         endforeach()
     endif()


### PR DESCRIPTION
Link libbpf to libdw instead of manually finding and including it.

Edit libbpf find_library calls to make them behave more like every other find_library call in lo2s.

Use library path output by pkg-config as a hint to find_library.