### PR TITLE
Make region a function range

### DIFF
--- a/cmake/FindDebuginfod.cmake
+++ b/cmake/FindDebuginfod.cmake
@@ -9,7 +9,8 @@ option(Debuginfod_USE_STATIC_LIBS "Link debuginfod statically." OFF)
 
 UnsetIfUpdated(Debuginfod_LIBRARY Debuginfod_USE_STATIC_LIBS)
 
-find_path(Debuginfod_INCLUDE_DIRS libelf.h
+find_path(Debuginfod_INCLUDE_DIRS
+    NAMES debuginfod.h elfutils/debuginfod.h
     PATHS ENV C_INCLUDE_PATH ENV CPATH
     PATH_SUFFIXES include)
 

--- a/include/lo2s/line_info.hpp
+++ b/include/lo2s/line_info.hpp
@@ -12,6 +12,27 @@
 
 namespace lo2s
 {
+struct FunctionInfo
+{
+    std::string file;
+    std::string function;
+    unsigned int begin_line;
+    unsigned int end_line;
+    std::string dso;
+
+    bool operator<(const FunctionInfo& other) const
+    {
+        return std::tie(file, function, begin_line, end_line, dso) <
+               std::tie(other.file, other.function, other.begin_line, other.end_line, other.dso);
+    }
+
+    bool operator==(const FunctionInfo& other) const
+    {
+        return std::tie(file, function, begin_line, end_line, dso) ==
+               std::tie(other.file, other.function, other.begin_line, other.end_line, other.dso);
+    }
+};
+
 struct LineInfo
 {
 private:
@@ -20,24 +41,40 @@ private:
     // Note: If line is not known, we write 1 anyway so the rest is shown in vampir
     // phijor 2018-11-08: I think this workaround is not needed anymore? vampir
     // shows source code locations with line == 0 just fine.
-    LineInfo(std::string file, std::string function, unsigned int line, std::string dso)
+    static unsigned int normalize_line(unsigned int line)
+    {
+        return (line != UNKNOWN_LINE) ? line : 1;
+    }
+
+    LineInfo(std::string file, std::string function, unsigned int line, std::string dso,
+             unsigned int function_begin_line = UNKNOWN_LINE,
+             unsigned int function_end_line = UNKNOWN_LINE, std::string function_file = "")
     : file(std::move(file)), function(std::move(function)), line((line != UNKNOWN_LINE) ? line : 1),
-      dso(std::move(dso))
+      dso(std::move(dso)), function_begin_line(normalize_line(function_begin_line)),
+      function_end_line(function_end_line), function_file(std::move(function_file))
     {
     }
 
-    LineInfo(const char* file, const char* function, unsigned int line, std::string dso)
-    : file(file), function(function), line((line != UNKNOWN_LINE) ? line : 1), dso(std::move(dso))
+    LineInfo(const char* file, const char* function, unsigned int line, std::string dso,
+             unsigned int function_begin_line = UNKNOWN_LINE,
+             unsigned int function_end_line = UNKNOWN_LINE, std::string function_file = "")
+    : file(file), function(function), line((line != UNKNOWN_LINE) ? line : 1),
+      dso(std::move(dso)), function_begin_line(normalize_line(function_begin_line)),
+      function_end_line(function_end_line), function_file(std::move(function_file))
     {
     }
 
 public:
     static LineInfo for_function(const char* file, const char* function, unsigned int line,
-                                 const std::string& dso)
+                                 const std::string& dso,
+                                 unsigned int function_begin_line = UNKNOWN_LINE,
+                                 unsigned int function_end_line = UNKNOWN_LINE,
+                                 const char* function_file = nullptr)
     {
         return { (file != nullptr) ? file : "<unknown file>",
                  (function != nullptr) ? function : "<unknown function>", line,
-                 std::filesystem::path(dso).filename().string() };
+                 std::filesystem::path(dso).filename().string(), function_begin_line,
+                 function_end_line, (function_file != nullptr) ? function_file : "" };
     }
 
     static LineInfo for_unknown_function()
@@ -60,18 +97,31 @@ public:
     std::string function;
     unsigned int line;
     std::string dso;
+    unsigned int function_begin_line;
+    unsigned int function_end_line;
+    std::string function_file;
+
+    FunctionInfo function_info() const
+    {
+        return { function_file.empty() ? file : function_file, function, function_begin_line,
+                 function_end_line, dso };
+    }
 
     // For std::map
     bool operator<(const LineInfo& other) const
     {
-        return std::tie(file, function, line, dso) <
-               std::tie(other.file, other.function, other.line, dso);
+        return std::tie(file, function, line, dso, function_begin_line, function_end_line,
+                        function_file) <
+               std::tie(other.file, other.function, other.line, other.dso,
+                        other.function_begin_line, other.function_end_line, other.function_file);
     }
 
     bool operator==(const LineInfo& other) const
     {
-        return std::tie(file, function, line, dso) ==
-               std::tie(other.file, other.function, other.line, dso);
+        return std::tie(file, function, line, dso, function_begin_line, function_end_line,
+                        function_file) ==
+               std::tie(other.file, other.function, other.line, other.dso,
+                        other.function_begin_line, other.function_end_line, other.function_file);
     }
 };
 

