### PR TITLE
feat(perf): Add support for pmu-events

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "lib/indicators"]
 	path = lib/indicators
 	url = https://github.com/p-ranav/indicators
+[submodule "lib/pmu-events"]
+	path = lib/pmu-events
+	url = https://github.com/cvonelm/pmu-events

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,6 +105,8 @@ add_subdirectory(lib/nitro)
 
 add_subdirectory(lib/indicators)
 
+add_subdirectory(lib/pmu-events)
+
 # configure x64_adapt_cxx library
 include(lib/x86_adapt/x86_adapt.cmake)
 
@@ -278,6 +280,7 @@ target_link_libraries(lo2s
         std::filesystem
         LibDw::LibDw
         indicators::indicators
+        PMUEvents::pmu-events
     )
 
 # old glibc versions require -lrt for clock_gettime()

--- a/include/lo2s/perf/event_attr.hpp
+++ b/include/lo2s/perf/event_attr.hpp
@@ -321,6 +321,7 @@ public:
     }
 
 protected:
+    static std::set<Cpu> get_cpu_set_for(EventAttr attr);
     void update_availability();
 
     struct perf_event_attr attr_;

--- a/include/lo2s/perf/pmu-events.hpp
+++ b/include/lo2s/perf/pmu-events.hpp
@@ -1,0 +1,172 @@
+/*
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2025,
+ *    Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <lo2s/perf/event_attr.hpp>
+#include <lo2s/perf/pmu.hpp>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <fmt/core.h>
+
+#include <nitro/lang/string.hpp>
+
+extern "C"
+{
+#include <linux/perf_event.h>
+#include <perfmon/pfmlib.h>
+#include <perfmon/pfmlib_perf_event.h>
+#include <pmu-events/pmu-events.h>
+}
+
+namespace lo2s
+{
+namespace perf
+{
+
+class PMUEventAttr : public EventAttr
+{
+public:
+    PMUEventAttr(struct pmu_event ev) : EventAttr(ev.event, static_cast<perf_type_id>(0), 0)
+    {
+        name_ = ev.name;
+        PMU pmu("cpu");
+
+        struct perf_event_attr pmu_attr = pmu.ev_from_string(ev.event);
+        attr_.type = pmu.type();
+        attr_.config = pmu_attr.config;
+        attr_.config1 = pmu_attr.config1;
+
+        Log::debug() << std::hex << std::showbase << "parsed event description: " << pmu.name()
+                     << "/" << name_ << "/type=" << attr_.type << ",config=" << attr_.config
+                     << ",config1=" << attr_.config1 << std::dec << std::noshowbase << "/";
+
+        if (ev.unit != nullptr)
+        {
+            unit(ev.unit);
+        }
+
+        get_cpu_set_for(*this);
+
+        if (!event_is_openable())
+        {
+            throw EventAttr::InvalidEvent(
+                "Event can not be opened in process- or system-monitoring-mode");
+        }
+    }
+};
+
+class PMUEvents
+{
+public:
+    static const PMUEvents& instance()
+    {
+        static PMUEvents pmu_events;
+        return pmu_events;
+    }
+
+    ~PMUEvents()
+    {
+    }
+
+    EventAttr read_event(const std::string& ev_desc) const
+    {
+        auto ev = get_event_by_name(ev_desc);
+
+        if (!ev.has_value())
+        {
+            throw EventAttr::InvalidEvent("Not a pmu-events event: " + ev_desc);
+        }
+        return PMUEventAttr(ev.value());
+    }
+
+    std::vector<EventAttr> get_events() const
+    {
+        std::vector<EventAttr> events;
+        // TODO realize _real_ multi-cpu handling
+        const struct pmu_events_map* map = map_for_cpu(perf_cpu{ 0 });
+
+        if (map == nullptr)
+        {
+            return events;
+        }
+
+        for (uint32_t i = 0; i < map->event_table.num_pmus; i++)
+        {
+            struct pmu_table_entry entry = map->event_table.pmus[i];
+            struct pmu_event pmu;
+            decompress_event(entry.pmu_name.offset, &pmu);
+
+            for (uint32_t x = 0; x < entry.num_entries; x++)
+            {
+                struct pmu_event ev;
+                decompress_event(entry.entries[x].offset, &ev);
+
+                try
+                {
+                    events.emplace_back(PMUEventAttr(ev));
+                }
+                catch (EventAttr::InvalidEvent& e)
+                {
+                }
+            }
+        }
+
+        return events;
+    }
+
+private:
+    std::optional<struct pmu_event> get_event_by_name(const std::string& ev_desc) const
+    {
+        const struct pmu_events_map* map = map_for_cpu(perf_cpu{ 0 });
+
+        if (map == nullptr)
+        {
+            return std::nullopt;
+        }
+
+        for (uint32_t i = 0; i < map->event_table.num_pmus; i++)
+        {
+            struct pmu_table_entry entry = map->event_table.pmus[i];
+            struct pmu_event pmu;
+            decompress_event(entry.pmu_name.offset, &pmu);
+
+            for (uint32_t x = 0; x < entry.num_entries; x++)
+            {
+                struct pmu_event ev;
+                decompress_event(entry.entries[x].offset, &ev);
+
+                if (ev_desc == ev.name)
+                {
+                    return ev;
+                }
+            }
+        }
+
+        return std::nullopt;
+    }
+};
+
+} // namespace perf
+} // namespace lo2s

--- a/include/lo2s/perf/pmu.hpp
+++ b/include/lo2s/perf/pmu.hpp
@@ -1,0 +1,267 @@
+/*
+ * This file is part of the lo2s software.
+ * Linux OTF2 sampling
+ *
+ * Copyright (c) 2025,
+ *    Technische Universitaet Dresden, Germany
+ *
+ * lo2s is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * lo2s is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with lo2s.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <lo2s/perf/event_attr.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <regex>
+#include <string>
+
+extern "C"
+{
+#include <linux/perf_event.h>
+}
+
+namespace lo2s
+{
+
+namespace perf
+{
+class PMU
+{
+public:
+    PMU(std::string pmu_name) : pmu_name_(pmu_name)
+    {
+
+        pmu_path_ = std::filesystem::path("/sys/bus/event_source/devices") / pmu_name;
+
+        if (!std::filesystem::exists(pmu_path_))
+        {
+            throw EventAttr::InvalidEvent("unknown PMU '" + pmu_name + "'");
+        }
+    }
+
+    template <typename T>
+    std::optional<T> try_read_file(const std::string& filename)
+    {
+        T val;
+        std::ifstream stream(filename);
+        stream >> val;
+        if (stream.fail())
+        {
+            return {};
+        }
+        return val;
+    }
+
+    perf_type_id type()
+    {
+        auto type = try_read_file<std::underlying_type<perf_type_id>::type>(pmu_path_ / "type");
+        return static_cast<perf_type_id>(type.value());
+    }
+
+    std::string name()
+    {
+        return pmu_name_;
+    }
+
+    double scale(std::string specific_event)
+    {
+        return try_read_file<double>(event_path(specific_event).replace_extension(".scale"))
+            .value_or(1.0);
+    }
+
+    std::string unit(std::string specific_event)
+    {
+        return try_read_file<std::string>(event_path(specific_event).replace_extension(".unit"))
+            .value_or("#");
+    }
+
+    std::filesystem::path event_path(std::string specific_event)
+    {
+        return pmu_path_ / "events" / specific_event;
+    }
+
+    struct perf_event_attr ev_from_name(std::string specific_event)
+    {
+
+        // read event configuration
+        auto ev_cfg = try_read_file<std::string>(event_path(specific_event));
+        if (!ev_cfg.has_value())
+        {
+            using namespace std::string_literals;
+            throw EventAttr::InvalidEvent("unknown event '"s + specific_event + "' for PMU '"s +
+                                          pmu_name_ + "'");
+        }
+
+        return ev_from_string(ev_cfg.value());
+    }
+
+    struct perf_event_attr ev_from_string(std::string ev_string)
+    {
+        struct perf_event_attr attr;
+        memset(&attr, 0, sizeof(attr));
+
+        // Parse event configuration from sysfs //
+
+        /* Event configuration format:
+         *   One or more terms with optional values, separated by ','.  (Taken from
+         *   linux/Documentation/ABI/testing/sysfs-bus-event_source-devices-events):
+         *
+         *     <term>[=<value>][,<term>[=<value>]...]
+         *
+         *   Example (config for 'cpu/cache-misses' on an Intel Core i5-7200U):
+         *
+         *     event=0x2e,umask=0x41
+         *
+         *  */
+
+        enum EVENT_CONFIG_REGEX_GROUPS
+        {
+            EC_WHOLE_MATCH,
+            EC_TERM,
+            EC_VALUE,
+        };
+
+        static const std::regex kv_regex(R"(([^=,]+)(?:=([^,]+))?)");
+
+        Log::debug() << "parsing event configuration: " << ev_string;
+        std::smatch kv_match;
+        while (std::regex_search(ev_string, kv_match, kv_regex))
+        {
+            static const std::string default_value("0x1");
+
+            const std::string& term = kv_match[EC_TERM];
+            const std::string& value =
+                (kv_match[EC_VALUE].length() != 0) ? kv_match[EC_VALUE] : default_value;
+
+            auto format = try_read_file<std::string>(pmu_path_ / "format" / term);
+            if (!format.has_value())
+            {
+                throw EventAttr::InvalidEvent("cannot read event format");
+            }
+
+            static_assert(sizeof(std::uint64_t) >= sizeof(unsigned long),
+                          "May not convert from unsigned long to uint64_t!");
+
+            std::uint64_t val = std::stol(value, nullptr, 0);
+            Log::debug() << "parsing config assignment: " << term << " = " << std::hex
+                         << std::showbase << val << std::dec << std::noshowbase;
+            event_attr_update(attr, val, format.value());
+
+            ev_string = kv_match.suffix();
+        }
+        return attr;
+    }
+
+    void event_attr_update(struct perf_event_attr& attr, std::uint64_t value,
+                           const std::string& format)
+    {
+        // Parse config terms //
+
+        /* Format:  <term>:<bitmask>
+         *
+         * We only assign the terms 'config' and 'config1'.
+         *
+         * */
+
+        static constexpr auto npos = std::string::npos;
+        const auto colon = format.find_first_of(':');
+        if (colon == npos)
+        {
+            throw EventAttr::InvalidEvent("invalid format description: missing colon");
+        }
+
+        const auto target_config = format.substr(0, colon);
+        const auto mask = parse_bitmask(format.substr(colon + 1));
+
+        if (target_config == "config")
+        {
+            attr.config |= apply_mask(value, mask);
+        }
+
+        if (target_config == "config1")
+        {
+            attr.config1 |= apply_mask(value, mask);
+        }
+    }
+
+    std::uint64_t apply_mask(std::uint64_t value, std::uint64_t mask)
+    {
+        std::uint64_t res = 0;
+        for (int mask_bit = 0, value_bit = 0; mask_bit < 64; mask_bit++)
+        {
+            if (mask & (1ull << mask_bit))
+            {
+                res |= ((value >> value_bit) & (1ull << 0)) << mask_bit;
+                value_bit++;
+            }
+        }
+        return res;
+    }
+
+    std::uint64_t parse_bitmask(const std::string& format)
+    {
+        enum BITMASK_REGEX_GROUPS
+        {
+            BM_WHOLE_MATCH,
+            BM_BEGIN,
+            BM_END,
+        };
+
+        std::uint64_t mask = 0x0;
+
+        static const std::regex bit_mask_regex(R"((\d+)?(?:-(\d+)))");
+        const std::sregex_iterator end;
+        for (std::sregex_iterator i = { format.begin(), format.end(), bit_mask_regex }; i != end;
+             ++i)
+        {
+            const auto& match = *i;
+            int start = std::stoi(match[BM_BEGIN]);
+            int end = (match[BM_END].length() == 0) ? start : std::stoi(match[BM_END]);
+
+            const auto len = (end + 1) - start;
+            if (start < 0 || end > 63 || len > 64)
+            {
+                throw EventAttr::InvalidEvent("invalid config mask");
+            }
+
+            /* Set `len` bits and shift them to where they should start.
+             * 4-bit example: format "1-3" produces mask 0b1110.
+             *    start := 1, end := 3
+             *    len  := 3 + 1 - 1 = 3
+             *    bits := bit(3) - 1 = 0b1000 - 1 = 0b0111
+             *    mask := 0b0111 << 1 = 0b1110
+             * */
+
+            // Shifting by 64 bits causes undefined behaviour, so in this case set
+            // all bits by assigning the maximum possible value for std::uint64_t.
+            const std::uint64_t bits =
+                (len == 64) ? std::numeric_limits<std::uint64_t>::max() : (1ull << len) - 1;
+
+            mask |= bits << start;
+        }
+        Log::debug() << std::showbase << std::hex << "config mask: " << format << " = " << mask
+                     << std::dec << std::noshowbase;
+        return mask;
+    }
+
+private:
+    std::string pmu_name_;
+    std::filesystem::path pmu_path_;
+};
+
+} // namespace perf
+} // namespace lo2s

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -29,6 +29,8 @@
 #ifdef HAVE_LIBPFM
 #include <lo2s/perf/pfm.hpp>
 #endif
+
+#include <lo2s/perf/pmu-events.hpp>
 #include <lo2s/perf/tracepoint/format.hpp>
 #include <lo2s/perf/util.hpp>
 #include <lo2s/platform.hpp>
@@ -565,6 +567,8 @@ void parse_program_options(int argc, const char** argv)
             print_availability(std::cout, "Libpfm events",
                                perf::PFM4::instance().get_pfm4_events());
 #endif
+            print_availability(std::cout, "perf PMU events",
+                               perf::PMUEvents::instance().get_events());
 
             std::cout << "(* Only available in process-monitoring mode" << std::endl;
             std::cout << "(# Only available in system-monitoring mode" << std::endl;

--- a/src/perf/event_attr.cpp
+++ b/src/perf/event_attr.cpp
@@ -22,13 +22,11 @@
 #include <lo2s/build_config.hpp>
 #include <lo2s/perf/event_attr.hpp>
 #include <lo2s/perf/event_resolver.hpp>
-
+#include <lo2s/perf/pmu.hpp>
 #include <lo2s/topology.hpp>
 #include <lo2s/util.hpp>
 
 #include <nitro/lang/string.hpp>
-
-#include <optional>
 
 extern "C"
 {
@@ -41,7 +39,7 @@ namespace lo2s
 namespace perf
 {
 
-std::set<Cpu> get_cpu_set_for(EventAttr ev)
+std::set<Cpu> EventAttr::get_cpu_set_for(EventAttr ev)
 {
     std::set<Cpu> cpus = std::set<Cpu>();
 
@@ -59,78 +57,6 @@ std::set<Cpu> get_cpu_set_for(EventAttr ev)
     }
 
     return cpus;
-}
-
-template <typename T>
-std::optional<T> try_read_file(const std::string& filename)
-{
-    T val;
-    std::ifstream stream(filename);
-    stream >> val;
-    if (stream.fail())
-    {
-        return {};
-    }
-    return val;
-}
-
-static std::uint64_t parse_bitmask(const std::string& format)
-{
-    enum BITMASK_REGEX_GROUPS
-    {
-        BM_WHOLE_MATCH,
-        BM_BEGIN,
-        BM_END,
-    };
-
-    std::uint64_t mask = 0x0;
-
-    static const std::regex bit_mask_regex(R"((\d+)?(?:-(\d+)))");
-    const std::sregex_iterator end;
-    for (std::sregex_iterator i = { format.begin(), format.end(), bit_mask_regex }; i != end; ++i)
-    {
-        const auto& match = *i;
-        int start = std::stoi(match[BM_BEGIN]);
-        int end = (match[BM_END].length() == 0) ? start : std::stoi(match[BM_END]);
-
-        const auto len = (end + 1) - start;
-        if (start < 0 || end > 63 || len > 64)
-        {
-            throw EventAttr::InvalidEvent("invalid config mask");
-        }
-
-        /* Set `len` bits and shift them to where they should start.
-         * 4-bit example: format "1-3" produces mask 0b1110.
-         *    start := 1, end := 3
-         *    len  := 3 + 1 - 1 = 3
-         *    bits := bit(3) - 1 = 0b1000 - 1 = 0b0111
-         *    mask := 0b0111 << 1 = 0b1110
-         * */
-
-        // Shifting by 64 bits causes undefined behaviour, so in this case set
-        // all bits by assigning the maximum possible value for std::uint64_t.
-        const std::uint64_t bits =
-            (len == 64) ? std::numeric_limits<std::uint64_t>::max() : (1ull << len) - 1;
-
-        mask |= bits << start;
-    }
-    Log::debug() << std::showbase << std::hex << "config mask: " << format << " = " << mask
-                 << std::dec << std::noshowbase;
-    return mask;
-}
-
-static constexpr std::uint64_t apply_mask(std::uint64_t value, std::uint64_t mask)
-{
-    std::uint64_t res = 0;
-    for (int mask_bit = 0, value_bit = 0; mask_bit < 64; mask_bit++)
-    {
-        if (mask & (1ull << mask_bit))
-        {
-            res |= ((value >> value_bit) & (1ull << 0)) << mask_bit;
-            value_bit++;
-        }
-    }
-    return res;
 }
 
 EventAttr::EventAttr(const std::string& name, perf_type_id type, std::uint64_t config,
@@ -155,37 +81,6 @@ PredefinedEventAttr::PredefinedEventAttr(const std::string& name, perf_type_id t
     cpus_ = get_cpu_set_for(*this);
 
     event_is_openable();
-}
-
-void EventAttr::event_attr_update(std::uint64_t value, const std::string& format)
-{
-    // Parse config terms //
-
-    /* Format:  <term>:<bitmask>
-     *
-     * We only assign the terms 'config' and 'config1'.
-     *
-     * */
-
-    static constexpr auto npos = std::string::npos;
-    const auto colon = format.find_first_of(':');
-    if (colon == npos)
-    {
-        throw EventAttr::InvalidEvent("invalid format description: missing colon");
-    }
-
-    const auto target_config = format.substr(0, colon);
-    const auto mask = parse_bitmask(format.substr(colon + 1));
-
-    if (target_config == "config")
-    {
-        attr_.config |= apply_mask(value, mask);
-    }
-
-    if (target_config == "config1")
-    {
-        attr_.config1 |= apply_mask(value, mask);
-    }
 }
 
 void EventAttr::sample_period(int period)
@@ -570,56 +465,24 @@ SysfsEventAttr::SysfsEventAttr(const std::string& ev_name)
         pmu_path = std::filesystem::path();
     }
 
-    name_ = ev_name_match[2];
-    std::string pmu_name = ev_name_match[1];
-    pmu_path = std::filesystem::path("/sys/bus/event_source/devices") / pmu_name;
+    PMU pmu(ev_name_match[1]);
+    std::string specific_event = ev_name_match[2];
 
-    Log::debug() << "parsing event description: pmu='" << pmu_name << "', event='" << name_ << "'";
+    Log::debug() << "parsing event description: pmu='" << pmu.name() << "', event='" << name_
+                 << "'";
 
-    // read PMU type id
-    auto type = try_read_file<std::underlying_type<perf_type_id>::type>(pmu_path / "type");
+    struct perf_event_attr pmu_attr = pmu.ev_from_name(specific_event);
 
-    if (!type.has_value())
-    {
-        using namespace std::string_literals;
-        throw EventAttr::InvalidEvent("unknown PMU '"s + pmu_name + "'");
-    }
+    attr_.type = pmu.type();
+    attr_.config = pmu_attr.config;
+    attr_.config1 = pmu_attr.config1;
 
-    attr_.type = static_cast<perf_type_id>(type.value());
-    attr_.config = 0;
-    attr_.config1 = 0;
+    Log::debug() << std::hex << std::showbase << "parsed event description: " << pmu.name() << "/"
+                 << name_ << "/type=" << attr_.type << ",config=" << attr_.config
+                 << ",config1=" << attr_.config1 << std::dec << std::noshowbase << "/";
 
-    // Parse event configuration from sysfs //
-
-    // read event configuration
-    std::filesystem::path event_path = pmu_path / "events" / name_;
-    auto ev_cfg = try_read_file<std::string>(event_path);
-    if (!ev_cfg.has_value())
-    {
-        using namespace std::string_literals;
-        throw EventAttr::InvalidEvent("unknown event '"s + name_ + "' for PMU '"s + pmu_name + "'");
-    }
-
-    name_ = ev_name;
-
-    /* Event configuration format:
-     *   One or more terms with optional values, separated by ','.  (Taken from
-     *   linux/Documentation/ABI/testing/sysfs-bus-event_source-devices-events):
-     *
-     *     <term>[=<value>][,<term>[=<value>]...]
-     *
-     *   Example (config for 'cpu/cache-misses' on an Intel Core i5-7200U):
-     *
-     *     event=0x2e,umask=0x41
-     *
-     *  */
-
-    enum EVENT_CONFIG_REGEX_GROUPS
-    {
-        EC_WHOLE_MATCH,
-        EC_TERM,
-        EC_VALUE,
-    };
+    scale(pmu.scale(specific_event));
+    unit(pmu.unit(specific_event));
 
     // If the processor is heterogenous, "cpus" contains the cores that support this PMU. If the
     // PMU is an uncore PMU "cpumask" contains the cores that are logically assigned to that
@@ -641,42 +504,6 @@ SysfsEventAttr::SysfsEventAttr(const std::string& ev_name)
         std::transform(cpuids.begin(), cpuids.end(), std::inserter(cpus_, cpus_.end()),
                        [](uint32_t cpuid) { return Cpu(cpuid); });
     }