--- a/include/lo2s/trace/reg_keys.hpp
+++ b/include/lo2s/trace/reg_keys.hpp
@@ -108,6 +108,12 @@ struct ByLineInfoTag
 
 using ByLineInfo = SimpleKeyType<LineInfo, ByLineInfoTag>;
 
+struct ByFunctionInfoTag
+{
+};
+
+using ByFunctionInfo = SimpleKeyType<FunctionInfo, ByFunctionInfoTag>;
+
 struct ByExecutionScopeTag
 {
 };
@@ -217,7 +223,7 @@ template <>
 struct Holder<otf2::definition::region>
 {
     using type = otf2::lookup_definition_holder<otf2::definition::region, ByProcess, ByThread,
-                                                ByLineInfo, BySyscall>;
+                                                ByLineInfo, ByFunctionInfo, BySyscall>;
 };
 
 template <>

--- a/src/dwarf_resolve.cpp
+++ b/src/dwarf_resolve.cpp
@@ -80,75 +80,105 @@ int find_containing_func_for_addr(Dwarf_Die* d, void* arg)
     return DWARF_CB_OK;
 }
 
-function_source_info source_info_for_function(Dwarf_Die* cudie, Dwarf_Die* function_die,
+function_source_info source_info_for_function(Dwarf_Die* cudie,
+                                              Dwarf_Die* function_die,
                                               const char* fallback_source_file)
 {
     int decl_line = 0;
-    if (dwarf_decl_line(function_die, &decl_line) != 0)
-    {
+    if (dwarf_decl_line(function_die, &decl_line) != 0 || decl_line < 0)
         decl_line = 0;
-    }
 
     const char* decl_file = dwarf_decl_file(function_die);
-    const char* source_file = (decl_file != nullptr) ? decl_file : fallback_source_file;
-    std::string source_file_string = (source_file != nullptr) ? source_file : "";
+    const char* source_file = decl_file ? decl_file : fallback_source_file;
 
-    Dwarf_Addr low_pc = 0;
-    Dwarf_Addr high_pc = 0;
-    if (dwarf_lowpc(function_die, &low_pc) != 0 || dwarf_highpc(function_die, &high_pc) != 0)
-    {
-        return { source_file_string, static_cast<unsigned int>(decl_line), 0 };
-    }
+    const std::string source_file_string = source_file ? source_file : "";
+    const std::optional<std::string> source_file_filter =
+        source_file ? std::optional<std::string>{source_file} : std::nullopt;
 
     Dwarf_Lines* lines = nullptr;
     size_t nlines = 0;
     if (dwarf_getsrclines(cudie, &lines, &nlines) != 0)
     {
-        return { source_file_string, static_cast<unsigned int>(decl_line), 0 };
+        return {
+            source_file_string,
+            static_cast<unsigned int>(std::max(decl_line, 0)),
+            0
+        };
     }
 
     int first_line = std::numeric_limits<int>::max();
     int last_line = 0;
+
+    auto addr_in_function = [&](Dwarf_Addr addr) -> bool {
+        Dwarf_Addr base = 0;
+        Dwarf_Addr begin = 0;
+        Dwarf_Addr end = 0;
+
+        ptrdiff_t off = 0;
+        while ((off = dwarf_ranges(function_die, off, &base, &begin, &end)) > 0)
+        {
+            if (addr >= begin && addr < end)
+                return true;
+        }
+
+        return false;
+    };
+
     for (size_t i = 0; i < nlines; ++i)
     {
         Dwarf_Line* line = dwarf_onesrcline(lines, i);
+        if (!line)
+            continue;
+
+        // Optional but usually correct: ignore end-of-sequence marker rows.
+        bool end_sequence = false;
+        if (dwarf_lineendsequence(line, &end_sequence) == 0 && end_sequence)
+            continue;
 
         Dwarf_Addr line_addr = 0;
-        if (line == nullptr || dwarf_lineaddr(line, &line_addr) != 0 || line_addr < low_pc ||
-            line_addr >= high_pc)
-        {
+        if (dwarf_lineaddr(line, &line_addr) != 0)
             continue;
-        }
+
+        if (!addr_in_function(line_addr))
+            continue;
 
         const char* line_source_file = dwarf_linesrc(line, nullptr, nullptr);
-        if (source_file != nullptr && line_source_file != nullptr &&
-            std::string(source_file) != line_source_file)
+
+        if (source_file_filter)
         {
-            continue;
+            if (!line_source_file)
+                continue;
+
+            if (*source_file_filter != line_source_file)
+                continue;
         }
 
         int lineno = 0;
         if (dwarf_lineno(line, &lineno) != 0 || lineno <= 0)
-        {
             continue;
-        }
 
         first_line = std::min(first_line, lineno);
         last_line = std::max(last_line, lineno);
     }
 
+    const bool found_line_rows = first_line != std::numeric_limits<int>::max();
+
     if (decl_line > 0)
     {
-        first_line = std::min(first_line, decl_line);
+        first_line = found_line_rows ? std::min(first_line, decl_line) : decl_line;
+
+        if (last_line == 0)
+            last_line = decl_line;
     }
 
     if (first_line == std::numeric_limits<int>::max())
-    {
-        first_line = decl_line;
-    }
+        first_line = 0;
 
-    return { source_file_string, static_cast<unsigned int>(first_line),
-             static_cast<unsigned int>(last_line) };
+    return {
+        source_file_string,
+        static_cast<unsigned int>(first_line),
+        static_cast<unsigned int>(last_line)
+    };
 }
 
 std::unique_ptr<Indicator> bar;

--- a/src/dwarf_resolve.cpp
+++ b/src/dwarf_resolve.cpp
@@ -14,6 +14,8 @@
 
 #include <nitro/log/severity.hpp>
 
+#include <algorithm>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <string>
@@ -26,7 +28,11 @@
 #ifdef HAVE_DEBUGINFOD
 extern "C"
 {
+#if __has_include(<elfutils/debuginfod.h>)
 #include <elfutils/debuginfod.h>
+#else
+#include <debuginfod.h>
+#endif
 }
 #endif
 
@@ -38,6 +44,14 @@ struct getfuncs_arg
 {
     Dwarf_Addr addr;
     std::string name;
+    Dwarf_Die die;
+};
+
+struct function_source_info
+{
+    std::string file;
+    unsigned int begin_line;
+    unsigned int end_line;
 };
 
 /*
@@ -59,10 +73,82 @@ int find_containing_func_for_addr(Dwarf_Die* d, void* arg)
         {
             args->name = name;
         }
+        args->die = *d;
         return DWARF_CB_ABORT;
     }
 
     return DWARF_CB_OK;
+}
+
+function_source_info source_info_for_function(Dwarf_Die* cudie, Dwarf_Die* function_die,
+                                              const char* fallback_source_file)
+{
+    int decl_line = 0;
+    if (dwarf_decl_line(function_die, &decl_line) != 0)
+    {
+        decl_line = 0;
+    }
+
+    const char* decl_file = dwarf_decl_file(function_die);
+    const char* source_file = (decl_file != nullptr) ? decl_file : fallback_source_file;
+    std::string source_file_string = (source_file != nullptr) ? source_file : "";
+
+    Dwarf_Addr low_pc = 0;
+    Dwarf_Addr high_pc = 0;
+    if (dwarf_lowpc(function_die, &low_pc) != 0 || dwarf_highpc(function_die, &high_pc) != 0)
+    {
+        return { source_file_string, static_cast<unsigned int>(decl_line), 0 };
+    }
+
+    Dwarf_Lines* lines = nullptr;
+    size_t nlines = 0;
+    if (dwarf_getsrclines(cudie, &lines, &nlines) != 0)
+    {
+        return { source_file_string, static_cast<unsigned int>(decl_line), 0 };
+    }
+
+    int first_line = std::numeric_limits<int>::max();
+    int last_line = 0;
+    for (size_t i = 0; i < nlines; ++i)
+    {
+        Dwarf_Line* line = dwarf_onesrcline(lines, i);
+
+        Dwarf_Addr line_addr = 0;
+        if (line == nullptr || dwarf_lineaddr(line, &line_addr) != 0 || line_addr < low_pc ||
+            line_addr >= high_pc)
+        {
+            continue;
+        }
+
+        const char* line_source_file = dwarf_linesrc(line, nullptr, nullptr);
+        if (source_file != nullptr && line_source_file != nullptr &&
+            std::string(source_file) != line_source_file)
+        {
+            continue;
+        }
+
+        int lineno = 0;
+        if (dwarf_lineno(line, &lineno) != 0 || lineno <= 0)
+        {
+            continue;
+        }
+
+        first_line = std::min(first_line, lineno);
+        last_line = std::max(last_line, lineno);
+    }
+
+    if (decl_line > 0)
+    {
+        first_line = std::min(first_line, decl_line);
+    }
+
+    if (first_line == std::numeric_limits<int>::max())
+    {
+        first_line = decl_line;
+    }
+
+    return { source_file_string, static_cast<unsigned int>(first_line),
+             static_cast<unsigned int>(last_line) };
 }
 
 std::unique_ptr<Indicator> bar;
@@ -226,9 +312,15 @@ LineInfo DwarfFunctionResolver::lookup_line_info(Address addr)
 
                 if (!arg.name.empty())
                 {
+                    const auto function_source =
+                        source_info_for_function(cudie, &arg.die, srcname);
+
                     return cache_
                         .emplace(addr, LineInfo::for_function(srcname, arg.name.c_str(), lineno,
-                                                              module_name))
+                                                              module_name,
+                                                              function_source.begin_line,
+                                                              function_source.end_line,
+                                                              function_source.file.c_str()))
                         .first->second;
                 }
             }

--- a/src/trace/trace.cpp
+++ b/src/trace/trace.cpp
@@ -1105,11 +1105,13 @@ const otf2::definition::source_code_location& Trace::intern_scl(const LineInfo& 
 
 const otf2::definition::region& Trace::intern_region(const LineInfo& info)
 {
+    const auto function_info = info.function_info();
     const auto& name_str = intern(info.function);
     const auto& region = registry_.emplace<otf2::definition::region>(
-        ByLineInfo(info), name_str, name_str, name_str, otf2::common::role_type::function,
-        otf2::common::paradigm_type::sampling, otf2::common::flags_type::none, intern(info.file),
-        info.line, 0);
+        ByFunctionInfo(function_info), name_str, name_str, name_str,
+        otf2::common::role_type::function, otf2::common::paradigm_type::sampling,
+        otf2::common::flags_type::none, intern(function_info.file), function_info.begin_line,
+        function_info.end_line);
 
     if (registry_.has<otf2::definition::regions_group>(ByString(info.dso)))
     {


### PR DESCRIPTION
Vibe-coded solution to https://github.com/tud-zih-energy/lo2s/issues/415 .

Examples focuses on `__vasprintf_internal`.

```
[...]
REGION                                39  Name: "opal_dl_lookup" <256> (Aka. "opal_dl_lookup" <256>), Descr.: "opal_dl_lookup" <256>, Role: FUNCTION, Paradigm: SAMPLING, Flags: NONE, File: "/usr/lib/x86_64-linux-gnu/libopen-pal.so.40.30.2" <153>, Begin: 1, End: 0
REGION                                40  Name: "__vasprintf_internal" <259> (Aka. "__vasprintf_internal" <259>), Descr.: "__vasprintf_internal" <259>, Role: FUNCTION, Paradigm: SAMPLING, Flags: NONE, File: "./libio/vasprintf.c" <258>, Begin: 32, End: 85
REGION                                41  Name: "_IO_new_file_underflow" <262> (Aka. "_IO_new_file_underflow" <262>), Descr.: "_IO_new_file_underflow" <262>, Role: FUNCTION, Paradigm: SAMPLING, Flags: NONE, File: "./libio/fileops.c" <261>, Begin: 460, End: 537
REGION                                42  Name: "_IO_old_init" <265> (Aka. "_IO_old_init" <265>), Descr.: "_IO_old_init" <265>, Role: FUNCTION, Paradigm: SAMPLING, Flags: NONE, File: "./libio/genops.c" <264>, Begin: 530, End: 558
[...]
CALLING_CONTEXT                      148  Region: "opal_dl_lookup" <39>, Source code location: "/usr/lib/x86_64-linux-gnu/libopen-pal.so.40.30.2:1" <42>, Parent: "<unknown function>@<unknown file>:1" <9>
CALLING_CONTEXT                      149  Region: "__vasprintf_internal" <40>, Source code location: "./libio/vasprintf.c:65" <43>, Parent: "<unknown function>@<unknown file>:1" <9>
CALLING_CONTEXT                      150  Region: "_IO_new_file_underflow" <41>, Source code location: "./libio/fileops.c:511" <44>, Parent: "<unknown function>@<unknown file>:1" <9>
CALLING_CONTEXT                      151  Region: "_IO_old_init" <42>, Source code location: "./libio/genops.c:534" <45>, Parent: "<unknown function>@<unknown file>:1" <9>
CALLING_CONTEXT                      152  Region: "_IO_old_init" <42>, Source code location: "./libio/genops.c:539" <46>, Parent: "<unknown function>@<unknown file>:1" <9>
CALLING_CONTEXT                      153  Region: "_IO_old_init" <42>, Source code location: "./libio/genops.c:555" <47>, Parent: "<unknown function>@<unknown file>:1" <9>
CALLING_CONTEXT                      154  Region: "_IO_no_init" <43>, Source code location: "./libio/genops.c:565" <48>, Parent: "<unknown function>@<unknown file>:1" <9>
CALLING_CONTEXT                      155  Region: "_IO_no_init" <43>, Source code location: "./libio/genops.c:588" <49>, Parent: "<unknown function>@<unknown file>:1" <9>
[...]
CALLING_CONTEXT                     1104  Region: "getenv" <111>, Source code location: "./stdlib/getenv.c:84" <188>, Parent: "osu_latency (541215)" <1>
CALLING_CONTEXT                     1105  Region: "__vasprintf_internal" <40>, Source code location: "./libio/vasprintf.c:85" <189>, Parent: "osu_latency (541215)" <1>
CALLING_CONTEXT                     1106  Region: "__vasprintf_internal" <40>, Source code location: "./libio/vasprintf.c:81" <190>, Parent: "osu_latency (541215)" <1>
CALLING_CONTEXT                     1107  Region: "_IO_setb" <112>, Source code location: "./libio/genops.c:335" <191>, Parent: "osu_latency (541215)" <1>
CALLING_CONTEXT                     1108  Region: "_IO_setb" <112>, Source code location: "./libio/genops.c:338" <192>, Parent: "osu_latency (541215)" <1>
CALLING_CONTEXT                     1109  Region: "_IO_default_xsputn" <90>, Source code location: "./libio/genops.c:371" <163>, Parent: "osu_latency (541215)" <1>
CALLING_CONTEXT                     1110  Region: "_IO_default_xsputn" <90>, Source code location: "./libio/genops.c:389" <193>, Parent: "osu_latency (541215)" <1>
[...]
CALLING_CONTEXT                     2399  Region: "__vasprintf_internal" <40>, Source code location: "./libio/vasprintf.c:34" <437>, Parent: "<unknown function>@<unknown file>:1" <2391>
CALLING_CONTEXT                     2400  Region: "__vasprintf_internal" <40>, Source code location: "./libio/vasprintf.c:34" <437>, Parent: "<unknown function>@<unknown file>:1" <2391>
CALLING_CONTEXT                     2401  Region: "__vasprintf_internal" <40>, Source code location: "./libio/vasprintf.c:85" <189>, Parent: "<unknown function>@<unknown file>:1" <2391>
CALLING_CONTEXT                     2402  Region: "__libc_free" <12>, Source code location: "./malloc/malloc.c:3352" <3>, Parent: "<unknown function>@<unknown file>:1" <2391>
[...]
CALLING_CONTEXT_PROPERTY                  Calling Context: "getenv@getenv.c:84" <1104>, Name: "ip" <87>, Type: STRING, Value: "133787390594102" <1001>
CALLING_CONTEXT_PROPERTY                  Calling Context: "__vasprintf_internal@vasprintf.c:85" <1105>, Name: "ip" <87>, Type: STRING, Value: "133787390869793" <1002>
CALLING_CONTEXT_PROPERTY                  Calling Context: "__vasprintf_internal@vasprintf.c:81" <1106>, Name: "ip" <87>, Type: STRING, Value: "133787390869881" <1003>
CALLING_CONTEXT_PROPERTY                  Calling Context: "_IO_setb@genops.c:335" <1107>, Name: "ip" <87>, Type: STRING, Value: "133787390893141" <1005>
[...]
CALLING_CONTEXT_PROPERTY                  Calling Context: "getenv@getenv.c:38" <2398>, Name: "ip" <87>, Type: STRING, Value: "133787390593932" <2135>
CALLING_CONTEXT_PROPERTY                  Calling Context: "__vasprintf_internal@vasprintf.c:34" <2399>, Name: "ip" <87>, Type: STRING, Value: "133787390869533" <2136>
CALLING_CONTEXT_PROPERTY                  Calling Context: "__vasprintf_internal@vasprintf.c:34" <2400>, Name: "ip" <87>, Type: STRING, Value: "133787390869592" <2137>
CALLING_CONTEXT_PROPERTY                  Calling Context: "__vasprintf_internal@vasprintf.c:85" <2401>, Name: "ip" <87>, Type: STRING, Value: "133787390869830" <2138>
CALLING_CONTEXT_PROPERTY                  Calling Context: "__libc_free@malloc.c:3352" <2402>, Name: "ip" <87>, Type: STRING, Value: "133787390989299" <280>
CALLING_CONTEXT_PROPERTY                  Calling Context: "__libc_free@malloc.c:3364" <2403>, Name: "ip" <87>, Type: STRING, Value: "133787390989314" <1605>

```