-
-    static const std::regex kv_regex(R"(([^=,]+)(?:=([^,]+))?)");
-
-    Log::debug() << "parsing event configuration: " << ev_cfg.value();
-    std::smatch kv_match;
-    while (std::regex_search(ev_cfg.value(), kv_match, kv_regex))
-    {
-        static const std::string default_value("0x1");
-
-        const std::string& term = kv_match[EC_TERM];
-        const std::string& value =
-            (kv_match[EC_VALUE].length() != 0) ? kv_match[EC_VALUE] : default_value;
-
-        auto format = try_read_file<std::string>(pmu_path / "format" / term);
-        if (!format.has_value())
-        {
-            throw EventAttr::InvalidEvent("cannot read event format");
-        }
-
-        static_assert(sizeof(std::uint64_t) >= sizeof(unsigned long),
-                      "May not convert from unsigned long to uint64_t!");
-
-        std::uint64_t val = std::stol(value, nullptr, 0);
-        Log::debug() << "parsing config assignment: " << term << " = " << std::hex << std::showbase
-                     << val << std::dec << std::noshowbase;
-        event_attr_update(val, format.value());
-
-        ev_cfg = kv_match.suffix();
-    }
-
-    Log::debug() << std::hex << std::showbase << "parsed event description: " << pmu_name << "/"
-                 << name_ << "/type=" << attr_.type << ",config=" << attr_.config
-                 << ",config1=" << attr_.config1 << std::dec << std::noshowbase << "/";
-
-    scale(try_read_file<double>(event_path.replace_extension(".scale")).value_or(1.0));
-    unit(try_read_file<std::string>(event_path.replace_extension(".unit")).value_or("#"));
 
     if (!event_is_openable())
     {

--- a/src/perf/event_resolver.cpp
+++ b/src/perf/event_resolver.cpp
@@ -27,6 +27,7 @@
 #include <lo2s/perf/pfm.hpp>
 #endif
 #include <lo2s/perf/event_resolver.hpp>
+#include <lo2s/perf/pmu-events.hpp>
 #include <lo2s/perf/util.hpp>
 #include <lo2s/topology.hpp>
 #include <lo2s/util.hpp>
@@ -312,6 +313,14 @@ EventAttr EventResolver::cache_event(const std::string& name)
             {
             }
 #endif
+            try
+            {
+                EventAttr ev = PMUEvents::instance().read_event(name);
+                return event_map_.emplace(name, ev).first->second.value();
+            }
+            catch (EventAttr::InvalidEvent& e)
+            {
+            }
 
             std::optional<EventAttr> ev = SysfsEventAttr(name);
             return event_map_.emplace(name, ev).first->second.value();


### PR DESCRIPTION
This adds support for pmu-events from the Linux kernel, as discussed in issue 379.

"pmu-events" is the folder on the Linux kernel source code that contains the list of all in-built events for the perf command. In github.com/cvonelm/pmu-events (should probably be moved to tud-zih-energy)
I've separated the code from the kernel and made it externally usable.

This commit adds the ability to get event names via pmu-events to lo2s.


**List of lo2s events**

```bash
./lo2s --list-events | tr -d "#" \ # Remove "Only available in per-process/per-system mode" info
 | grep '^ '  \ #Only match lines beginning with a space, e.g. events
 | tr -d ' '   \ # Trim whitespaces
 | grep -v "::" \ # Remove PFM4 events. Both lo2s and perf support those and they are exactly the same
 | sort -u > filtered_events_lo2s
```
**List of perf events**
```bash
# jq is awesome, the line there does the following things:
# .[] take the elements of the list
# Filter those where
#      - EventType is PFM event (we dont need those, bot lo2s and perf do libpfm
#      - EventType is "SDT event" Statically Defined Tracepoint (not relevant to Hardware Events)
#      - EventType is Raw Event Descriptor (e.g. "specifying r0124)
#      - Topic is tool (tool defined events)
#       - Topic is Hardware Breakpoint definition
#       - Topic is hwmon (not perf)
 perf list -j  \ #List events in JSON format
 | jq -r '.[] |  select(.EventType != "PFM event") | select(.EventType != "SDT event") |select(.EventType != "Raw event descriptor") | select(.Topic != "tool") | select(.EventType != "Hardware breakpoint") | select(.Topic != "hwmon") |.EventName'  \
 | grep -v "null" \ # Remove null values
 |sort -u > filtered_events_perf
 ```
 
```bash
diff filtered_events_lo2s filtered_events_perf
```

 ```diff
 --- filtered_events_lo2s	2025-09-25 15:47:37.310560806 +0200
+++ ../filtered_events_perf	2025-09-25 15:43:36.086173764 +0200
@@ -50,16 +50,9 @@
 cache-references
 cgroup-switches
 context-switches
-cpu/branch-instructions/
-cpu/branch-misses/
-cpu/cache-misses/
-cpu/cache-references/
 cpu-clock
-cpu/cpu-cycles/
 cpu-cycles
-cpu/instructions/
 cpu-migrations
-cpu/stalled-cycles-frontend/
 de_dis_cops_from_decoder.disp_op_type.any_fp_dispatch
 de_dis_cops_from_decoder.disp_op_type.any_integer_dispatch
 de_dis_dispatch_token_stalls1.fp_flush_recovery_stall
@@ -77,14 +70,6 @@
 de_dis_dispatch_token_stalls2.int_sch3_token_stall
 de_dis_dispatch_token_stalls2.retire_token_stall
 de_dis_uop_queue_empty_di0
-dram_channel_data_controller_0
-dram_channel_data_controller_1
-dram_channel_data_controller_2
-dram_channel_data_controller_3
-dram_channel_data_controller_4
-dram_channel_data_controller_5
-dram_channel_data_controller_6
-dram_channel_data_controller_7
 dTLB-load-misses
 dTLB-loads
 dummy
@@ -208,12 +193,6 @@
 l2_wcb_req.wcb_close
 l2_wcb_req.wcb_write
 l2_wcb_req.zero_byte_store
-l3_cache_accesses
-l3_comb_clstr_state.other_l3_miss_typs
-l3_comb_clstr_state.request_miss
-l3_lookup_state.all_l3_req_typs
-l3_misses
-l3_request_g1.caching_l3_cache_accesses
 ls_alloc_mab_count
 ls_any_fills_from_sys.ext_cache_local
 ls_any_fills_from_sys.ext_cache_remote
@@ -299,12 +278,6 @@
 page-faults
 power_core/energy-core/
 power/energy-pkg/
-remote_outbound_data_controller_0
-remote_outbound_data_controller_1
-remote_outbound_data_controller_2
-remote_outbound_data_controller_3
 sse_avx_stalls
 stalled-cycles-frontend
 task-clock
-xi_ccx_sdp_req1
-xi_sys_fill_latency
```

Red means in lo2s, but not in perf.

At least according to the listing, we can now do __all the events perf does__.

This closes #29